### PR TITLE
Fix Linux .deb build: add homepage + linux.maintainer metadata

### DIFF
--- a/UI-source/package.json
+++ b/UI-source/package.json
@@ -2,6 +2,7 @@
   "name": "aio-downloader-ui",
   "version": "1.7.2",
   "description": "Desktop UI for AIO Manga/Webtoon Downloader",
+  "homepage": "https://github.com/zzyil/AIO-Webtoon-Downloader",
   "main": "electron/main.js",
   "scripts": {
     "dev": "vite",
@@ -77,6 +78,7 @@
         { "target": "deb", "arch": ["x64"] }
       ],
       "category": "Network",
+      "maintainer": "AIO Downloader Project <noreply@github.com>",
       "synopsis": "Multi-site manga/webtoon downloader with PDF/EPUB/CBZ output",
       "description": "Desktop app for downloading manga, webtoons, and comics from 50+ sites with cross-site search and quality ranking. Builds PDF, EPUB, or CBZ output (with optional Mihon/Komikku-compatible per-chapter CBZs). Bundles Python + Patchright Chromium for VRF-gated sources. Resume-safe by default; configurable per-host concurrency throttling on CDN errors."
     },


### PR DESCRIPTION
## Summary

Follow-up to #32 (which fixed `prepare-src.js` for all three platforms). With the Win/mac dist builds now green, the Linux dist still failed — this PR fixes the remaining `.deb`-specific failure.

## The failure

After #32 unblocked the build past `prepare-src.js`, the Linux release run got further along but tripped on electron-builder's `.deb` packaging:

```
⨯ Please specify project homepage, see
      https://www.electron.build/configuration#metadata
Please specify author 'email' in the application package.json
It is required to set Linux .deb package maintainer. Or you can set
      maintainer in the custom linux options.

  failedTask=build
  at FpmTarget.computeFpmMetaInfoOptions (.../FpmTarget.ts:100:13)
  at FpmTarget.build (.../FpmTarget.ts:176:25)
```

Windows/mac dist runs are unaffected because NSIS / dmg metadata isn't RFC-822-shaped — only the `.deb` format triggers this check.

## Cause

electron-builder's `FpmTarget` enforces dpkg + lintian metadata requirements when building `.deb` packages — specifically a `Homepage:` field (lintian Policy 5.6.23) and a `Maintainer:` field (`dpkg-deb` refuses to build without one). The current `UI-source/package.json` doesn't set either field at top-level and doesn't override them under `build.linux.*`. The `.deb` target was added to `build.linux.target` in #31, but the required metadata wasn't, so the failure was latent until #32 unblocked the workflow far enough to surface it.

## Fix

Two minimal additions to `UI-source/package.json`:

```diff
   "version": "1.7.2",
   "description": "Desktop UI for AIO Manga/Webtoon Downloader",
+  "homepage": "https://github.com/zzyil/AIO-Webtoon-Downloader",
   "main": "electron/main.js",
```

```diff
       "category": "Network",
+      "maintainer": "AIO Downloader Project <noreply@github.com>",
       "synopsis": "Multi-site manga/webtoon downloader with PDF/EPUB/CBZ output",
```

- **Top-level `homepage`** points to this repo. Gets embedded in the `.deb` control file's `Homepage:` field and shown by `apt show aio-downloader-ui` / synaptic.
- **`build.linux.maintainer`** is the explicit override electron-builder docs prescribe for satisfying dpkg's required `Maintainer:` field without needing top-level `author.email`. Anonymous-but-valid string (`AIO Downloader Project <noreply@github.com>`) — keeps the maintenance-attribution surface narrow. Chosen over `build.deb.maintainer` so any future `.rpm` / `.snap` / `.pacman` targets inherit it.

Declined to add a top-level `author` block — npm reads that for package-registry metadata too, and this isn't a published npm package. The Linux-scoped `maintainer` is the smaller hammer.

## Test plan

- [x] `python -c "import json; json.load(open('UI-source/package.json'))"` parses cleanly after the two added keys.
- [x] Windows / macOS dist builds are unaffected — electron-builder reads `linux.maintainer` only on the Linux platform target; Win/mac config paths don't touch FpmTarget.
- [x] AppImage build on Linux is also unaffected — the FpmTarget check only fires for `target=deb` (and rpm/snap if added). AppImage uses a separate target driver.
- [ ] CI release run on this branch goes green for Linux `.deb` build (deferred to PR run).

## Notes for review

- One-file change, +2 / -0 in `UI-source/package.json` only. No source-code or test changes.
- Net effect is purely metadata embedded in the `.deb` control file (`Homepage:` + `Maintainer:`).
- The author `email`-required message in the original error is satisfied transitively by setting `linux.maintainer`; electron-builder uses `linux.maintainer` as the authoritative source when present, falling back to `author` derivation only when it isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
