### PR TITLE
Fix release build: generate empty aio_config.json fallback

### DIFF
--- a/UI-source/scripts/prepare-src.js
+++ b/UI-source/scripts/prepare-src.js
@@ -98,7 +98,6 @@ console.log("  ✓ requirements.txt");
 for (const file of [
   "aio_search_cli.py",
   "aio_config.py",
-  "aio_config.json",
   "library_state.py",
   "metadata_editor.py",
   "metadata_cli.py",
@@ -112,6 +111,30 @@ for (const file of [
   }
   fs.copyFileSync(src, path.join(DEST, file));
   console.log(`  ✓ ${file}`);
+}
+
+// aio_config.json is a runtime USER config file that's gitignored at source
+// (users customize it locally to override library output_dir / HID-marker
+// filenames; absent file means "use the defaults baked into aio_config.py").
+// The CI release builds — and any fresh clone — therefore don't have it,
+// which used to crash this step. Handle both shapes:
+//   - File exists in source     → copy it (a contributor was testing their
+//                                  own overrides; preserve them in the bundle).
+//   - File missing from source  → generate an empty `{}` in the bundle. The
+//                                  runtime's load_aio_config() also handles
+//                                  the truly-missing case (returns {}), but
+//                                  shipping a valid JSON file matches the
+//                                  rest of python-src/ and silences any
+//                                  ENOENT log noise from the Electron side.
+// Cross-file: aio_config.py:CONFIG_FILENAME (line 12), load_aio_config (line 20).
+const configSrc = path.join(AIO_SOURCE, "aio_config.json");
+const configDest = path.join(DEST, "aio_config.json");
+if (fs.existsSync(configSrc)) {
+  fs.copyFileSync(configSrc, configDest);
+  console.log("  ✓ aio_config.json (copied from source)");
+} else {
+  fs.writeFileSync(configDest, "{}\n", "utf-8");
+  console.log("  ✓ aio_config.json (generated default empty config)");
 }
 
 // Copy sites/ folder


### PR DESCRIPTION
## Summary

Follow-up to #31 — the release workflow on `main` is currently failing on all three platforms in two distinct ways. This PR addresses both with two small commits.

## Failure 1 (all three platforms): `prepare-src.js` requires gitignored file

```
== Preparing Python source files for packaging ==
ERROR: aio_config.json not found at /home/runner/work/.../aio_config.json
Error: Process completed with exit code 1.
```

**Cause**: `UI-source/scripts/prepare-src.js` listed `aio_config.json` in the same required-files loop as `aio_config.py`, `library_state.py`, etc. — but `aio_config.json` is a runtime user-config file that's gitignored at source. Neither this fork nor upstream has ever tracked it, so a fresh CI checkout never has the file. `aio_config.py:load_aio_config` already handles the truly-missing case gracefully (returns `{}`), so the runtime didn't care — only the build step's hard `process.exit(1)` was the problem.

**Fix** (`90fd091`): Pull `aio_config.json` out of the required-files loop into an optional-with-fallback block. Contributor has a local file → copy it through. CI / fresh clone → write `{}` to the bundle. The runtime sees the same `{}` either way.

## Failure 2 (Linux only): missing `.deb` package metadata

After the prepare-src.js fix landed on the Win/mac builds, only Linux remained broken, with a different error:

```
⨯ Please specify project homepage, see
      https://www.electron.build/configuration#metadata
Please specify author 'email' in the application package.json
It is required to set Linux .deb package maintainer. Or you can set
      maintainer in the custom linux options.
```

**Cause**: electron-builder's `FpmTarget` enforces dpkg / lintian metadata requirements when building `.deb` packages — specifically a `Homepage:` field (lintian policy) and a `Maintainer:` field (dpkg-deb refuses to build without one). Windows / macOS targets don't need these because NSIS / dmg metadata isn't RFC-822-shaped, so this was a Linux-only failure. The `.deb` target was added in #31, but the required metadata wasn't, so this was latent until the prepare-src.js fix unblocked the workflow far enough to surface it.

**Fix** (`b9effd9`): Two minimal package.json additions:

```diff
   "version": "1.7.2",
   "description": "Desktop UI for AIO Manga/Webtoon Downloader",
+  "homepage": "https://github.com/zzyil/AIO-Webtoon-Downloader",
   "main": "electron/main.js",
```

```diff
       "category": "Network",
+      "maintainer": "AIO Downloader Project <noreply@github.com>",
       "synopsis": "Multi-site manga/webtoon downloader with PDF/EPUB/CBZ output",
```

- Top-level `homepage` points to the actual project home (this upstream repo). Embedded in the `.deb` control file's `Homepage:` field and shown by `apt show aio-downloader-ui`.
- `build.linux.maintainer` is the explicit override electron-builder docs prescribe for satisfying dpkg's required `Maintainer:` without needing a top-level `author.email`. Anonymous-but-valid string keeps the maintenance-attribution surface narrow; chosen over `build.deb.maintainer` so any future `.rpm` / `.snap` / `.pacman` targets inherit it.

Declined to add a top-level `author` block — npm reads that for package-registry metadata too, and this isn't a published npm package, so a Linux-scoped maintainer is the smaller hammer.

## Test plan

- [x] **Failure 1 reproducer**: `rm aio_config.json && cd UI-source && node scripts/prepare-src.js` → before: `process.exit(1)`. After: succeeds with `✓ aio_config.json (generated default empty config)`.
- [x] **Failure 2 reproducer requires running electron-builder on Linux** — local Win/mac dev box can't reach the FpmTarget code path. The CI release run on this PR is the actual proof.
- [x] `python -c "import json; json.load(open('UI-source/package.json'))"` parses cleanly after the two added keys.
- [x] `python -c "from aio_config import load_aio_config; print(load_aio_config('UI-source/python-src'))"` against a `{}` bundle file returns `{}` — runtime semantics unchanged from the missing-file case.
- [ ] CI release run on this branch goes green for Win + mac + Linux dist builds (deferred to PR run).

## Notes for review

- Two small commits, total +26 / -1 across two files. No source-code or test changes.
- No breaking change to the contributor flow (existing local `aio_config.json` still gets copied through) or to the runtime (`load_aio_config` is unchanged).
- Net effect of the maintainer/homepage additions is purely metadata embedded in the `.deb` control file. AppImage builds and Win/mac targets are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
