### PR TITLE
ghost-chapter detection + comix bypass on --multi-source-prefetched

### DIFF
--- a/UI-source/electron/downloader.js
+++ b/UI-source/electron/downloader.js
@@ -210,13 +210,15 @@ function buildCliArgs(args) {
     cliArgs.push("--no-cbz-preserve-originals");
   }
 
-  // Global collapse-splits toggle (item 8 in snappy-forging-waffle.md).
-  // Same negative-default pattern as cbzPreserveOriginals: aio-dl.py defaults
-  // to collapse=True, we emit --no-collapse-splits only when the user has it
-  // explicitly off. useDownloader.queueDownload injects the field from
-  // settings.collapseSplits before calling startDownload.
-  if (args.collapseSplits === false) {
-    cliArgs.push("--no-collapse-splits");
+  // Global collapse-splits toggle (item 8 in snappy-forging-waffle.md,
+  // updated 2026-05-27 for the opt-in flip). aio-dl.py now defaults
+  // collapse=False; we emit the positive --collapse-splits flag only
+  // when the user has explicitly turned it on. useDownloader.queueDownload
+  // injects the field from settings.collapseSplits before calling
+  // startDownload. The deprecated --no-collapse-splits is still a hidden
+  // alias on the Python side for any script users — we just don't emit it.
+  if (args.collapseSplits === true) {
+    cliArgs.push("--collapse-splits");
   }
 
   // LINE Webtoon recompression valued knobs (Phase 1, 2026-05-11). Only

--- a/UI-source/electron/searcher.js
+++ b/UI-source/electron/searcher.js
@@ -69,12 +69,14 @@ function buildSearchArgs(query, opts = {}) {
   // Boolean toggles
   if (opts.seededOnly) args.push("--seeded-only");
   if (opts.multiSource) args.push("--multi-source");
-  // collapseSplits defaults TRUE; we only emit the negative flag when the
-  // user has explicitly turned it off in Settings or the inline toggle.
-  // `=== false` is intentional: undefined / null / true all mean "leave
-  // default ON" so older saved searchOpts dicts without the field don't
-  // accidentally disable collapse.
-  if (opts.collapseSplits === false) args.push("--no-collapse-splits");
+  // collapseSplits defaults FALSE as of 2026-05-27 (opt-in flip); we emit
+  // the positive --collapse-splits flag only when the user has explicitly
+  // turned it on in Settings or the inline toggle. `=== true` is
+  // intentional: undefined / null / false all mean "leave default OFF"
+  // so older saved searchOpts dicts without the field stay off (the new
+  // safer default). aio-dl.py's argparse keeps --no-collapse-splits as a
+  // hidden alias for script users; we don't emit it.
+  if (opts.collapseSplits === true) args.push("--collapse-splits");
   // enableMlRating defaults FALSE (production default; matches argparse).
   // Only emit the flag when explicitly enabled. Wiring this through so
   // users can opt into torch-backed T2/T3 image-quality scoring (CLIP-IQA,

--- a/UI-source/src/components/SearchChapterMap.jsx
+++ b/UI-source/src/components/SearchChapterMap.jsx
@@ -10,11 +10,121 @@
 //
 // Lets the user spot DMCA gaps + licensed-translation coverage
 // at a glance. Power feature — collapsed by default in SearchTab.
+//
+// Per-source breakdown chips (2026-05-27): when the backend supplies
+// merge_diagnostics[site].breakdown (sites/chapter_merger.py:
+// ChapterBreakdown dataclass), each row renders a strip of micro-chips
+// after the main/entries summary, color-coded by bucket kind:
+//   amber  = side stories       (X.5+ kept as content)
+//   cyan   = prologue           (chapter 0 / negatives)
+//   emerald = source-only latest (above peer max — fresh releases)
+//   orange = source-only orphans (mid-range, suspicious but kept)
+//   rose   = fragments dropped  (.1/.2/.3/.4 source-only duplicates)
+// Grep target: buildBuckets in this file; classifier source in
+// sites/chapter_merger.py:_classify_chapter_breakdown.
 // ============================================================
 
 import React, { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Info } from "lucide-react";
+
+// Convert one source's breakdown dict into an ordered list of chip
+// descriptors. Buckets are SEMANTIC, not raw — consensus_side_stories
+// and safe_decimals merge into one "side" chip because the user thinks
+// of them as one thing ("extras kept"); the tooltip preserves the
+// confirmation-status distinction. Empty/zero buckets are omitted so
+// clean sources render no chips at all. Order is intentional: kept
+// content first (positive sign), suspicious in middle (?), dropped
+// last (− with strikethrough) — mirrors the "additive vs removed"
+// mental model.
+function buildBuckets(breakdown, collapseApplied) {
+  if (!breakdown) return [];
+  const sideConfirmed = breakdown.consensus_side_stories || 0;
+  const sideSourceOnly = breakdown.safe_decimals || 0;
+  const sideTotal = sideConfirmed + sideSourceOnly;
+  const out = [];
+  if (sideTotal > 0) {
+    let tip;
+    if (sideConfirmed === sideTotal) {
+      tip = `${sideConfirmed} side stor${sideConfirmed === 1 ? "y" : "ies"} confirmed by peer sources (X.5-style sub-chapters). Kept as content.`;
+    } else if (sideSourceOnly === sideTotal) {
+      tip = `${sideSourceOnly} side stor${sideSourceOnly === 1 ? "y" : "ies"} this source carries alone (X.5 or higher). Kept — too risky to call duplicates.`;
+    } else {
+      tip = `${sideConfirmed} peer-confirmed + ${sideSourceOnly} source-only side stor${sideTotal === 1 ? "y" : "ies"}. All kept as content.`;
+    }
+    out.push({ key: "side", count: sideTotal, sign: "+", label: "side", color: "text-amber-400/80", tooltip: tip });
+  }
+  if (breakdown.prologue_count > 0) {
+    out.push({
+      key: "pro",
+      count: breakdown.prologue_count,
+      sign: "+",
+      label: "pro",
+      color: "text-cyan-400/80",
+      tooltip: `${breakdown.prologue_count} chapter 0 / prologue entr${breakdown.prologue_count === 1 ? "y" : "ies"}. Kept as content.`,
+    });
+  }
+  if (breakdown.source_only_latest > 0) {
+    out.push({
+      key: "new",
+      count: breakdown.source_only_latest,
+      sign: "+",
+      label: "new",
+      color: "text-emerald-400/80",
+      tooltip: `${breakdown.source_only_latest} chapter${breakdown.source_only_latest === 1 ? "" : "s"} past the peer-confirmed range (fresh release${breakdown.source_only_latest === 1 ? "" : "s"} other sources haven't caught up to). Kept.`,
+    });
+  }
+  if (breakdown.source_only_orphans > 0) {
+    out.push({
+      key: "orph",
+      count: breakdown.source_only_orphans,
+      sign: "?",
+      label: "orph",
+      color: "text-orange-400/80",
+      tooltip: `${breakdown.source_only_orphans} mid-range chapter${breakdown.source_only_orphans === 1 ? "" : "s"} peers don't have. Suspicious (possible re-released duplicates) but kept — could also be legit content.`,
+    });
+  }
+  if (breakdown.fragments_dropped > 0) {
+    out.push({
+      key: "drop",
+      count: breakdown.fragments_dropped,
+      sign: collapseApplied ? "−" : "·",
+      label: collapseApplied ? "drop" : "frag",
+      // Color tracks collapse state: bright rose when actually dropped,
+      // muted rose when surfaced-but-not-dropped (collapse OFF). The
+      // user immediately sees whether the count represents a real
+      // download-time action or just an advisory tally.
+      color: collapseApplied ? "text-rose-400/75" : "text-rose-400/40",
+      strikethrough: collapseApplied,
+      tooltip: collapseApplied
+        ? `${breakdown.fragments_dropped} source-only .1/.2/.3/.4 fragment${breakdown.fragments_dropped === 1 ? "" : "s"} dropped — peers don't carry them, treated as duplicate uploads of the integer parent. Toggle collapse off in Settings to keep them.`
+        : `${breakdown.fragments_dropped} source-only .1/.2/.3/.4 fragment${breakdown.fragments_dropped === 1 ? "" : "s"} (collapse is OFF — these are KEPT in the download). Toggle collapse on to drop them as duplicates.`,
+    });
+  }
+  return out;
+}
+
+// Render-helper for a single bucket chip. Baseline-aligned dual-
+// typography pattern: bright sign+count, half-opacity micro-label.
+// Lower-case font-mono labels stay aligned with the row's existing
+// "main / entries" text. The strikethrough on dropped chips uses a
+// thin decoration so the count is still readable; the line-through
+// is a semantic hint, not a censor.
+function BucketChip({ chip }) {
+  return (
+    <span
+      title={chip.tooltip}
+      className={cn(
+        "tabular-nums font-mono inline-flex items-baseline gap-0.5 cursor-help",
+        chip.color,
+        chip.strikethrough && "line-through decoration-1 decoration-rose-400/40",
+      )}
+    >
+      <span>{chip.sign}{chip.count}</span>
+      <span className="opacity-50 text-[8.5px] not-italic tracking-tight">{chip.label}</span>
+    </span>
+  );
+}
 
 export default function SearchChapterMap({ chapterMap }) {
   const [expanded, setExpanded] = useState(false);
@@ -66,7 +176,12 @@ export default function SearchChapterMap({ chapterMap }) {
   // Per-site stats for the row label. Helps the user see which source has
   // the deepest catalog at a glance without expanding. Phase 3 enriches
   // this with effective_chapters from merge_diagnostics so MangaFire-style
-  // 362-vs-119 inflation is visible without reading the heatmap.
+  // 362-vs-119 inflation is visible without reading the heatmap. 2026-05-27
+  // additionally extracts the per-source ChapterBreakdown buckets (built by
+  // sites/chapter_merger.py:_classify_chapter_breakdown) into chip
+  // descriptors via buildBuckets(). Sources without a breakdown (older
+  // payloads, single-source runs with no consensus) yield buckets=[] which
+  // renders nothing — no visual difference from the previous behavior.
   const siteStats = sites.map((site) => {
     const ch = presence[site]?.size || 0;
     const off = officialAt[site]?.size || 0;
@@ -74,8 +189,16 @@ export default function SearchChapterMap({ chapterMap }) {
     const totalChapters = diag.total_chapters ?? ch;
     const effective = diag.effective_chapters ?? totalChapters;
     const compatibility = diag.compatibility;
-    return { site, ch, totalChapters, effective, off, compatibility };
+    const buckets = buildBuckets(diag.breakdown, collapseApplied);
+    return { site, ch, totalChapters, effective, off, compatibility, buckets };
   });
+
+  // Headline-level dropped tally: difference between aligned-entries and
+  // post-refinement-effective. Surfaces what's removed at the aggregate
+  // level so the user sees "22 dropped" at the header without expanding.
+  // When collapse is off, the same count is shown muted (informational —
+  // these chapters are NOT actually removed from the download).
+  const headlineDropped = Math.max(0, totalAligned - effectiveAligned);
 
   return (
     <div className="rounded-lg border bg-card/50 overflow-hidden">
@@ -96,7 +219,7 @@ export default function SearchChapterMap({ chapterMap }) {
               className="text-xs text-muted-foreground tabular-nums"
               title={
                 collapseApplied
-                  ? "Aggregator catalogs include split-chapter rows (e.g. 1.1, 1.2). Main count collapses those; entries shows the raw row count."
+                  ? "Aggregator catalogs include split-chapter rows (e.g. 1.1, 1.2) and source-only fragment uploads. The 'main' count post-collapses both; 'entries' is the raw row count from the deepest source."
                   : "Series uses decimal numbering — collapse is off, so main and entries diverge naturally."
               }
             >
@@ -105,6 +228,22 @@ export default function SearchChapterMap({ chapterMap }) {
           ) : (
             <span className="text-xs text-muted-foreground tabular-nums">
               · {totalAligned} chapters aligned
+            </span>
+          )}
+          {headlineDropped > 0 && (
+            <span
+              className={cn(
+                "text-[10px] font-mono tabular-nums tracking-tight",
+                collapseApplied ? "text-rose-400/70" : "text-rose-400/35",
+              )}
+              title={
+                collapseApplied
+                  ? `${headlineDropped} duplicate fragment${headlineDropped === 1 ? "" : "s"} removed across all sources (source-only .1/.2/.3/.4 uploads). Expand the panel to see which source each came from.`
+                  : `${headlineDropped} duplicate fragment${headlineDropped === 1 ? "" : "s"} detected but KEPT (collapse is off). Turn collapse on in Settings to drop them.`
+              }
+            >
+              · <span className={collapseApplied ? "line-through decoration-1 decoration-rose-400/40" : ""}>−{headlineDropped}</span>{" "}
+              <span className="opacity-60 text-[9px]">{collapseApplied ? "dropped" : "frag"}</span>
             </span>
           )}
         </div>
@@ -121,14 +260,14 @@ export default function SearchChapterMap({ chapterMap }) {
               "X main / Y entries"; otherwise just "X chapters". The "main"
               count is what the user should compare across sources for parity. */}
           <div className="grid gap-1.5 mb-3" style={{ gridTemplateColumns: "120px 1fr" }}>
-            {siteStats.map(({ site, ch, totalChapters, effective, off, compatibility }) => {
+            {siteStats.map(({ site, ch, totalChapters, effective, off, compatibility, buckets }) => {
               const showInflation = effective !== totalChapters;
               return (
                 <React.Fragment key={site}>
                   <div className="flex items-center gap-1.5 min-w-0">
                     <span className="font-mono text-[11px] truncate">{site}</span>
                   </div>
-                  <div className="flex items-center gap-2 text-[10px] tabular-nums">
+                  <div className="flex items-center gap-2 text-[10px] tabular-nums flex-wrap">
                     {showInflation ? (
                       <span
                         className="text-muted-foreground"
@@ -152,11 +291,64 @@ export default function SearchChapterMap({ chapterMap }) {
                         · {Math.round(compatibility * 100)}% match
                       </span>
                     )}
+                    {/* Breakdown chips: only rendered when the backend
+                        supplied a populated ChapterBreakdown for this source.
+                        The vertical separator uses border + height instead
+                        of a "·" character so the visual break between
+                        existing diag and the new chips is more deliberate.
+                        Each chip carries a tooltip that explains its bucket;
+                        the dropped-chip color/strikethrough additionally
+                        encodes the collapse state. */}
+                    {buckets.length > 0 && (
+                      <>
+                        <span
+                          aria-hidden="true"
+                          className="inline-block w-px h-2.5 bg-border/60 mx-0.5"
+                        />
+                        {buckets.map((chip) => (
+                          <BucketChip key={chip.key} chip={chip} />
+                        ))}
+                      </>
+                    )}
                   </div>
                 </React.Fragment>
               );
             })}
           </div>
+
+          {/* Bucket legend — only render when any source has chips. The
+              legend is a thin row of muted swatches that gives the user
+              one place to learn what the chip colors mean without having
+              to hover every chip individually. Mirrors the heatmap
+              legend below so visually they read as one cohesive
+              "what you're looking at" footer. */}
+          {siteStats.some((s) => s.buckets.length > 0) && (
+            <div className="flex items-center flex-wrap gap-x-3 gap-y-1 mb-3 px-0.5 text-[9.5px] font-mono text-muted-foreground/60">
+              <span className="opacity-60">breakdown:</span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-sm bg-amber-400/70" />
+                <span>side stories</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-sm bg-cyan-400/70" />
+                <span>prologue</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-sm bg-emerald-400/70" />
+                <span>ahead of peers</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-sm bg-orange-400/70" />
+                <span>orphans</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-sm bg-rose-400/70" />
+                <span>
+                  {collapseApplied ? "duplicates dropped" : "duplicates (kept)"}
+                </span>
+              </span>
+            </div>
+          )}
 
           {/* Heatmap grid — site rows × chapter columns. Each cell ~6px
               wide so a 1200-chapter series fits in ~7000px (horizontal

--- a/UI-source/src/components/SearchSourceCard.jsx
+++ b/UI-source/src/components/SearchSourceCard.jsx
@@ -25,6 +25,34 @@ function qualityTier(score) {
   return { color: "bg-red-500", label: "weak" };
 }
 
+// Source-level "currently broken / degraded handler" flags. Keyed by
+// site name — must match handler.name in the Python `sites/<file>.py`
+// (which is a stable identifier, not a display string). When a handler
+// is known to be functionally broken (downloads usually fail, output is
+// incomplete, etc.) we render a red AlertTriangle next to the site name
+// so users see the warning BEFORE clicking Download and wasting a slot
+// in their queue. The download path itself isn't blocked — users may
+// still try, and the source might recover.
+//
+// Add/remove entries here when handlers break / get fixed. Each value
+// is the tooltip text the user sees on hover.
+//
+// Entries:
+//   - comix (added 2026-05-27): the canvas-scrape fallback for
+//     unscrambled chapter images can't render all pages within the 300s
+//     per-chapter time budget. Chapter downloads time out at single-
+//     digit page counts (e.g. 3/193 pages in the 2026-05-27 Shangri-La
+//     Frontier run). The Patchright bridge is single-threaded so
+//     increasing parallelism doesn't help. See sites/comix.py for the
+//     in-progress work and the PR-31 context doc's "fix comix" pointer.
+const BROKEN_HANDLERS = {
+  comix: (
+    "Currently broken: canvas-scrape can't capture all pages within the "
+    + "per-chapter time budget. Downloads typically time out at a small "
+    + "number of pages. You can still try, but expect failure."
+  ),
+};
+
 export default function SearchSourceCard({
   source,           // SourceEntry from JSON (site, url, cover, scores, etc.)
   officialPublisher, // string | null — non-null if any chapter via this site is is_official=true
@@ -155,11 +183,31 @@ export default function SearchSourceCard({
 
       {/* Body */}
       <div className="px-2.5 py-2 space-y-1.5">
-        {/* Site name + format chip + chapter count */}
+        {/* Site name + broken-handler warning + format chip + chapter count */}
         <div className="flex items-center gap-1 min-w-0">
           <span className="font-mono text-[11px] font-medium text-foreground truncate">
             {source.site}
           </span>
+          {/* Broken-handler danger icon. Sourced from BROKEN_HANDLERS map at
+              the top of this file — keyed by source.site, value is the
+              tooltip text. Red AlertTriangle distinguishes "handler is
+              broken" (this) from the yellow outlier-flag AlertTriangle on
+              the score row below (which is "this source's image quality is
+              suspect"). Inline span carries the title because lucide-react's
+              SVGs don't surface native tooltips reliably across browsers.
+              Cross-file: BROKEN_HANDLERS comment for current entries and
+              the why; remove an entry when the handler is fixed. */}
+          {BROKEN_HANDLERS[source.site] && (
+            <span
+              className="shrink-0 inline-flex items-center"
+              title={BROKEN_HANDLERS[source.site]}
+            >
+              <AlertTriangle
+                className="w-3 h-3 text-red-500"
+                aria-label={`${source.site} is currently broken: ${BROKEN_HANDLERS[source.site]}`}
+              />
+            </span>
+          )}
           {formatLabel && (
             // Format chip from Phase H metadata. Lowercase font-mono lines up
             // with the site name visually; muted color keeps it secondary.

--- a/UI-source/src/components/SearchTab.jsx
+++ b/UI-source/src/components/SearchTab.jsx
@@ -433,19 +433,24 @@ export default function SearchTab({
               behavior too. SettingsTab → "Default Chapter Behavior" mirrors
               this same toggle; the global state stays in sync regardless of
               which surface the user changes it from. Always visible (not
-              gated on multi-source) since downloads are affected too. */}
+              gated on multi-source) since downloads are affected too.
+              2026-05-27: flipped to OPT-IN — checked = strictly true.
+              `=== true` (not `!== false`) so undefined/null defaults to OFF;
+              old users who set it true stay opted in. */}
           <div className="flex items-center justify-between gap-3">
             <div>
               <Label htmlFor="opt-collapse-splits" className="text-xs font-medium block">
                 Collapse split chapters
               </Label>
               <p className="text-[10px] text-muted-foreground mt-0.5">
-                Merge X.1/X.2/X.3 splits; drop duplicate uploads. Affects downloads.
+                Merge X.1/X.2/X.3 splits and drop source-only .1/.2/.3/.4
+                fragment uploads (multi-source only). Default off — opt in if
+                aggregators inflate your chapter counts.
               </p>
             </div>
             <Switch
               id="opt-collapse-splits"
-              checked={settings?.collapseSplits !== false}
+              checked={settings?.collapseSplits === true}
               onCheckedChange={(v) => onSaveSettings?.({ collapseSplits: v })}
               disabled={isRunning}
             />

--- a/UI-source/src/hooks/useDownloader.js
+++ b/UI-source/src/hooks/useDownloader.js
@@ -48,12 +48,16 @@ export function useDownloader() {
     workingDir: "",
     defaults: {},
     verboseAlways: true,
-    // Global toggle: collapse split-cluster chapters at download time AND in
-    // search-display diagnostic counts. Default ON. The Python side reads
-    // args.collapse_splits; the UI emits --no-collapse-splits when this is
-    // explicitly false. See sites/chapter_merger.py:group_chapters_for_download
-    // for the cluster rule.
-    collapseSplits: true,
+    // Global toggle: collapse split-cluster chapters + cross-source duplicate
+    // fragments at download time AND in search-display diagnostic counts.
+    // Default OFF as of 2026-05-27 (opt-in flip). The new refinement drops
+    // source-only .1/.2/.3/.4 fragments under --multi-source, which is more
+    // aggressive than the old behavior — explicit user buy-in is required.
+    // The Python side reads args.collapse_splits; the UI emits the positive
+    // --collapse-splits flag (downloader.js / searcher.js) when this is
+    // explicitly true. See sites/chapter_merger.py:group_chapters_for_download
+    // for the full Rule 2 / 3b / 6 refinement.
+    collapseSplits: false,
     // Inter-chapter image prefetch worker count (Phase G7, 2026-05-08).
     // While chapter N is encoding/processing on the main thread, a
     // background thread downloads chapter N+1's images using this many
@@ -622,12 +626,14 @@ export function useDownloader() {
 
     // Merge the global collapseSplits setting into opts so SearchTab's inline
     // toggle (which writes settings.collapseSplits via onSaveSettings) is
-    // honored even when the caller passes opts that omit the field. The
-    // searcher.js buildSearchArgs only emits --no-collapse-splits when this
-    // is explicitly false. Caller-passed opts win on conflict (...opts at end).
+    // honored even when the caller passes opts that omit the field.
+    // Post 2026-05-27 opt-in flip: `=== true` is required (undefined/null
+    // default to OFF). searcher.js buildSearchArgs only emits the positive
+    // --collapse-splits flag when this is explicitly true. Caller-passed
+    // opts win on conflict (...opts at end).
     const s = settingsRef.current;
     const finalOpts = {
-      collapseSplits: s?.collapseSplits !== false,
+      collapseSplits: s?.collapseSplits === true,
       ...opts,
     };
 

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -18,13 +18,32 @@ import re
 import shutil
 import subprocess
 import sys
+
+# Force UTF-8 on stdio before anything prints. When Electron spawns this
+# script (UI-source/electron/downloader.js:585, searcher.js:160,
+# main.js:195/878), stdio is a pipe, not a TTY, so Python falls back to
+# locale.getpreferredencoding(False) → cp1252 on default Western Windows
+# (ACP=1252). Many log lines use → ─ — × ≥ which cp1252 can't encode,
+# crashing the run with UnicodeEncodeError mid-listing. errors='replace'
+# keeps it crash-proof for any future char. No-op on UTF-8-ACP boxes
+# (Win11 Beta UTF-8 mode) and real terminals (PEP 528 WriteConsoleW).
+# Grep target: UnicodeEncodeError reconfigure
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+try:
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 import threading
 import time
 import textwrap
 import xml.sax.saxutils
 import zipfile
 import zlib
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse, unquote_to_bytes
 
 from aio_config import (
@@ -5154,21 +5173,38 @@ def main():
              "sequential download → process → next-download.",
     )
     p.add_argument(
+        "--collapse-splits",
+        dest="collapse_splits",
+        action="store_true",
+        default=False,
+        help="Enable split-fragment + cross-source-duplicate chapter collapse. "
+             "Default OFF (2026-05-27 opt-in flip — see "
+             "~/.claude/plans/ultrathink-mangafire-and-some-flickering-sparkle.md). "
+             "When ON, the following are merged or dropped: "
+             "(a) sequential X.1/X.2/X.3 splits with no integer X "
+             "(MangaDex-style upload fragments) → merged into one chapter X; "
+             "(b) integer X + scattered decimals like {X, X.1, X.5} → X kept, "
+             ".5 kept as side story, .1 dropped as fragment; "
+             "(c) integer X + single fragment-shaped decimal "
+             "(.1/.2/.3/.4) with no peer source confirming it → "
+             "the decimal is dropped as a duplicate upload of X. "
+             "Decimals at .5 or higher, peer-confirmed decimals of any "
+             "shape, chapter 0 / prologues, and source-only integer "
+             "chapters are ALWAYS kept. The cross-source duplicate "
+             "signal only fires under --multi-source / "
+             "--multi-source-prefetched; direct-URL runs fall back to "
+             "the in-source heuristics (current Rule 3a / 3b / 6 "
+             "behavior with no consensus refinement).",
+    )
+    # Hidden deprecated alias — old --no-collapse-splits is now a no-op
+    # (the new default IS "no collapse"), but keep parsing it so any script
+    # pinned to the old flag continues to launch. Suppressed from --help to
+    # avoid confusing new users with both flag forms.
+    p.add_argument(
         "--no-collapse-splits",
         dest="collapse_splits",
         action="store_false",
-        default=True,
-        help="Disable split-cluster collapse in --multi-source coverage "
-             "diagnostics. By default (collapse ON), decimal sub-chapters "
-             "X.1/X.2/X.3 with no integer X are reported as ONE main "
-             "chapter for the per-source 'effective' count — fixes the "
-             "misleading 362-vs-119 display where one aggregator splits "
-             "each chapter into 4 decimal entries. Pass this flag if your "
-             "series legitimately uses decimal numbering (some webnovel "
-             "adaptations / episodic releases) and you want each decimal "
-             "counted as its own chapter. Affects only the displayed "
-             "counts; the per-chapter download alternatives in the "
-             "chapter_map are unchanged either way.",
+        help=argparse.SUPPRESS,
     )
     p.add_argument(
         "--multi-source-prefetched",
@@ -5825,6 +5861,12 @@ def main():
     # _process_chapter_strict for per-chapter fallback. Empty/None means
     # single-source mode (existing behavior unchanged).
     _multi_source_alternatives: Dict[float, List[Dict[str, Any]]] = {}
+    # consensus_set for the refined collapse-splits Rule 2 / 3b / 6 drops at
+    # group_chapters_for_download (2026-05-27). Populated alongside
+    # _multi_source_alternatives from the same three carriers (auto-pick,
+    # prefetched JSON, direct-URL discovery). None = no peer signal; the
+    # group helper falls through to original in-source-only heuristics.
+    _multi_source_consensus_set: Optional[Set[float]] = None
 
     if getattr(args, "search", None):
         from aio_search_cli import run_search_mode, take_latest_multi_source_state
@@ -5842,6 +5884,7 @@ def main():
         _ms_state = take_latest_multi_source_state()
         if _ms_state and _ms_state.get("alternatives_by_chap_num"):
             _multi_source_alternatives = _ms_state["alternatives_by_chap_num"]
+            _multi_source_consensus_set = _ms_state.get("consensus_set")
             n_alts = sum(len(v) for v in _multi_source_alternatives.values())
             n_chapters_with_alts = len(_multi_source_alternatives)
             print(
@@ -6386,7 +6429,7 @@ def main():
         try:
             if prefetched_path:
                 from aio_search_cli import build_alternatives_from_prefetched
-                _ms_alts = build_alternatives_from_prefetched(
+                _ms_result = build_alternatives_from_prefetched(
                     prefetched_path=prefetched_path,
                     primary_handler=handler,
                     primary_context=context,
@@ -6397,7 +6440,7 @@ def main():
                 )
             else:
                 from aio_search_cli import find_alternatives_for_direct_url
-                _ms_alts = find_alternatives_for_direct_url(
+                _ms_result = find_alternatives_for_direct_url(
                     primary_url=args.comic_url,
                     primary_handler=handler,
                     primary_context=context,
@@ -6407,8 +6450,19 @@ def main():
                     record_rate_limit=_record_rate_limit,
                     on_status=lambda m: print(m, file=sys.stderr),
                 )
+            # New return shape (2026-05-27): both helpers now return a dict
+            # with alts + consensus. Tolerate the legacy bare-dict shape too
+            # in case some downstream call path bypassed the update.
+            if isinstance(_ms_result, dict) and "alternatives_by_chap_num" in _ms_result:
+                _ms_alts = _ms_result.get("alternatives_by_chap_num") or {}
+                _ms_consensus = _ms_result.get("consensus_set")
+            else:
+                # Legacy / unexpected shape — treat the whole thing as the alts dict.
+                _ms_alts = _ms_result if isinstance(_ms_result, dict) else {}
+                _ms_consensus = None
             if _ms_alts:
                 _multi_source_alternatives = _ms_alts
+                _multi_source_consensus_set = _ms_consensus
                 n_alts = sum(len(v) for v in _multi_source_alternatives.values())
                 n_chapters_with_alts = len(_multi_source_alternatives)
                 print(
@@ -6538,8 +6592,23 @@ def main():
     # carrying `_merged_parts`; _process_chapter_impl detects this and
     # fetches each part's images in order. Output filename uses
     # group.label so the user sees "Title Ch 1.pdf".
-    collapse_splits_enabled = bool(getattr(args, "collapse_splits", True))
-    groups = group_chapters_for_download(chapters, collapse_splits=collapse_splits_enabled)
+    # Default flipped to False (opt-in) as of 2026-05-27. The new collapse
+    # logic drops source-only .1/.2/.3/.4 fragments under --multi-source,
+    # which is more aggressive than the old behavior — explicit user buy-in
+    # is required to avoid surprise drops. Both --collapse-splits and the
+    # deprecated --no-collapse-splits set this same dest.
+    collapse_splits_enabled = bool(getattr(args, "collapse_splits", False))
+    # consensus_set is sourced from whichever multi-source path populated it
+    # (auto-pick search, prefetched JSON, or direct-URL discovery). None when
+    # no peer data is available — group_chapters_for_download then falls
+    # through to the original in-source-only Rule 2 / 3b / 6 behavior.
+    # When non-None, Rule 2's lone source-only .1 fragment gets dropped
+    # (the user's Shangri-La Frontier 52.1 / 75.1 / etc. case).
+    groups = group_chapters_for_download(
+        chapters,
+        collapse_splits=collapse_splits_enabled,
+        consensus_set=_multi_source_consensus_set,
+    )
     grouped_chapters: List[Dict[str, Any]] = []
     for group in groups:
         if len(group.parts) == 1:

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -57,14 +57,23 @@ class ChapterSkippedError(Exception):
       - any page failed to download (zero-tolerance: pages_ok < pages_total)
       - watchdog deadline fired (chapter took too long)
       - host poison threshold hit (≥N distinct URLs to one host fully failed)
+      - ghost chapter (every page returns an identical structural error response
+        — uniform status + uniform body size — indicating the chapter doesn't
+        exist on the primary source despite being listed in the chapter index;
+        canonical example: mangafire "chapter 0" placeholder entries whose
+        image URLs all return the same 5051-byte 403 template body)
 
     Caught by _process_chapter_strict, which performs an inline retry pass
     (long wait + redo the chapter from scratch). After inline retries are
     exhausted, _process_chapter_strict converts this into ChapterAbortedError
-    which the main loop treats as a fatal stop.
+    which the main loop treats as a fatal stop — EXCEPT for ghost_chapter,
+    which short-circuits inline-retry (a structural failure won't fix itself
+    after 30s of sleep) and raises ChapterGhostError instead, which the main
+    loop catches as skip-and-continue.
 
     Attributes:
-        reason:       short tag, one of: 'incomplete', 'time_budget', 'host_poison'
+        reason:       short tag, one of: 'incomplete', 'time_budget',
+                      'host_poison', 'ghost_chapter'
         host:         netloc that triggered the bail (for diagnostic logging)
         pages_ok:     count of pages successfully downloaded before the bail
         pages_total:  total pages the chapter was supposed to have
@@ -104,6 +113,57 @@ class ChapterAbortedError(Exception):
         super().__init__(
             f"chapter {chap} aborted after {attempts} attempt(s): "
             f"reason={reason} host={host or '-'} pages={pages_ok}/{pages_total}"
+        )
+
+
+class ChapterGhostError(Exception):
+    """Raised by _process_chapter_strict when the primary source returned a
+    'ghost chapter' signature (every page failed with an identical error
+    response: same status, same body-size bucket) AND no alternative source
+    could deliver the chapter. Distinct from ChapterAbortedError on purpose:
+    the main loop treats this as skip-and-continue, NOT abort.
+
+    Why a distinct exception (not just another ChapterSkippedError reason):
+    a ghost signature on the primary means the chapter is structurally absent
+    there — VRF token rotated to a different URL space, soft-launched
+    placeholder, CDN URL signed for a chapter that was unpublished, etc. No
+    amount of inline retry will help, because the response template that
+    every page returns won't change after a 30s/60s sleep (mangafire's
+    5051-byte CF 'access denied' is the canonical case — see the 2026-05-27
+    Shangri-La Frontier failure for the original observed pattern). Aborting
+    the whole run on a single fake chapter punishes 290 valid chapters for
+    one structural mismatch we can prove is structural. Recording as missed
+    + continuing preserves the all-or-nothing guarantee at the CHAPTER level
+    (we never produced partial PDF output for it) while not sacrificing the
+    run-level coverage.
+
+    The caller-loop path:
+        ChapterSkippedError(reason='ghost_chapter') (one attempt)
+          → _process_chapter_strict tries multi-source alts (might recover)
+          → if every alt also fails: raise ChapterGhostError (no inline-retry)
+          → main for-loop's except clause: _record_missed + continue
+
+    Attributes:
+        chap:         chapter label (from ch.get('chap'))
+        host:         netloc whose responses formed the ghost signature
+        pages_total:  total pages the chapter was supposed to have
+        primary_only: True if the alignment data shows no non-primary source
+                      listed this chapter number (strong "ghost" corroboration);
+                      False otherwise; None if multi-source isn't enabled and
+                      the cross-source check couldn't be evaluated. Surfaced
+                      so the log line tells the user WHICH ghost-chapter shape
+                      this was (primary-only is the canonical "fake placeholder"
+                      pattern; non-primary-only just means the alt sources
+                      also couldn't deliver).
+    """
+    def __init__(self, chap, host: str = "", pages_total: int = 0, primary_only: Optional[bool] = None):
+        self.chap = chap
+        self.host = host
+        self.pages_total = pages_total
+        self.primary_only = primary_only
+        super().__init__(
+            f"chapter {chap} ghost: host={host or '-'} pages={pages_total} "
+            f"primary_only={primary_only}"
         )
 
 
@@ -653,6 +713,31 @@ _HOST_FAIL_COUNT: Dict[str, int] = {}
 _HOST_FAIL_URLS: Dict[str, set] = {}
 _HOST_FAIL_LOCK = threading.Lock()
 
+# Per-chapter response-signature accumulator for ghost-chapter detection.
+# Each entry is (status_code, body_size) — raw response bytes, NOT bucketed.
+# Initially designed with 64-byte bucketing for fuzzy match, but real CF
+# error responses are byte-identical even when Ray IDs differ (Ray IDs are
+# fixed-format 16-char hex strings, so the BYTE length is constant across
+# responses with different Ray IDs). The 64-byte bucketing introduced
+# false-negatives when responses straddled bucket boundaries (e.g. 5051
+# vs 5060 split between buckets 4992 and 5056); exact-match is both more
+# correct AND simpler. If future handlers produce ghost patterns with
+# genuinely-variable body lengths, we can revisit with a tolerance-based
+# detector — but for the mangafire case (the canonical 5051-byte CF 403
+# placeholder) exact match is provably right.
+#
+# Read by _is_ghost_chapter_signature at chapter-failure time. Cleared at
+# the start of every chapter via _reset_host_failures_for_chapter() so the
+# detector is scoped per chapter — a prior chapter's ghosts must not
+# poison the next chapter's classification.
+#
+# Cross-file: written from sites/base.py:fast_download_images via the
+# record_host_failure callback (aio-dl.py:_record_failure now accepts a
+# signature kwarg), and from _try_download_url's failure path at the
+# bottom of the retry loop.
+_CHAPTER_FAIL_SIGNATURES: List[Tuple[Optional[int], int]] = []
+_CHAPTER_FAIL_SIG_LOCK = threading.Lock()
+
 # Phase D (2026-05-13): per-host concurrency cap that dials DOWN on
 # confirmed CDN failures during a run. Distinct from _HOST_FAIL_COUNT
 # (per-chapter, drives the chapter-skip threshold) — this lives across
@@ -837,16 +922,34 @@ def _looks_like_rate_limit(status: Optional[int], body_snippet: str) -> bool:
     return _classify_response_failure(status, body_snippet) == "rate_limit"
 
 
-def _record_failure(host: str, url: str, cls: str) -> None:
+def _record_failure(
+    host: str,
+    url: str,
+    cls: str,
+    *,
+    status: Optional[int] = None,
+    body_size: Optional[int] = None,
+) -> None:
     """Record a fully-failed URL (after retries exhausted) against a host so
     the per-chapter poison threshold can detect a broken host. Counts each
     URL only once per chapter — multiple retry attempts on the same URL
     increment the counter once.
 
-    Called from _try_download_url after the retry loop ends without success.
-    Cls is the classification of the *last* failure; we only count network
+    Called from _try_download_url after the retry loop ends without success,
+    and from sites/base.py:fast_download_images via the record_host_failure
+    callback when curl_cffi exhausts its 2 attempts.
+
+    `cls` is the classification of the *last* failure; we only count network
     failures (origin_error / rate_limit / retryable) — permanent 4xx errors
-    don't indicate the host is broken.
+    don't indicate the host is broken. NOTE on mangafire's ghost-chapter 403s:
+    those classify as 'rate_limit' (the 5051-byte body contains 'cloudflare'
+    /'ray id' rate-limit keywords per _classify_response_failure ~line 819),
+    so they DO get counted here and DO trip _HOST_FAIL_COUNT. That's
+    intentional — the chapter-poison threshold and the ghost-signature
+    detector are complementary: poison says "many distinct URLs failed,"
+    ghost says "every failure looks structurally identical." Ghost takes
+    precedence in the reason ladder (~line 7110) because it's the more
+    specific signal.
 
     Phase D (2026-05-13): also feeds _record_host_failure_for_backoff,
     which dials down the per-host concurrency cap on rate_limit/retryable
@@ -854,7 +957,24 @@ def _record_failure(host: str, url: str, cls: str) -> None:
     counter here) and is independent of the chapter-poison threshold —
     it makes the in-flight fetch lighter BEFORE the threshold trips a
     chapter abort.
+
+    `status` and `body_size`, when provided, feed the ghost-chapter
+    signature accumulator (_CHAPTER_FAIL_SIGNATURES) so a uniform
+    "every page returned identical structural error" pattern can be
+    detected. Optional/keyword-only so existing call sites that don't
+    have response metadata (the failing-without-a-response exception
+    path in fast_download_images) keep working unchanged. Recording is
+    independent of `cls == "permanent"` early-return: even permanent
+    4xx failures contribute to ghost detection if they came with a
+    body (the host-fail count guard stays gated on non-permanent only).
     """
+    # Signature recording happens BEFORE the cls=="permanent" gate so that
+    # uniform 4xx ghost responses (e.g. true 403 placeholder pages whose
+    # body lacks rate-limit keywords) still feed the detector. Without
+    # this, a "pure 403" ghost would never be classified as such — only
+    # the rate-limit-classified ones would.
+    if body_size is not None:
+        _record_failure_signature(status, body_size)
     if not host or cls == "permanent":
         return
     with _HOST_FAIL_LOCK:
@@ -868,6 +988,118 @@ def _record_failure(host: str, url: str, cls: str) -> None:
     _record_host_failure_for_backoff(host, cls)
 
 
+def _record_failure_signature(status: Optional[int], body_size: int) -> None:
+    """Append one failed-URL response signature to the per-chapter
+    accumulator for ghost-chapter detection. Stored as raw (status,
+    body_size) — exact-match comparison at detection time. See the
+    _CHAPTER_FAIL_SIGNATURES module-level comment for why we don't bucket.
+
+    Negative or None body_size is treated as 0 (the exception path passes
+    no body when the request never produced a response). Zero-byte
+    signatures still contribute to the uniformity check, which is correct:
+    a chapter where every page exception'd with the same error class is
+    also structurally broken even if there's no body to fingerprint.
+
+    No-op outside a chapter (when _CHAPTER_FAIL_SIG_LOCK has just been
+    cleared) — the lock and list are process-wide but only meaningful
+    inside _process_chapter; callers outside that scope just contribute
+    noise that the next _reset_host_failures_for_chapter wipes.
+    """
+    sz = max(0, int(body_size)) if body_size is not None else 0
+    with _CHAPTER_FAIL_SIG_LOCK:
+        _CHAPTER_FAIL_SIGNATURES.append((status, sz))
+
+
+def _is_ghost_chapter_signature(
+    *,
+    pages_ok: int,
+    pages_total: int,
+    primary_only: Optional[bool] = None,
+) -> bool:
+    """Return True iff this chapter's failure pattern matches a ghost.
+
+    A "ghost chapter" is a chapter listed in the source's chapter index
+    whose image URLs all return the same structural error response —
+    indicating the chapter doesn't actually have images on the source,
+    not that the CDN is having a moment. Canonical example: mangafire
+    "chapter 0" placeholder entries where every page returns a 5051-byte
+    CF 403 (same status + same byte-bucket = uniform signature).
+
+    Detection signal set:
+      1. pages_ok == 0 (literally nothing succeeded — real transient
+         failures rarely take ALL pages down; usually at least one slips
+         through). Hard requirement.
+      2. pages_total >= threshold. Default 5; lowered to 3 when
+         primary_only is True (the cross-source alignment showed no other
+         site lists this chapter number, which is independent corroboration
+         for "this is fake / soft-launched"). Don't false-positive on
+         legit 1-2 page placeholders.
+      3. len(set(signatures)) == 1. The smoking gun: every failure was
+         the EXACT same (status, body_size). Real CDN issues vary in body
+         length because error pages have varying request-context lines
+         (Ray IDs, timestamps, paths) — but the Ray-ID-bearing parts of
+         CF templates are fixed-format strings, so the BYTE length stays
+         constant across responses with different Ray IDs. Identical
+         signatures across many pages = "the server is intentionally
+         returning a fixed response template" = structural.
+      4. The single signature's status is a 4xx (400 <= status < 500).
+         5xx errors and pure network failures (status=None from
+         timeouts/connection-reset) are inherently transient — the host
+         is sick, not lying about chapter existence — and need the normal
+         host_poison → inline-retry → abort path. 4xx is the discriminator
+         that says "the server is intentionally rejecting this URL,"
+         which IS the ghost shape. The mangafire ghost case is 403; a
+         future "404 placeholder" handler would also fit.
+      5. len(signatures) >= max(3, pages_total // 2). Don't trip on
+         fewer than 3 recorded signatures (statistical floor) and require
+         at least half the chapter's pages have contributed a signature
+         (so we don't ghost-classify a chapter that mostly succeeded but
+         then deadline-cancelled). pages_total // 2 caps at 3 minimum to
+         keep small chapters checkable.
+
+    Cross-source quorum (Idea B from the design brainstorm) is folded
+    into the threshold knob (rule 2) — primary_only=True lowers the
+    pages_total floor from 5 to 3, making detection slightly more
+    aggressive when we have independent evidence the chapter is fake.
+    primary_only=None (multi-source disabled, can't evaluate) treats
+    the chapter as not-primary-only (use the default threshold of 5).
+
+    Cross-file: called from _process_chapter_impl's reason-determination
+    block (~line 7105) BEFORE host_poison/time_budget/incomplete checks
+    so a uniform-signature failure is classified as 'ghost_chapter' even
+    when the host-poison threshold also tripped. Both are real signals
+    about the same failure; ghost is the more specific (and actionable)
+    one.
+    """
+    if pages_ok != 0:
+        return False
+    pages_floor = 3 if primary_only is True else 5
+    if pages_total < pages_floor:
+        return False
+    with _CHAPTER_FAIL_SIG_LOCK:
+        sigs = list(_CHAPTER_FAIL_SIGNATURES)
+    if not sigs:
+        return False
+    sample_floor = max(3, pages_total // 2)
+    if len(sigs) < sample_floor:
+        return False
+    sig_set = set(sigs)
+    if len(sig_set) != 1:
+        return False
+    # 4xx-only gate (rule 4 in the docstring). 5xx and None (timeouts /
+    # network errors) are transient host-level issues that must NOT classify
+    # as ghost — they need the existing host_poison → inline-retry → abort
+    # path. Without this gate, a true host outage (every request times out
+    # → every signature is (None, 0)) would silently skip the ENTIRE
+    # chapter queue chapter-by-chapter, wasting an hour before the user
+    # realizes the host is down. 4xx is the actionable shape: server is
+    # intentionally rejecting THESE URLs, not failing globally.
+    (only_status, _only_size) = next(iter(sig_set))
+    if only_status is None or not (400 <= only_status < 500):
+        return False
+    return True
+
+
 def _host_fail_count(host: str) -> int:
     """Distinct URLs that have fully failed against this host this chapter."""
     if not host:
@@ -878,10 +1110,18 @@ def _host_fail_count(host: str) -> int:
 
 def _reset_host_failures_for_chapter() -> None:
     """Clear per-chapter host-failure state. Called at the top of every chapter
-    in _process_chapter so the threshold is scoped per chapter, not per run."""
+    in _process_chapter so the threshold is scoped per chapter, not per run.
+
+    Also clears _CHAPTER_FAIL_SIGNATURES so the ghost-chapter detector starts
+    fresh for each chapter — without this, a previous chapter's ghost
+    signatures would persist and false-positive subsequent chapters that
+    happen to share the same body-size bucket on partial failures.
+    """
     with _HOST_FAIL_LOCK:
         _HOST_FAIL_COUNT.clear()
         _HOST_FAIL_URLS.clear()
+    with _CHAPTER_FAIL_SIG_LOCK:
+        _CHAPTER_FAIL_SIGNATURES.clear()
 
 
 def _record_host_failure_for_backoff(host: str, cls: str) -> None:
@@ -996,6 +1236,18 @@ def _try_download_url(
     host = urlparse(url).netloc
     last_error: Optional[requests.exceptions.RequestException] = None
     last_class = "retryable"
+    # Track the last response's status code + full body length for the
+    # ghost-chapter signature accumulator. _extract_error_info only returns
+    # a 200-char snippet; for the ghost detector we need the FULL body
+    # length (the discriminator for mangafire's 5051-byte uniform 403s).
+    # Captured per iteration so the LAST iteration's values are what we
+    # record at the failure point — matching the existing last_class
+    # convention. Both default to None outside the response path so a
+    # network-only failure (Timeout, ConnectionError with no response
+    # attached) forwards (None, None) and the detector treats it as a
+    # zero-bucket signature.
+    last_status: Optional[int] = None
+    last_body_size: Optional[int] = None
     poison_threshold = int(globals().get("_CHAPTER_HOST_POISON", 5))
 
     for attempt in range(max_retries):
@@ -1046,6 +1298,22 @@ def _try_download_url(
             status, body_snippet = _extract_error_info(e)
             cls = _classify_response_failure(status, body_snippet)
             last_class = cls
+            last_status = status
+            # Capture full body length for ghost-chapter signature. text[:200]
+            # was already read by _extract_error_info, so the response body
+            # is already drained — len(response.text) reads from the cached
+            # buffer (no extra network I/O). Network-only errors (Timeout,
+            # ConnectionError) have no response attached; leave last_body_size
+            # as None in that case so the detector treats it as zero-bucket.
+            try:
+                resp = getattr(e, "response", None)
+                if resp is not None:
+                    last_body_size = len(resp.text or "")
+            except Exception:
+                # Defensive: any exception reading body text shouldn't
+                # affect the retry decision. Leave last_body_size as
+                # whatever the previous iteration set it to.
+                pass
 
             if cls == "rate_limit":
                 # Bounded cooldown: 3-12s. The browser-equivalent server response
@@ -1089,7 +1357,13 @@ def _try_download_url(
 
     # Loop ended without success — record the URL once against the host so
     # the chapter-level poison threshold can fire if many distinct URLs fail.
-    _record_failure(host, url, last_class)
+    # status + body_size feed the ghost-chapter signature accumulator (uniform
+    # signatures across all chapter pages → ghost_chapter reason).
+    _record_failure(
+        host, url, last_class,
+        status=last_status,
+        body_size=last_body_size,
+    )
     return False, last_error, None
 
 
@@ -6980,7 +7254,16 @@ def main():
                         # failures as 'retryable' (we don't have HTTP status
                         # context out here; the host-poison threshold treats
                         # any non-permanent failure the same).
-                        record_host_failure=lambda h, u: _record_failure(h, u, "retryable"),
+                        # status/body_size are forwarded by the kwargs path
+                        # in sites/base.py:_fetch_one when an HTTP response
+                        # was received (vs. an exception with no body). They
+                        # feed the ghost-chapter signature accumulator so
+                        # uniform "every page returned identical error" is
+                        # detected as ghost_chapter rather than host_poison.
+                        # See aio-dl.py:_record_failure + _is_ghost_chapter_signature.
+                        record_host_failure=lambda h, u, *, status=None, body_size=None: _record_failure(
+                            h, u, "retryable", status=status, body_size=body_size,
+                        ),
                         # Forward cookies from the cloudscraper session so
                         # handlers whose image CDN gates on session cookies
                         # (e.g. age-gated content) ride them. Base impl
@@ -7056,9 +7339,18 @@ def main():
             # hit on Record of Ragnarok: 4-of-65 pages failed but a 61-page PDF
             # was saved with silent gaps. Now: chapter is all-or-nothing.
             #
-            # Reason precedence: 'incomplete' < 'time_budget' < 'host_poison'.
+            # Reason precedence: 'incomplete' < 'time_budget' < 'host_poison'
+            #   < 'ghost_chapter'.
             # The most informative reason takes priority for the diagnostic
-            # log line and the timing summary block.
+            # log line and the timing summary block. ghost_chapter trumps
+            # host_poison when both signals fire because ghost is the more
+            # SPECIFIC classification — "every page returned identical
+            # structural error" implies host_poison (5+ distinct URLs failed)
+            # but the inverse isn't true. The ChapterSkippedError raised
+            # with reason='ghost_chapter' causes _process_chapter_strict to
+            # short-circuit the inline-retry path (no point retrying a
+            # structural failure) and raise ChapterGhostError, which the
+            # main loop catches as skip-and-continue instead of abort.
             pages_total = len(download_tasks) + len(immediate_images)
             pages_ok = sum(1 for _, p in downloaded_images if p) + len(immediate_images)
             poison_threshold = int(globals().get("_CHAPTER_HOST_POISON", 5))
@@ -7102,7 +7394,37 @@ def main():
                         except Exception:
                             pass
                     return ""
-                if poisoned_hosts:
+                # Ghost-chapter check FIRST. The detector uses pages_ok=0 +
+                # uniform signatures across all recorded failures, which is
+                # disjoint from "any pages succeeded" — so a chapter that
+                # had even one successful download will never classify here.
+                # primary_only feeds the threshold knob: when the alignment
+                # data shows no non-primary source for this chapter, drop
+                # the pages_total floor from 5 to 3 (independent corroboration
+                # the chapter is fake). Cross-file:
+                # _is_ghost_chapter_signature lives at ~line 990 here, the
+                # alignment dict (_multi_source_alternatives) is populated
+                # in main() at ~line 5821 / 6388.
+                primary_only_for_ghost: Optional[bool] = None
+                if _multi_source_alternatives:
+                    try:
+                        chap_str = str(ch.get("chap") or "").strip()
+                        m = re.search(r"(\d+(?:\.\d+)?)", chap_str)
+                        if m:
+                            chap_float = float(m.group(1))
+                            primary_only_for_ghost = (
+                                not _multi_source_alternatives.get(chap_float)
+                            )
+                    except (TypeError, ValueError):
+                        primary_only_for_ghost = None
+                if _is_ghost_chapter_signature(
+                    pages_ok=pages_ok,
+                    pages_total=pages_total,
+                    primary_only=primary_only_for_ghost,
+                ):
+                    reason = "ghost_chapter"
+                    host_blame = _resolve_host_blame()
+                elif poisoned_hosts:
                     reason = "host_poison"
                     host_blame = poisoned_hosts[0]
                 elif deadline_hit:
@@ -7111,10 +7433,30 @@ def main():
                 else:
                     reason = "incomplete"
                     host_blame = _resolve_host_blame()
-                print(
-                    f"  [!] Chapter {n} incomplete: {pages_ok}/{pages_total} pages "
-                    f"(reason={reason}, host={host_blame or '-'}). Will inline-retry."
-                )
+                # Reason-aware log line. The "Will inline-retry" suffix is
+                # false for ghost_chapter — _process_chapter_strict
+                # short-circuits the inline-retry sleep + redo when the
+                # primary reason is ghost (a structural failure won't
+                # change after a 30s sleep). For ghost, we hand the
+                # decision off to multi-source alts and, if those also
+                # fail, raise ChapterGhostError (skip+continue, not abort).
+                if reason == "ghost_chapter":
+                    primary_only_qual = (
+                        " (primary-only in alignment)"
+                        if primary_only_for_ghost is True else ""
+                    )
+                    print(
+                        f"  [!] Chapter {n} ghost signature: "
+                        f"{pages_ok}/{pages_total} pages succeeded, every failure "
+                        f"returned an identical error response (host={host_blame or '-'})"
+                        f"{primary_only_qual}. "
+                        f"Will try alternative sources before skipping."
+                    )
+                else:
+                    print(
+                        f"  [!] Chapter {n} incomplete: {pages_ok}/{pages_total} pages "
+                        f"(reason={reason}, host={host_blame or '-'}). Will inline-retry."
+                    )
                 # Wipe partial chapter dir so the inline retry starts fresh.
                 rm_tree(tdir)
                 raise ChapterSkippedError(
@@ -7930,8 +8272,42 @@ def main():
                     # on the primary source (the alignment anchor).
                     handler, scraper, context, comic_data = primary_state
 
-        # All alternatives failed (or none available). Fall back to the
-        # existing inline-retry on the primary source.
+        # All alternatives failed (or none available).
+        #
+        # Ghost-chapter short-circuit: when the PRIMARY failed with the ghost
+        # signature (every page returned an identical structural error), the
+        # inline-retry sleep + redo is pointless — the response template that
+        # produced the signature is generated by a server-side rule that won't
+        # change in 30s or 60s. mangafire's 5051-byte CF 403 for chapter-0
+        # placeholders is the canonical case. Hand off to ChapterGhostError
+        # (caught by the main loop as skip-and-continue) so the run isn't
+        # aborted on a structurally-fake chapter. Cross-source diagnostic:
+        # carry the primary_only flag through from the alignment lookup so
+        # the log line tells the user whether the chapter was primary-only
+        # (strongest fake signal) or just unavailable everywhere (alts
+        # listed it but couldn't deliver — could be coincident outage).
+        if primary_err.reason == "ghost_chapter":
+            primary_only_for_ghost: Optional[bool] = None
+            if _multi_source_alternatives:
+                try:
+                    chap_str = str(ch.get("chap") or "").strip()
+                    m = re.search(r"(\d+(?:\.\d+)?)", chap_str)
+                    if m:
+                        chap_float = float(m.group(1))
+                        primary_only_for_ghost = (
+                            not _multi_source_alternatives.get(chap_float)
+                        )
+                except (TypeError, ValueError):
+                    primary_only_for_ghost = None
+            raise ChapterGhostError(
+                chap=n_for_log,
+                host=primary_err.host,
+                pages_total=primary_err.pages_total,
+                primary_only=primary_only_for_ghost,
+            ) from primary_err
+
+        # Other reasons (incomplete / time_budget / host_poison): fall back
+        # to inline-retry on the primary source — these CAN be transient.
         last_err: ChapterSkippedError = primary_err
         for retry_attempt in range(max_retries):
             wait = base_backoff * (2 ** retry_attempt)
@@ -7975,6 +8351,40 @@ def main():
     aborted_remaining = False
     aborted_chapter: Optional[Dict[str, Any]] = None
 
+    # Consecutive-ghost escalation. Ghost detection alone is right for the
+    # canonical "chapter 0 is a fake placeholder" case (skip + continue), but
+    # WRONG when the host is globally CF-blocked / auth-expired and EVERY
+    # chapter ghosts identically — silently slogging through 290 chapters of
+    # uniform 403s is the "reliability compromise" we explicitly rejected.
+    # Real-world test 2026-05-27: user's mangafire was returning uniform
+    # 5051-byte 403s for chapter 0 (host l1n.mfcdn2.xyz) AND chapter 1 (host
+    # k99.mfcdn2.xyz) — different hosts, same ghost shape — meaning the
+    # block was at the auth/account level, not the chapter level.
+    #
+    # Escalation rule: when GHOST_ABORT_THRESHOLD consecutive chapters
+    # classify as ghost without a successful chapter or non-ghost failure
+    # between them, escalate to abort. The user sees the same FATAL message
+    # they would have seen pre-fix, just slightly later (after N ghosts
+    # instead of after the very first chapter's inline-retries exhausted).
+    #
+    # Threshold = 3:
+    #   - 2 would catch the host-outage case but false-trigger on real
+    #     series with two placeholder chapters at the start (e.g. chapter 0
+    #     + chapter 0.5 both fake — rare but documented).
+    #   - 3 is a safe margin: a user who hits 3 placeholder chapters at the
+    #     start of a manga has bigger problems than this escalator. Real
+    #     host outages produce many more than 3 consecutive ghosts, so 3 is
+    #     fine for the escalation trigger.
+    #
+    # Reset conditions (counter goes back to 0):
+    #   - any successful chapter (chapter_content non-empty after the
+    #     strict wrapper returns)
+    #   - any non-ghost ChapterAbortedError (we're aborting anyway)
+    #   - any generic Exception (recorded as 'exception' missed; not ghost)
+    #   - any empty_content miss (no content but not ghost either)
+    consecutive_ghosts = 0
+    GHOST_ABORT_THRESHOLD = 3
+
     for ch_idx, ch in enumerate(chapters):
         grp_name = handler.get_group_name(ch)
         insert_list_index = len(current_book_content)
@@ -7994,6 +8404,107 @@ def main():
             chapter_content, grp_name, n, chapter_content_size = _process_chapter_strict(
                 ch, next_chapter=next_ch, upcoming_chapters=upcoming_slice
             )
+        except ChapterGhostError as cge:
+            # Soft skip: chapter looks structurally absent on the primary
+            # (uniform error signature across every page) and no alternative
+            # source could deliver it either. NOT abort by default — recording
+            # missed and continuing is the right call, because the failure
+            # shape is "this chapter doesn't exist here" not "the CDN is
+            # broken." See ChapterGhostError docstring near top of file for
+            # rationale, and _process_chapter_strict's
+            # primary_err.reason == "ghost_chapter" branch for the raise site.
+            # Cross-file: _is_ghost_chapter_signature is the detector;
+            # _record_failure_signature is what feeds it from the download
+            # paths.
+            #
+            # EXCEPT when GHOST_ABORT_THRESHOLD consecutive ghosts have fired
+            # without a successful chapter between — see the
+            # consecutive_ghosts comment block above main()'s for-loop for
+            # why. At that point we escalate to abort because the failure
+            # is host-level, not chapter-level, and slogging through the
+            # remaining queue is the "speed and reliability compromise" the
+            # user explicitly rejected.
+            consecutive_ghosts += 1
+            qualifier = (
+                "primary-only ghost"
+                if cge.primary_only is True
+                else "ghost"
+            )
+            if consecutive_ghosts >= GHOST_ABORT_THRESHOLD:
+                # Escalate. Print FATAL message + record this chapter as
+                # aborted:ghost_chapter (NOT plain ghost_chapter) so the
+                # missed-chapters log distinguishes the escalation chapter
+                # from the leading ghost-skipped ones. Record remaining
+                # chapters as not_attempted_after_abort to mirror the
+                # ChapterAbortedError branch's bookkeeping.
+                print(
+                    f"\n[!] FATAL: Chapter {cge.chap} is the "
+                    f"{GHOST_ABORT_THRESHOLD}rd consecutive ghost chapter "
+                    f"(host={cge.host or '?'}). The uniform-error pattern "
+                    f"across multiple chapters indicates a host-level block "
+                    f"(auth expired, CF rule tightened, CDN broken globally) "
+                    f"rather than per-chapter placeholder absence."
+                )
+                print(
+                    f"    Aborting run. Chapters successfully saved before "
+                    f"this point are kept (per-chapter files via "
+                    f"--keep-chapters)."
+                )
+                _record_missed(
+                    ch, grp_name, "aborted:ghost_chapter",
+                    f"escalated after {consecutive_ghosts} consecutive ghosts on primary",
+                    insert_list_index=insert_list_index,
+                    insert_chapter_index=insert_chapter_index,
+                    insert_marker_index=insert_marker_index,
+                    insert_page_index=insert_page_index,
+                    host=cge.host,
+                    pages_ok=0,
+                    pages_total=cge.pages_total,
+                )
+                aborted_remaining = True
+                aborted_chapter = ch
+                for j in range(ch_idx + 1, len(chapters)):
+                    skipped_ch = chapters[j]
+                    _record_missed(
+                        skipped_ch,
+                        handler.get_group_name(skipped_ch),
+                        "not_attempted_after_abort",
+                        f"main pass aborted after {GHOST_ABORT_THRESHOLD} consecutive ghosts",
+                        insert_list_index=len(current_book_content),
+                        insert_chapter_index=len(current_book_chapters),
+                        insert_marker_index=len(current_epub_markers),
+                        insert_page_index=_running_page_count if args.format == 'epub' else 0,
+                        host=cge.host,
+                        pages_ok=0,
+                        pages_total=0,
+                    )
+                break
+
+            # Normal ghost handling — skip + continue, with a counter hint
+            # so the user sees the escalation looming.
+            counter_hint = (
+                f" [{consecutive_ghosts}/{GHOST_ABORT_THRESHOLD} "
+                f"consecutive — will abort at {GHOST_ABORT_THRESHOLD}]"
+                if consecutive_ghosts > 1 else ""
+            )
+            print(
+                f"\n[!] Chapter {cge.chap} is a {qualifier} on "
+                f"{cge.host or '?'}: every page returned an identical "
+                f"structural error response ({cge.pages_total} pages, 0 succeeded). "
+                f"Recorded as missed; the run continues.{counter_hint}"
+            )
+            _record_missed(
+                ch, grp_name, "ghost_chapter",
+                f"uniform error signature on primary; primary_only={cge.primary_only}",
+                insert_list_index=insert_list_index,
+                insert_chapter_index=insert_chapter_index,
+                insert_marker_index=insert_marker_index,
+                insert_page_index=insert_page_index,
+                host=cge.host,
+                pages_ok=0,
+                pages_total=cge.pages_total,
+            )
+            continue
         except ChapterAbortedError as cae:
             # Hard abort: a chapter could not be downloaded fully even after
             # inline retries. The user explicitly asked for this — refuse to
@@ -8055,6 +8566,7 @@ def main():
             # 2026-05-16 run; printing here means future regressions of the
             # same shape are visible immediately rather than only via
             # missed_chapters.json after the run ends.
+            consecutive_ghosts = 0  # reset: this is not a ghost
             print(
                 f"  [!] Chapter {ch.get('chap', '?')} hit an unexpected error: "
                 f"{type(e).__name__}: {str(e)[:200]}. "
@@ -8064,8 +8576,14 @@ def main():
             continue
 
         if not chapter_content:
+            consecutive_ghosts = 0  # reset: empty content is not a ghost
             _record_missed(ch, grp_name, 'empty_content', 'No downloadable content', insert_list_index=insert_list_index, insert_chapter_index=insert_chapter_index, insert_marker_index=insert_marker_index, insert_page_index=insert_page_index)
             continue
+
+        # Successful chapter — reset the consecutive-ghost counter. The
+        # canonical "chapter 0 fake" pattern produces 1 ghost then real
+        # downloads; this reset is what keeps that working.
+        consecutive_ghosts = 0
 
         should_split_by_size = (
             split_size_bytes > 0

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -7440,17 +7440,34 @@ def main():
                 # change after a 30s sleep). For ghost, we hand the
                 # decision off to multi-source alts and, if those also
                 # fail, raise ChapterGhostError (skip+continue, not abort).
+                #
+                # primary_only-aware descriptor: "ghost" alone is misleading
+                # for chapters that exist on alt sources but happen to be
+                # broken on the primary (the canonical 2026-05-27 case:
+                # mangafire chapter 1 has uniform 5051-byte 403s but is on
+                # atsumaru, mangakatana, etc.). User feedback was clear that
+                # such chapters aren't "ghosts" — they're broken-on-primary
+                # and exactly the scenario multi-source exists to fix. The
+                # three states:
+                #   primary_only=True  → genuine placeholder (no other source
+                #                        lists this chapter); skip is the
+                #                        right disposition
+                #   primary_only=False → real chapter, primary CDN broken;
+                #                        multi-source alt-fetch should rescue
+                #   primary_only=None  → multi-source disabled / alignment
+                #                        not built; can't tell
                 if reason == "ghost_chapter":
-                    primary_only_qual = (
-                        " (primary-only in alignment)"
-                        if primary_only_for_ghost is True else ""
-                    )
+                    if primary_only_for_ghost is True:
+                        descriptor = "ghost (primary-only — no other source has this chapter)"
+                    elif primary_only_for_ghost is False:
+                        descriptor = "primary unavailable (alt sources have this chapter — will rescue if possible)"
+                    else:
+                        descriptor = "uniform error on primary"
                     print(
-                        f"  [!] Chapter {n} ghost signature: "
-                        f"{pages_ok}/{pages_total} pages succeeded, every failure "
-                        f"returned an identical error response (host={host_blame or '-'})"
-                        f"{primary_only_qual}. "
-                        f"Will try alternative sources before skipping."
+                        f"  [!] Chapter {n} {descriptor}: "
+                        f"{pages_ok}/{pages_total} pages, every failure had identical "
+                        f"signature (host={host_blame or '-'}). "
+                        f"Trying alternative sources next."
                     )
                 else:
                     print(
@@ -8258,9 +8275,35 @@ def main():
                     # silently fail and waste a worker pool. Subsequent
                     # chapters resume on the primary anyway (strict wrapper's
                     # finally restores primary state).
-                    return _process_chapter(
+                    alt_result = _process_chapter(
                         alt_chapter, force_redownload=True, next_chapter=next_chapter, is_alt_source=True
                     )
+                    # Alt rescue succeeded. Record the rescue in the
+                    # cross-chapter tally so the timing summary can
+                    # surface multi-source value. Also print an explicit
+                    # "rescued" line when the primary failure was the
+                    # ghost-signature shape (the canonical case the user
+                    # said "multi-source exists exactly for this" about).
+                    # For other reasons (host_poison / time_budget /
+                    # incomplete) the existing "[Multi-source] -> X"
+                    # line + the per-chapter "CBZ saved" already make
+                    # the rescue obvious; we only need the extra line for
+                    # ghost because the in-chapter log claimed "every
+                    # failure had identical signature" and we want to
+                    # close the loop visually.
+                    multi_source_rescues.append({
+                        "chap": n_for_log,
+                        "alt_site": alt_handler.name,
+                        "primary_site": primary_state[0].name,
+                        "primary_reason": primary_err.reason,
+                    })
+                    if primary_err.reason == "ghost_chapter":
+                        print(
+                            f"    [Multi-source] ✓ Chapter {n_for_log} rescued "
+                            f"from {primary_state[0].name} ({primary_err.reason}) "
+                            f"via {alt_handler.name}"
+                        )
+                    return alt_result
                 except ChapterSkippedError as cse_alt:
                     print(
                         f"    [Multi-source] {alt_handler.name} also failed "
@@ -8385,6 +8428,17 @@ def main():
     consecutive_ghosts = 0
     GHOST_ABORT_THRESHOLD = 3
 
+    # Multi-source rescue tally: chapters whose primary source failed AND
+    # an alt source successfully delivered them. Each entry is a dict with
+    # chap, alt_site, primary_site, primary_reason. Surfaced in the
+    # end-of-run timing summary so the user can see multi-source's value
+    # at a glance. User feedback 2026-05-27: "chapter 1 isn't a ghost
+    # chapter, it's an exact target for multi-source since it's broken on
+    # MF. That's exactly why multi-source exists." The summary line makes
+    # that value tangible — without it, users may think the run "had
+    # failures" when in fact half the failures were silently rescued.
+    multi_source_rescues: List[Dict[str, Any]] = []
+
     for ch_idx, ch in enumerate(chapters):
         grp_name = handler.get_group_name(ch)
         insert_list_index = len(current_book_content)
@@ -8425,11 +8479,22 @@ def main():
             # remaining queue is the "speed and reliability compromise" the
             # user explicitly rejected.
             consecutive_ghosts += 1
-            qualifier = (
-                "primary-only ghost"
-                if cge.primary_only is True
-                else "ghost"
-            )
+            # primary_only-aware descriptor (same three-state taxonomy as
+            # the in-chapter log line ~line 7385). When this branch runs,
+            # the alt loop in _process_chapter_strict has already been
+            # tried and exhausted — so primary_only=False here means "alts
+            # exist but ALSO couldn't deliver this chapter," which is
+            # a different shape than "primary-only ghost" (genuinely fake)
+            # OR "primary unavailable, untried" (the in-chapter pre-alt
+            # message). Keep these distinct so the user can tell at a
+            # glance whether the missed chapter is a placeholder or a
+            # multi-source rescue that just didn't pan out.
+            if cge.primary_only is True:
+                descriptor = "primary-only ghost (no other source has this chapter)"
+            elif cge.primary_only is False:
+                descriptor = "primary unavailable AND all alt sources failed"
+            else:
+                descriptor = "uniform-error ghost on primary (multi-source disabled)"
             if consecutive_ghosts >= GHOST_ABORT_THRESHOLD:
                 # Escalate. Print FATAL message + record this chapter as
                 # aborted:ghost_chapter (NOT plain ghost_chapter) so the
@@ -8439,11 +8504,12 @@ def main():
                 # ChapterAbortedError branch's bookkeeping.
                 print(
                     f"\n[!] FATAL: Chapter {cge.chap} is the "
-                    f"{GHOST_ABORT_THRESHOLD}rd consecutive ghost chapter "
-                    f"(host={cge.host or '?'}). The uniform-error pattern "
-                    f"across multiple chapters indicates a host-level block "
-                    f"(auth expired, CF rule tightened, CDN broken globally) "
-                    f"rather than per-chapter placeholder absence."
+                    f"{GHOST_ABORT_THRESHOLD}rd consecutive uniform-error "
+                    f"chapter on primary (host={cge.host or '?'}; {descriptor}). "
+                    f"The uniform-error pattern across multiple chapters "
+                    f"indicates a host-level block (auth expired, CF rule "
+                    f"tightened, CDN broken globally) rather than per-chapter "
+                    f"placeholder absence."
                 )
                 print(
                     f"    Aborting run. Chapters successfully saved before "
@@ -8488,9 +8554,8 @@ def main():
                 if consecutive_ghosts > 1 else ""
             )
             print(
-                f"\n[!] Chapter {cge.chap} is a {qualifier} on "
-                f"{cge.host or '?'}: every page returned an identical "
-                f"structural error response ({cge.pages_total} pages, 0 succeeded). "
+                f"\n[!] Chapter {cge.chap}: {descriptor} on "
+                f"{cge.host or '?'} ({cge.pages_total} pages, 0 succeeded). "
                 f"Recorded as missed; the run continues.{counter_hint}"
             )
             _record_missed(
@@ -8864,6 +8929,33 @@ def main():
     print(f"  Processing       : {_fmt_time(_timing['processing'])}")
     print(f"  Other (overhead) : {_fmt_time(_timing_other)}")
     print(f"  Total            : {_fmt_time(_timing_total)}")
+
+    # --- Multi-source rescue tally ---
+    # Surfaces the value of multi-source: chapters whose primary source
+    # failed (any reason — ghost / host_poison / time_budget / incomplete)
+    # and were successfully delivered from an alternative source. The
+    # tally is built up during the main loop in _process_chapter_strict's
+    # alt-success branch. Skipped entirely when empty so single-source
+    # runs aren't polluted with a hollow header. Cross-file:
+    # multi_source_rescues declared near the top of main()'s chapter loop
+    # (~line 8355 with the consecutive_ghosts state). For why this block
+    # exists at all: user feedback 2026-05-27 emphasized that broken-on-
+    # primary chapters (chapter 1 in the Shangri-La Frontier failure case)
+    # are exactly what multi-source exists to handle — making the rescue
+    # visible in the summary closes the loop visually for the user.
+    if multi_source_rescues:
+        print(f"\n--- Multi-source Rescues ---")
+        print(
+            f"  {len(multi_source_rescues)} chapter(s) rescued from primary "
+            f"failures via alternative sources:"
+        )
+        # Stable ordering: insertion order matches chapter-loop order which
+        # is already chap-ascending after collapse-splits + filter.
+        for r in multi_source_rescues:
+            print(
+                f"    Ch {r['chap']:<8} <- {r['alt_site']:<14} "
+                f"(primary {r['primary_site']} failed: {r['primary_reason']})"
+            )
 
     # --- Skipped chapters report ---
     # Printed AFTER the timing summary but BEFORE 'Done.' so the Electron

--- a/aio_search_cli.py
+++ b/aio_search_cli.py
@@ -362,17 +362,15 @@ def run_search_mode(
         probe_failure_cache=cache,
         img_quality_cache=img_cache,
         seed_hits=seed_hits or None,
-        # When the user passed a URL via --search, the seed_hit's site
-        # is the source we're already committed to surfacing as the
-        # primary — its quality_probe result has no bearing on whether
-        # we'll use it, only on ranking. Skipping the probe matches the
-        # user's intent ("I gave you this URL, don't waste cycles
-        # second-guessing it") and avoids the round-trip cost on
-        # handlers that are slow to probe (MangaFire VRF can be 3-5 s
-        # per chapter × 8 chapters = ~30 s on the seeded host alone).
-        skip_probe_sites=(
-            {h.site for h in seed_hits} if seed_hits else None
-        ),
+        # Search mode always probes ALL sources (including the seed
+        # source, when --search was given a URL) so the JSON output
+        # surfaces a real comparable img_quality_score for every
+        # candidate. Quality skip is reserved for direct-URL
+        # --multi-source (find_alternatives_for_direct_url below),
+        # where the primary is already committed and probing it is
+        # waste. SKIP_QUALITY_PROBE class-attr handlers (currently
+        # comix) opt out unconditionally via search_orchestrator's
+        # per-source loop — no plumbing needed here.
         on_status=_status,
         seeded_only=bool(getattr(args, "seeded_only", False)),
     )

--- a/aio_search_cli.py
+++ b/aio_search_cli.py
@@ -362,6 +362,17 @@ def run_search_mode(
         probe_failure_cache=cache,
         img_quality_cache=img_cache,
         seed_hits=seed_hits or None,
+        # When the user passed a URL via --search, the seed_hit's site
+        # is the source we're already committed to surfacing as the
+        # primary — its quality_probe result has no bearing on whether
+        # we'll use it, only on ranking. Skipping the probe matches the
+        # user's intent ("I gave you this URL, don't waste cycles
+        # second-guessing it") and avoids the round-trip cost on
+        # handlers that are slow to probe (MangaFire VRF can be 3-5 s
+        # per chapter × 8 chapters = ~30 s on the seeded host alone).
+        skip_probe_sites=(
+            {h.site for h in seed_hits} if seed_hits else None
+        ),
         on_status=_status,
         seeded_only=bool(getattr(args, "seeded_only", False)),
     )
@@ -622,6 +633,21 @@ def _filter_and_rank_alt_sources(sources, *, primary_host: str = "", quality_min
     for s in sources:
         if primary_host and urlparse(s.url).netloc.lower() == primary_host:
             continue
+        # Handlers that opt out of multi-source merging entirely via the
+        # SKIP_MULTI_SOURCE class attribute (currently only comix — see
+        # sites/comix.py for the why). These are sites whose chapter-list
+        # fetch is wildly more expensive than other handlers in absolute
+        # wall-clock terms (comix runs a ~25 s bridge-DOM-scrape per
+        # candidate through a single-threaded Patchright worker), so
+        # adding them to the alternatives pool delays --multi-source
+        # alignment for the user's primary download without buying real
+        # fallback coverage — the primary site almost always has the
+        # same chapters. Treat the flag as equivalent to primary_host
+        # exclusion: drop before the quality_min check so they never
+        # reach _fetch_chapters_for_winner.
+        handler = get_handler_by_name(s.site)
+        if handler is not None and getattr(handler, "SKIP_MULTI_SOURCE", False):
+            continue
         # Sources qualify by either explicit seed_quality OR a measured
         # img_quality_score >= 0.4 (rough "ok quality" floor). A measured
         # 0.0 (CDN-poisoned probe) does NOT qualify via the img_quality
@@ -735,6 +761,17 @@ def find_alternatives_for_direct_url(
         min_match=min_match,
         probe_failure_cache=cache,
         img_quality_cache=img_cache,
+        # Direct-URL --multi-source: the primary site is committed (we're
+        # downloading from primary_url regardless). Skip its image-quality
+        # probe — the score wouldn't affect our use of it, only ranking,
+        # and the primary_host filter below drops it from alternatives
+        # anyway so its score has no effect on the multi-source merge
+        # either. On MangaFire (the canonical primary), this cuts ~30 s
+        # of chapter-VRF + image-fetch work that the probe would otherwise
+        # spend on the source we already chose.
+        skip_probe_sites=(
+            {primary_handler.name} if primary_handler is not None else None
+        ),
         on_status=on_status,
         seeded_only=bool(getattr(args, "seeded_only", False)),
     )

--- a/aio_search_cli.py
+++ b/aio_search_cli.py
@@ -26,6 +26,23 @@ from __future__ import annotations
 
 import json
 import sys
+
+# Force UTF-8 on stdio before anything prints. When Electron spawns this
+# script (UI-source/electron/searcher.js:160), stdio is a pipe, not a TTY,
+# so Python falls back to locale.getpreferredencoding(False) → cp1252 on
+# default Western Windows (ACP=1252). Log decoration uses → ─ — × ≥ which
+# cp1252 can't encode, crashing the run with UnicodeEncodeError.
+# errors='replace' keeps it crash-proof for any future char.
+# Mirrors aio-dl.py top-of-file block. Grep: UnicodeEncodeError reconfigure
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+try:
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 import time
 from typing import Any, Callable, Optional
 
@@ -409,12 +426,12 @@ def run_search_mode(
             )
             # Alignment input is the older tuple shape; project the richer
             # records down for align_chapter_lists.
-            # collapse_splits flows from --no-collapse-splits CLI flag (default
-            # True). Affects only the per-source diagnostic counts in the
-            # winner_chapter_map JSON; the chapter_map structure is identical
-            # regardless. UI reads `collapse_splits_applied` to label which
-            # interpretation the displayed counts reflect.
-            collapse_splits = bool(getattr(args, "collapse_splits", True))
+            # collapse_splits flows from the --collapse-splits CLI flag
+            # (default False as of 2026-05-27 opt-in flip). Affects per-
+            # source `effective_chapters` AND, when consensus is present,
+            # the actual download list. UI reads `collapse_splits_applied`
+            # to label which interpretation the displayed counts reflect.
+            collapse_splits = bool(getattr(args, "collapse_splits", False))
             alignment = align_chapter_lists(
                 [(rec["site"], rec["chapters"]) for rec in source_records],
                 collapse_splits=collapse_splits,
@@ -424,17 +441,33 @@ def run_search_mode(
             # aligned" the UI surfaces alongside the raw entry count. We need
             # to count each chapter_map entry's chapter_num — the union of
             # everything any source contributed (anchor + orphans).
+            # consensus_set passed through so the aggregate matches per-source
+            # `effective_chapters` (post-refinement), e.g. for Shangri-La
+            # Frontier the aggregate drops from 290 to 283 = 305 - 22
+            # source-only .1 fragments. Without the consensus arg here, the
+            # aggregate would still report 290 while per-source mangafire
+            # reports 283 — inconsistent. (2026-05-27 cross-source duplicate
+            # detection; see ~/.claude/plans/ultrathink-mangafire-and-some-flickering-sparkle.md)
             all_aligned_nums = [
                 e.chapter_num for e in alignment.chapter_map
             ]
             _, effective_aligned = _classify_main_chapters(
-                all_aligned_nums, collapse_splits=collapse_splits
+                all_aligned_nums,
+                collapse_splits=collapse_splits,
+                consensus_set=alignment.consensus_set,
             )
             winner_chapter_map = {
                 "canonical_title": winner.canonical_title,
                 "merge_diagnostics": alignment.merge_diagnostics,
                 "collapse_splits_applied": alignment.collapse_splits_applied,
                 "effective_chapters_aligned": effective_aligned,
+                # consensus_set serialized as a sorted list — sets aren't
+                # JSON-serializable. Consumers (downstream aio-dl.py via
+                # --multi-source-prefetched, and the UI if it ever needs to
+                # render which chapters are peer-confirmed) rebuild the set
+                # via `set(consensus_set)`.
+                "consensus_set": sorted(alignment.consensus_set),
+                "consensus_max": alignment.consensus_max,
                 "chapters": [
                     {
                         "chapter_num": entry.chapter_num,
@@ -496,6 +529,15 @@ def run_search_mode(
                 "anchor_site": anchor_site,
                 "alternatives_by_chap_num": alternatives_by_chap_num,
                 "source_records": source_records,  # holds live scraper/handler/context refs
+                # consensus_set passed in-memory (real set, not list) so
+                # aio-dl.py's group_chapters_for_download call can refine
+                # Rule 2 / 3b / 6 with peer-source confirmation. None when
+                # alignment.consensus_set is empty (single source / no peer
+                # overlap), to keep downstream's "no peer data" check simple.
+                "consensus_set": (
+                    alignment.consensus_set if alignment.consensus_set else None
+                ),
+                "consensus_max": alignment.consensus_max,
             }
 
     if json_output and not auto_pick:
@@ -701,12 +743,26 @@ def find_alternatives_for_direct_url(
       5. Run alignment with primary's chapters as anchor (since primary
          is what the user picked — its chapter set is canonical for the
          download).
-      6. Return alternatives_by_chap_num dict.
+      6. Return a dict with alternatives_by_chap_num AND the consensus_set
+         from alignment so the download path can refine its collapse rules
+         with cross-source duplicate detection (2026-05-27).
 
-    Returns {} when search yields nothing, when no alternatives have
-    chapters, or on any failure. The user's direct-URL download still
-    proceeds; multi-source just provides no fallback in that case.
+    Return shape:
+      {
+        "alternatives_by_chap_num": Dict[float, List[alt]],
+        "consensus_set": Set[float] | None,    # None when single source / no overlap
+        "consensus_max": float | None,
+      }
+    Returns {"alternatives_by_chap_num": {}, ...} when search yields nothing,
+    when no alternatives have chapters, or on any failure. The user's direct-
+    URL download still proceeds; multi-source just provides no fallback in
+    that case.
     """
+    _empty_result = {
+        "alternatives_by_chap_num": {},
+        "consensus_set": None,
+        "consensus_max": None,
+    }
     # Step 1: title.
     title = (
         getattr(primary_context, "title", None)
@@ -729,7 +785,7 @@ def find_alternatives_for_direct_url(
     if not title:
         if on_status:
             on_status("[!] Multi-source: couldn't determine title from URL; skipping alternatives discovery")
-        return {}
+        return _empty_result
 
     if on_status:
         on_status(f"[*] Multi-source: searching for alternatives to '{title}'...")
@@ -776,7 +832,7 @@ def find_alternatives_for_direct_url(
     if not candidates:
         if on_status:
             on_status("[!] Multi-source: no search candidates found; no alternatives available")
-        return {}
+        return _empty_result
 
     # Step 3: pick the top candidate, drop sources on the same host as primary,
     # and filter out unknown-quality (default seed=0.50) sources that are
@@ -802,7 +858,7 @@ def find_alternatives_for_direct_url(
                 f"(quality_min={quality_min:.2f}; lower with "
                 f"--multi-source-quality-min if you want broader fallback)"
             )
-        return {}
+        return _empty_result
 
     # Step 4: pre-fetch chapter lists from alternatives.
     # Build a synthetic candidate exposing just the alt sources to reuse
@@ -827,7 +883,7 @@ def find_alternatives_for_direct_url(
 
     alignment = align_chapter_lists(
         sources_with_chapters,
-        collapse_splits=bool(getattr(args, "collapse_splits", True)),
+        collapse_splits=bool(getattr(args, "collapse_splits", False)),
     )
 
     # Step 6: build alternatives_by_chap_num.
@@ -852,7 +908,18 @@ def find_alternatives_for_direct_url(
         if alts:
             alternatives_by_chap_num[entry.chapter_num] = alts
 
-    return alternatives_by_chap_num
+    # consensus_set surfaced so the download path (group_chapters_for_download
+    # at aio-dl.py:6541) can refine Rule 2 / 3b / 6 with peer confirmation.
+    # None when alignment found no peer overlap (single eligible alt or all
+    # alts diverged via compatibility threshold) — downstream falls through
+    # to in-source-only heuristics.
+    return {
+        "alternatives_by_chap_num": alternatives_by_chap_num,
+        "consensus_set": (
+            alignment.consensus_set if alignment.consensus_set else None
+        ),
+        "consensus_max": alignment.consensus_max,
+    }
 
 
 def build_alternatives_from_prefetched(
@@ -882,12 +949,19 @@ def build_alternatives_from_prefetched(
         downloader.js spawn-close handler. Same place ImageQualityCache
         and ProbeFailureCache snapshots live.
 
-    Failure modes — all yield {} so multi-source quietly degrades to
-    single-source rather than blocking the download:
+    Failure modes — all yield the empty-result dict so multi-source quietly
+    degrades to single-source rather than blocking the download:
       - File missing / unreadable
       - Malformed JSON (no `alternatives` key, etc.)
       - Every alt's handler is unknown (renamed sites, etc.)
       - Every alt's chapter-list fetch throws
+
+    Return shape — same as find_alternatives_for_direct_url (2026-05-27):
+      {
+        "alternatives_by_chap_num": Dict[float, List[alt]],
+        "consensus_set": Set[float] | None,
+        "consensus_max": float | None,
+      }
 
     Cross-file:
       - Path passed via aio-dl.py's --multi-source-prefetched flag
@@ -898,13 +972,19 @@ def build_alternatives_from_prefetched(
     import json as _json
     import os as _os
 
+    _empty_result = {
+        "alternatives_by_chap_num": {},
+        "consensus_set": None,
+        "consensus_max": None,
+    }
+
     if not prefetched_path or not _os.path.exists(prefetched_path):
         if on_status:
             on_status(
                 f"[!] Multi-source: prefetched alts file missing ({prefetched_path}); "
                 f"skipping discovery"
             )
-        return {}
+        return _empty_result
 
     try:
         with open(prefetched_path, "r", encoding="utf-8") as f:
@@ -915,7 +995,7 @@ def build_alternatives_from_prefetched(
                 f"[!] Multi-source: failed to read prefetched alts: "
                 f"{type(exc).__name__}: {exc}"
             )
-        return {}
+        return _empty_result
 
     alternatives = payload.get("alternatives") or []
     if not isinstance(alternatives, list) or not alternatives:
@@ -924,7 +1004,7 @@ def build_alternatives_from_prefetched(
                 f"[!] Multi-source: prefetched payload had no alternatives; "
                 f"skipping discovery"
             )
-        return {}
+        return _empty_result
 
     title = (payload.get("title") or "").strip() or "<prefetched>"
     if on_status:
@@ -994,7 +1074,7 @@ def build_alternatives_from_prefetched(
                 "[!] Multi-source: prefetched alternatives had no usable (site, url) "
                 "entries; skipping discovery"
             )
-        return {}
+        return _empty_result
 
     alt_candidate = SeriesCandidate(
         canonical_title=title,
@@ -1015,7 +1095,7 @@ def build_alternatives_from_prefetched(
 
     alignment = align_chapter_lists(
         sources_with_chapters,
-        collapse_splits=bool(getattr(args, "collapse_splits", True)),
+        collapse_splits=bool(getattr(args, "collapse_splits", False)),
     )
 
     records_by_site = {rec["site"]: rec for rec in source_records}
@@ -1039,7 +1119,15 @@ def build_alternatives_from_prefetched(
         if alts:
             alternatives_by_chap_num[entry.chapter_num] = alts
 
-    return alternatives_by_chap_num
+    # Same consensus surfacing as find_alternatives_for_direct_url; consumed
+    # by aio-dl.py at the group_chapters_for_download call site.
+    return {
+        "alternatives_by_chap_num": alternatives_by_chap_num,
+        "consensus_set": (
+            alignment.consensus_set if alignment.consensus_set else None
+        ),
+        "consensus_max": alignment.consensus_max,
+    }
 
 
 __all__ = [

--- a/aio_search_cli.py
+++ b/aio_search_cli.py
@@ -940,11 +940,32 @@ def build_alternatives_from_prefetched(
     # for ranking — just for the parallel chapter-list fetch.
     from sites.search_orchestrator import SeriesCandidate, SourceEntry
 
+    # SKIP_MULTI_SOURCE filter: mirrors _filter_and_rank_alt_sources's check
+    # (see ~line 647). Required at THIS entry point too because the prefetched
+    # JSON path bypasses _filter_and_rank_alt_sources entirely — that filter
+    # only runs on the direct-URL multi-source path
+    # (find_alternatives_for_direct_url, above). Without this hook, comix gets
+    # queued for a chapter-list fetch despite SKIP_MULTI_SOURCE=True and the
+    # user pays a ~25 s Patchright bridge scrape per multi-source download
+    # AND a ~5-minute canvas scrape per chapter when comix is hit as a
+    # fallback alt — see sites/comix.py:99 for the why-not-multi-source
+    # rationale.
+    # Cross-file: SKIP_MULTI_SOURCE is set in sites/comix.py (the only handler
+    # using it today). _filter_and_rank_alt_sources in this file does the same
+    # check; both filters must agree for SKIP_MULTI_SOURCE to be honored
+    # consistently across the direct-URL and prefetched-JSON paths.
     alt_sources = []
+    skipped_skip_multi: list = []
     for alt in alternatives:
         site = (alt.get("site") or "").strip()
         url = (alt.get("url") or "").strip()
         if not site or not url:
+            continue
+        handler_for_alt = get_handler_by_name(site)
+        if handler_for_alt is not None and getattr(
+            handler_for_alt, "SKIP_MULTI_SOURCE", False,
+        ):
+            skipped_skip_multi.append(site)
             continue
         alt_sources.append(
             SourceEntry(
@@ -958,6 +979,13 @@ def build_alternatives_from_prefetched(
                 seed_quality=0.0,
                 composite_score=1.0,
             )
+        )
+
+    if skipped_skip_multi and on_status:
+        on_status(
+            f"[*] Multi-source: dropping {len(skipped_skip_multi)} prefetched "
+            f"alternative(s) marked SKIP_MULTI_SOURCE: "
+            f"{', '.join(sorted(set(skipped_skip_multi)))}"
         )
 
     if not alt_sources:

--- a/comix_seed_calibration.py
+++ b/comix_seed_calibration.py
@@ -1,0 +1,456 @@
+"""Standalone comix seed calibrator.
+
+Drives ComixSiteHandler end-to-end on a list of comix.to URLs and emits the
+aggregate T1+T2 quality score that the orchestrator's _probe_chapter_aggregate
+would have computed — minus the orchestrator's 240 s probe deadline and the
+60 s bridge timeout that together prevent the real probe from ever finishing
+on comix.
+
+Why this tool exists
+====================
+sites/comix.py canvas-captures every page of a chapter to defeat the site's
+client-side image scrambling. A single chapter takes 30–180 s through the
+single-worker Patchright bridge. The probe phase needs 8 chapters/source ×
+6 parallel sources, all queueing on that one bridge worker — the orchestrator
+hits its 240 s wall-clock deadline long before comix produces a single score.
+Worse, when it DID complete, the synthetic ``comix-page://`` URLs the canvas
+capture returns aren't HTTP-fetchable by ``_fetch_probe_item_bytes`` so every
+chapter scored 0.0 anyway.
+
+This tool runs the probe sequentially with no outer wall-clock, resolves the
+synthetic URLs out of sites/image_cache (where comix's response listener
+stashes the decoded bytes), and feeds them through the same _score_image_blob
+path the probe would have used — with --enable-ml-rating forced on so T2 NIQE
++ CLIP-IQA+ contribute to the composite.
+
+Output
+======
+Per URL: JSON with aggregate_score + per-chapter scores + content classification.
+At the end: arithmetic mean of all aggregate scores — the calibrated seed
+that should land in sites/quality_seed.json under "comix".
+
+Usage
+=====
+    python comix_seed_calibration.py URL [URL ...]
+
+Cross-file
+==========
+- sites/comix.py:_COMIX_BROWSER_BRIDGE — bridge facade used here for the
+  bytes path. _COMIX_DEFAULT_TIMEOUT_S is the per-call cap; bumped to 900 s
+  below so 130+ page chapters don't trip it.
+- sites/base.py:_pick_representative_chapters / _pick_random_middle_page_index
+  — same sampler the real probe uses.
+- sites/search_orchestrator.py:_score_image_blob — full T1+T2 pipeline.
+  Gated on _ML_RATING_ENABLED which we flip True via the env var BEFORE
+  importing the module.
+"""
+from __future__ import annotations
+
+# Must precede any sites.* import so the module-level _ML_RATING_ENABLED
+# read picks up the gate. set_ml_rating_enabled also works post-import but
+# the env-var path is one less moving part.
+import os
+os.environ.setdefault("AIO_ENABLE_ML_RATING", "1")
+
+import json
+import statistics
+import sys
+import time
+import traceback
+from typing import Any, Dict, List, Optional, Tuple
+
+import cloudscraper
+
+import sites.comix as comix_mod
+from sites import image_cache
+from sites.base import SearchHit
+from sites.comix import ComixSiteHandler
+from sites.search_orchestrator import (
+    _classify_series_content,
+    _score_image_blob,
+    is_ml_rating_enabled,
+    set_ml_rating_enabled,
+    warmup_t2_models,
+)
+
+# Bump the bridge's default per-call timeout. The real probe relies on the
+# per-method _timeout_s plumbing (fetch_chapter_images_via_dom defaults to
+# 300+30 s) so _COMIX_DEFAULT_TIMEOUT_S only matters for calls that don't
+# pass an explicit timeout — but bumping it costs nothing and guards
+# against future bridge methods that forget.
+comix_mod._COMIX_DEFAULT_TIMEOUT_S = 900.0
+
+
+def _make_request(url: str, scraper):
+    """Minimal make_request shim — single GET, 30 s timeout, no retry.
+
+    Comix's _cf_aware_request wraps this with zendriver CF resilience on
+    403/503, so we don't need our own retry loop. Search-time
+    _search_make_request_factory does retries; for one-off calibration we
+    don't bother.
+    """
+    return scraper.get(url, timeout=30)
+
+
+def _resolve_to_bytes(
+    item: Any, scraper,
+) -> Optional[Tuple[bytes, str]]:
+    """Resolve a get_chapter_images return item to (bytes, content_type).
+
+    Item shapes:
+      - str starting with ``comix-page://`` — synthetic key for a canvas-
+        captured page. Bytes live in sites/image_cache under that key.
+      - other str — plain CDN URL for a non-scrambled <img>. Fetch via
+        the supplied cloudscraper instance (CF cookies already loaded).
+
+    Returns None on miss / fetch failure / undersized body.
+    """
+    if not isinstance(item, str) or not item:
+        return None
+    cached = image_cache.get_cached_image(item)
+    if cached is not None:
+        return cached
+    if item.startswith("comix-page://"):
+        # Synthetic URL that should have been in cache but wasn't —
+        # likely TTL-evicted between scrape and read. We don't retry
+        # because re-scraping the chapter would just re-populate the
+        # same key on a 600 s budget that's already gone.
+        return None
+    try:
+        resp = scraper.get(item, timeout=30)
+        if resp.status_code >= 400:
+            return None
+        body = resp.content
+        if not body or len(body) < 256:
+            return None
+        ct = resp.headers.get("content-type", "")
+        return (body, ct)
+    except Exception:
+        return None
+
+
+def calibrate_one(url: str, n_chapters: int = 8) -> Dict[str, Any]:
+    """Run the full _probe_chapter_aggregate-equivalent pipeline on one URL.
+
+    Returns a dict with aggregate_score + per-chapter detail. Mirrors the
+    shape that the orchestrator's per-source cache stores so the numbers
+    can be compared directly against other sites' cached scores.
+    """
+    print(f"\n{'=' * 70}", flush=True)
+    print(f"[*] calibrating: {url}", flush=True)
+    print(f"{'=' * 70}", flush=True)
+    handler = ComixSiteHandler()
+    scraper = cloudscraper.create_scraper(
+        browser={"browser": "chrome", "platform": "darwin", "mobile": False}
+    )
+    handler.configure_session(scraper, args=None)
+
+    t0 = time.monotonic()
+
+    # Step 1: fetch_comic_context (1 HTTP, CF-resilient via _cf_aware_request)
+    print("[*] fetch_comic_context...", flush=True)
+    t_ctx = time.monotonic()
+    try:
+        ctx = handler.fetch_comic_context(url, scraper, _make_request)
+    except Exception as exc:
+        print(f"[!] fetch_comic_context failed: {type(exc).__name__}: {exc}", flush=True)
+        return {"url": url, "error": f"fetch_comic_context: {exc}"}
+    print(
+        f"    title={ctx.title!r} ({time.monotonic() - t_ctx:.1f}s)", flush=True,
+    )
+
+    # Step 2: get_chapters (encrypted API → bridge DOM scrape)
+    print("[*] get_chapters...", flush=True)
+    t_ch = time.monotonic()
+    try:
+        chapters = handler.get_chapters(ctx, scraper, "en", _make_request)
+    except Exception as exc:
+        print(f"[!] get_chapters failed: {type(exc).__name__}: {exc}", flush=True)
+        return {"url": url, "error": f"get_chapters: {exc}"}
+    n_chap_total = len(chapters)
+    print(
+        f"    {n_chap_total} chapter(s) ({time.monotonic() - t_ch:.1f}s)",
+        flush=True,
+    )
+    if not chapters:
+        return {"url": url, "title": ctx.title, "error": "no chapters"}
+
+    # Step 3: pick N representative chapters via the same sampler the
+    # orchestrator uses.
+    chapter_picks = ComixSiteHandler._pick_representative_chapters(
+        chapters, n=n_chapters,
+    )
+    print(
+        f"[*] sampling {len(chapter_picks)} chapter(s) at indices "
+        f"{[i for i, _ in chapter_picks]}",
+        flush=True,
+    )
+
+    # Step 4: per-chapter scrape + score (interleaved so image_cache TTL
+    # doesn't expire between scrape and read on slow runs).
+    per_chapter_scores: List[float] = []
+    per_chapter_metas: List[Dict] = []
+    per_chapter_blobs: List[Optional[bytes]] = []
+    per_chapter_records: List[Dict[str, Any]] = []
+
+    for abs_idx, chapter in chapter_picks:
+        t_chap = time.monotonic()
+        chap_label = chapter.get("chap") or "?"
+        chap_url = chapter.get("url") or "?"
+        print(
+            f"  • idx={abs_idx} chap={chap_label!r} "
+            f"url={chap_url}",
+            flush=True,
+        )
+
+        try:
+            image_items = handler.get_chapter_images(
+                chapter, scraper, _make_request,
+            )
+        except Exception as exc:
+            print(
+                f"      ! get_chapter_images raised "
+                f"{type(exc).__name__}: {exc}",
+                flush=True,
+            )
+            per_chapter_scores.append(0.0)
+            per_chapter_blobs.append(None)
+            per_chapter_records.append({
+                "idx": abs_idx, "score": 0.0,
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            continue
+
+        n_imgs = len(image_items) if image_items else 0
+        dt_scrape = time.monotonic() - t_chap
+        print(f"      → {n_imgs} image(s) ({dt_scrape:.1f}s)", flush=True)
+
+        if not image_items:
+            per_chapter_scores.append(0.0)
+            per_chapter_blobs.append(None)
+            per_chapter_records.append({
+                "idx": abs_idx, "score": 0.0, "reason": "no_images",
+            })
+            continue
+
+        page_idx = ComixSiteHandler._pick_random_middle_page_index(
+            len(image_items), url, abs_idx, chapter=chapter,
+        )
+        if page_idx is None:
+            per_chapter_scores.append(0.0)
+            per_chapter_blobs.append(None)
+            per_chapter_records.append({
+                "idx": abs_idx, "score": 0.0, "reason": "no_page_picked",
+            })
+            continue
+
+        resolved = _resolve_to_bytes(image_items[page_idx], scraper)
+        if resolved is None:
+            per_chapter_scores.append(0.0)
+            per_chapter_blobs.append(None)
+            per_chapter_records.append({
+                "idx": abs_idx, "score": 0.0,
+                "reason": "no_bytes",
+                "picked_item": image_items[page_idx],
+            })
+            print(
+                f"      ! resolved no bytes for "
+                f"{image_items[page_idx]!r}",
+                flush=True,
+            )
+            continue
+        blob, ct = resolved
+
+        # First pass: score with content_type="unknown" so we can
+        # classify the series across all 8 samples below.
+        scored = _score_image_blob(blob)
+        if scored is None:
+            per_chapter_scores.append(0.0)
+            per_chapter_blobs.append(None)
+            per_chapter_records.append({
+                "idx": abs_idx, "score": 0.0, "reason": "score_failed",
+            })
+            continue
+        score, metadata = scored
+        per_chapter_scores.append(score)
+        per_chapter_metas.append(metadata)
+        per_chapter_blobs.append(blob)
+        per_chapter_records.append({
+            "idx": abs_idx,
+            "score": score,
+            "width": metadata.get("width"),
+            "height": metadata.get("height"),
+            "is_grayscale": metadata.get("is_grayscale"),
+            "format": metadata.get("format"),
+            "t1_score": metadata.get("t1_score"),
+            "t2_available": metadata.get("t2_available"),
+            "t2_score": metadata.get("t2_score"),
+            "niqe_score": metadata.get("niqe_score"),
+            "clip_iqa_score": metadata.get("clip_iqa_score"),
+        })
+        print(
+            f"      ✓ score={score:.4f} "
+            f"t1={metadata.get('t1_score')!s:.6} "
+            f"t2={metadata.get('t2_score')!s:.6} "
+            f"({metadata.get('width')}×{metadata.get('height')} "
+            f"{metadata.get('format')})",
+            flush=True,
+        )
+
+    # Step 5: classify content_type from per-page metadata and re-score
+    # successful blobs if the classification produced a non-trivial
+    # content_type. Mirrors base.py:_probe_chapter_aggregate.
+    series_content_type = "unknown"
+    if per_chapter_metas:
+        try:
+            feature_view = [
+                {
+                    "width": m.get("width", 0),
+                    "height": m.get("height", 0),
+                    "aspect": (
+                        m.get("width", 0) / m["height"]
+                        if m.get("height") else 1.0
+                    ),
+                    "is_grayscale_page": bool(m.get("is_grayscale", False)),
+                    "chroma_var": float(m.get("chroma_var", 0.0)),
+                }
+                for m in per_chapter_metas
+            ]
+            series_content_type = _classify_series_content(feature_view)
+        except Exception as exc:
+            print(
+                f"[!] classify_series_content failed: "
+                f"{type(exc).__name__}: {exc}",
+                flush=True,
+            )
+
+    print(f"[*] series content_type = {series_content_type!r}", flush=True)
+
+    if series_content_type not in ("unknown", "bw_manga") and per_chapter_blobs:
+        print(
+            f"[*] re-scoring with content_type={series_content_type!r}...",
+            flush=True,
+        )
+        new_scores = list(per_chapter_scores)
+        rescore_idx = 0
+        for i, old_score in enumerate(per_chapter_scores):
+            if old_score <= 0.0:
+                continue
+            blob = per_chapter_blobs[i]
+            if blob is None:
+                rescore_idx += 1
+                continue
+            r = _score_image_blob(blob, content_type=series_content_type)
+            if r is None:
+                rescore_idx += 1
+                continue
+            new_score, _new_meta = r
+            new_scores[i] = new_score
+            rescore_idx += 1
+        per_chapter_scores = new_scores
+
+    # Step 6: aggregate — median when all succeeded, mean otherwise.
+    successes = [s for s in per_chapter_scores if s > 0.0]
+    if not successes:
+        aggregate = 0.0
+    elif len(successes) == len(per_chapter_scores):
+        aggregate = statistics.median(per_chapter_scores)
+    else:
+        aggregate = sum(per_chapter_scores) / len(per_chapter_scores)
+
+    result = {
+        "url": url,
+        "title": ctx.title,
+        "content_type": series_content_type,
+        "n_chapters_total": n_chap_total,
+        "n_chapters_probed": len(chapter_picks),
+        "n_chapters_succeeded": len(successes),
+        "aggregate_score": round(float(aggregate), 4),
+        "per_chapter": per_chapter_records,
+        "per_chapter_scores": [round(float(s), 4) for s in per_chapter_scores],
+        "elapsed_s": round(time.monotonic() - t0, 1),
+    }
+    print(
+        f"\n[✓] {url}\n    aggregate_score = {aggregate:.4f} "
+        f"(n={len(successes)}/{len(per_chapter_scores)} successful, "
+        f"content_type={series_content_type!r}, "
+        f"{result['elapsed_s']:.1f}s)",
+        flush=True,
+    )
+    return result
+
+
+def _shutdown_bridge() -> None:
+    """Best-effort: tell the comix bridge to close its Patchright session.
+    Daemon thread, so the interpreter exits regardless."""
+    try:
+        comix_mod._COMIX_REQUEST_QUEUE.put_nowait(
+            comix_mod._COMIX_SHUTDOWN_SENTINEL
+        )
+    except Exception:
+        pass
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(
+            "usage: python comix_seed_calibration.py URL [URL ...]",
+            file=sys.stderr,
+        )
+        return 1
+    urls = sys.argv[1:]
+
+    print("[*] enabling ML rating + warming T2 models...", flush=True)
+    set_ml_rating_enabled(True)
+    t_warm = time.monotonic()
+    warmup_t2_models(background=False)
+    print(
+        f"[*] T2 ready in {time.monotonic() - t_warm:.1f}s. "
+        f"ml_rating_enabled={is_ml_rating_enabled()}",
+        flush=True,
+    )
+
+    results: List[Dict[str, Any]] = []
+    for url in urls:
+        try:
+            r = calibrate_one(url)
+        except Exception as exc:
+            print(
+                f"[!] {url} top-level exception: "
+                f"{type(exc).__name__}: {exc}",
+                flush=True,
+            )
+            traceback.print_exc()
+            r = {"url": url, "error": f"{type(exc).__name__}: {exc}"}
+        results.append(r)
+
+    scores = [
+        r["aggregate_score"]
+        for r in results
+        if isinstance(r.get("aggregate_score"), (int, float))
+    ]
+
+    summary = {
+        "results": results,
+        "average_score": (
+            round(sum(scores) / len(scores), 4) if scores else None
+        ),
+        "n_scored": len(scores),
+        "n_total": len(results),
+    }
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+    print(json.dumps(summary, indent=2, default=str))
+    if scores:
+        print(
+            f"\n→ Suggested comix seed (mean of {len(scores)} title(s)): "
+            f"{summary['average_score']}",
+            flush=True,
+        )
+    _shutdown_bridge()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metadata_cli.py
+++ b/metadata_cli.py
@@ -5,6 +5,23 @@ import argparse
 import json
 import sys
 
+# Force UTF-8 on stdio before anything prints. When Electron spawns this
+# script (UI-source/electron/main.js:195), stdio is a pipe, not a TTY,
+# so Python falls back to locale.getpreferredencoding(False) → cp1252 on
+# default Western Windows (ACP=1252). Metadata JSON can contain any
+# non-ASCII char (titles, author names, summaries) — cp1252 chokes on
+# anything outside Latin-1, crashing the IPC mid-response. Mirrors the
+# top-of-file block in aio-dl.py / aio_search_cli.py.
+# Grep: UnicodeEncodeError reconfigure
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+try:
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 from metadata_editor import read_metadata, update_metadata
 
 

--- a/sites/base.py
+++ b/sites/base.py
@@ -277,7 +277,7 @@ class BaseSiteHandler:
         concurrency: int = 8,
         timeout: float = 30.0,
         is_cancelled: Optional[Callable[[], bool]] = None,
-        record_host_failure: Optional[Callable[[str, str], None]] = None,
+        record_host_failure: Optional[Callable[..., None]] = None,
         scraper: Any = None,
     ) -> List[Tuple[int, Optional[str]]]:
         """Bulk-download chapter images via curl_cffi async + HTTP/2.
@@ -305,7 +305,14 @@ class BaseSiteHandler:
                           checks before sending the next request and bails.
           record_host_failure: Optional callback fired when a URL hard-fails.
                           Updates aio-dl.py's _HOST_FAIL_COUNT so the chapter
-                          watchdog can poison-detect a flaky CDN.
+                          watchdog can poison-detect a flaky CDN. Forward-
+                          compatible kwarg signature: callers may pass
+                          (host, url) or (host, url, status=..., body_size=...)
+                          — the latter feeds the ghost-chapter signature
+                          accumulator. Older overrides that pass only
+                          (host, url) keep working; new code should forward
+                          status + body_size when the response object is in
+                          scope.
           scraper:        Optional cloudscraper session. When supplied, the
                           curl_cffi AsyncSession is constructed with cookies
                           forwarded from the scraper that match the host of
@@ -401,15 +408,23 @@ class BaseSiteHandler:
                             continue
                         if record_host_failure is not None:
                             try:
+                                # No response object (request itself raised),
+                                # so no status/body_size to forward. The
+                                # callback's kwargs default to None and the
+                                # ghost-detector treats absent signatures
+                                # as zero-bucket — exceptions that all share
+                                # the same cls also register as uniform if
+                                # they all hit this path identically.
                                 record_host_failure(host, url)
                             except Exception:
                                 pass
                         return page_idx, None
                 if r.status_code != 200 or not r.content or len(r.content) < 256:
                     import sys
+                    body_len = len(r.content) if r.content else 0
                     print(
                         f"[-] curl_cffi status={r.status_code} "
-                        f"size={len(r.content) if r.content else 0} for URL: {url}",
+                        f"size={body_len} for URL: {url}",
                         file=sys.stderr,
                     )
                     if attempt < 1:
@@ -417,7 +432,18 @@ class BaseSiteHandler:
                         continue
                     if record_host_failure is not None:
                         try:
-                            record_host_failure(host, url)
+                            # Forward status + body_size so aio-dl.py's
+                            # _record_failure can feed the ghost-chapter
+                            # signature accumulator. Uniform (status,
+                            # body_bucket) across every page of a chapter
+                            # is the signal that distinguishes a fake/
+                            # placeholder chapter from a transient CDN
+                            # issue. See aio-dl.py:_is_ghost_chapter_signature.
+                            record_host_failure(
+                                host, url,
+                                status=r.status_code,
+                                body_size=body_len,
+                            )
                         except Exception:
                             pass
                     return page_idx, None

--- a/sites/chapter_merger.py
+++ b/sites/chapter_merger.py
@@ -28,8 +28,8 @@ Cross-file:
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
 
 
 # Compiled once. Matches the FIRST decimal-or-integer chapter number in a
@@ -37,6 +37,49 @@ from typing import Dict, List, Optional, Tuple
 # include "Ch 47", "Chapter 47", "047", "Ch.47.5", etc. We just want the
 # first numeric token that can act as a chapter ordinal.
 _CHAPTER_NUM_RE = re.compile(r"(\d+(?:\.\d+)?)")
+
+
+# Fragment-shaped decimal values: typically partial-upload chunks of the
+# integer parent, not canonical sub-chapters. Empirically, sites that emit
+# X.Y as a real "Chapter X.5: Side Story" overwhelmingly use Y ∈ {.5..9};
+# Y ∈ {.1..4} are almost always upload fragments (the publisher's first-
+# pass partial release before the canonical chapter is bundled). The
+# cross-source check still gates the drop — if a peer source also has
+# X.1, we keep it. So this is a safe-by-default heuristic, not a hard ban.
+# Grep target: _is_source_only_fragment, group_chapters_for_download Rule 2.
+_FRAGMENT_DECIMAL_VALUES = (0.1, 0.2, 0.3, 0.4)
+
+
+def _is_fragment_shaped_decimal(num: float, floor: int) -> bool:
+    """True iff the decimal portion of ``num`` is one of .1/.2/.3/.4.
+
+    Round to 1 dp to absorb 0.1+0.2-style float drift (same convention as
+    _is_sequential_split_decimals). Pure value check — does NOT consult any
+    consensus set; combine with _is_source_only_fragment for the gated drop.
+    """
+    rel = round(num - floor, 1)
+    return rel in _FRAGMENT_DECIMAL_VALUES
+
+
+def _is_source_only_fragment(
+    num: float, floor: int, consensus_set: Optional[Set[float]],
+) -> bool:
+    """Should this decimal be treated as a duplicate fragment?
+
+    True iff the decimal value is fragment-shaped (.1/.2/.3/.4) AND no peer
+    source confirms it (it's not in the cross-source consensus). Requires
+    a non-empty ``consensus_set`` to fire — when there's no peer signal
+    (single-source run, direct URL, or just no overlap among sources) the
+    function returns False so the existing in-source heuristics own the
+    decision. Used by both ``group_chapters_for_download`` (the actual
+    drop site) and ``_classify_chapter_breakdown`` (diagnostic counting),
+    keeping the two perfectly in sync.
+    """
+    if consensus_set is None or not consensus_set:
+        return False
+    if num in consensus_set:
+        return False
+    return _is_fragment_shaped_decimal(num, floor)
 
 
 @dataclass
@@ -78,10 +121,76 @@ class AlignmentResult:
     identical regardless — collapse only affects the diagnostic counts, not
     the per-chapter download alternatives. See `_classify_main_chapters` for
     the collapse rules.
+
+    `consensus_set` is the set of chapter numbers that appear in ≥2 sources
+    after alignment. Used by ``group_chapters_for_download`` (download side)
+    and ``_classify_chapter_breakdown`` (display side) to identify source-only
+    fragment-shaped decimals (.1/.2/.3/.4) for duplicate detection — see the
+    Rule 2 refinement and the duplicate-detection-plan in
+    ~/.claude/plans/ultrathink-mangafire-and-some-flickering-sparkle.md.
+    Empty when only one source contributed (no peer signal); the consumers
+    fall through to current single-source heuristics in that case.
+
+    `consensus_max` is the highest chapter number in `consensus_set`, or
+    None when consensus is empty. Used to distinguish "source-only latest"
+    (legitimate fresh chapters above the peer-confirmed range) from
+    "source-only orphan" (suspicious mid-range chapters peers don't have).
     """
     chapter_map: List[ChapterMapEntry]
     merge_diagnostics: Dict[str, Dict] = field(default_factory=dict)
     collapse_splits_applied: bool = True
+    consensus_set: Set[float] = field(default_factory=set)
+    consensus_max: Optional[float] = None
+
+
+@dataclass
+class ChapterBreakdown:
+    """Per-source classification of a chapter list using cross-source consensus
+    as ground truth. Computed by ``_classify_chapter_breakdown``; surfaced in
+    ``merge_diagnostics[site]['breakdown']`` regardless of collapse state.
+
+    Buckets are MUTUALLY EXCLUSIVE — every chapter falls into exactly one.
+    Sum of all fields == count of chapters in this source's get_chapters
+    output (including unparseable). The UI renders these as separate sub-
+    labels alongside the main count so users can see where the "X main" /
+    "Y entries" gap comes from.
+
+    Bucket semantics:
+      consensus_main           — integer ≥ 1, present in ≥2 sources (counted toward "main")
+      source_only_latest       — integer ≥ 1, > consensus_max, source-only (legit fresh chapter, counted toward "main")
+      consensus_side_stories   — fractional > 0, in consensus (peer-confirmed X.5-style side story)
+      safe_decimals            — fractional > 0, source-only, value ≥ .5 (kept as side story; cannot confidently call duplicate)
+      prologue_count           — chapter num ≤ 0 (chapter 0, negatives — kept but not in main count)
+      source_only_orphans      — integer ≥ 1, ≤ consensus_max, NOT in consensus (suspicious re-release; kept but flagged)
+      fragments_dropped        — fractional > 0, value ∈ {.1,.2,.3,.4}, NOT in consensus (Rule 2 refinement target: dropped when collapse ON)
+      unparseable_passthrough  — _extract_chapter_num returned None (oneshots, omakes by name only)
+
+    Why this dataclass exists alongside _classify_main_chapters:
+    `_classify_main_chapters` returns a single ``effective_chapters`` count
+    for the back-compat headline; ``ChapterBreakdown`` exposes the components
+    so the UI can render "266 main · 16 side stories · 1 prologue · 22
+    fragments dropped" instead of a single number. The two functions share
+    the same predicates (``_is_source_only_fragment`` etc.) so the displayed
+    breakdown is always consistent with what ``group_chapters_for_download``
+    will actually emit when the user turns collapse on.
+
+    Cross-file: SearchChapterMap.jsx reads ``breakdown`` from merge_diagnostics
+    and renders the bucketed line. aio_search_cli.py serializes the dataclass
+    via dataclasses.asdict() into the winner_chapter_map JSON.
+    """
+    # MAIN — counted toward the "X main" headline
+    consensus_main: int = 0
+    source_only_latest: int = 0
+    # EXTRAS — kept as content, shown in a separate UI sub-label
+    consensus_side_stories: int = 0
+    safe_decimals: int = 0
+    prologue_count: int = 0
+    # SUSPICIOUS — kept but flagged
+    source_only_orphans: int = 0
+    # DROPPED when collapse ON — flagged in UI as "N fragments dropped"
+    fragments_dropped: int = 0
+    # PASSTHROUGH — non-numeric labels (oneshots, omakes by name only)
+    unparseable_passthrough: int = 0
 
 
 def _is_sequential_split_decimals(decimals_rel: List[float]) -> bool:
@@ -111,7 +220,12 @@ def _is_sequential_split_decimals(decimals_rel: List[float]) -> bool:
     return sorted_decimals == expected
 
 
-def _classify_main_chapters(numbers, *, collapse_splits: bool = True) -> Tuple[int, int]:
+def _classify_main_chapters(
+    numbers,
+    *,
+    collapse_splits: bool = True,
+    consensus_set: Optional[Set[float]] = None,
+) -> Tuple[int, int]:
     """Compute (unique_main_chapters, effective_chapters) for a chapter-number set.
 
     `unique_main_chapters` is the count of unique floor() values across the
@@ -120,7 +234,7 @@ def _classify_main_chapters(numbers, *, collapse_splits: bool = True) -> Tuple[i
     entry or split across N decimals. The UI surfaces this as "X main".
 
     `effective_chapters` is what the UI shows as the headline count, and
-    depends on `collapse_splits`:
+    depends on `collapse_splits` AND ``consensus_set``:
 
       - ``collapse_splits=True`` (default): split-only clusters X.1 / X.2 /
         ... / X.k where the decimals form a sequential .1/.2/.3 pattern
@@ -147,7 +261,15 @@ def _classify_main_chapters(numbers, *, collapse_splits: bool = True) -> Tuple[i
         1.5 is a real distinct chapter, not a side story or split. Collapse
         would falsely merge those.
 
-    Examples (collapse_splits=True):
+      - ``consensus_set`` (NEW 2026-05-27, cross-source duplicate detection):
+        when provided AND collapse is on, refines Rule 2 / 3b / 6 by dropping
+        fragment-shaped decimals (.1/.2/.3/.4) that no peer source confirms.
+        Mirrors the actual drops in ``group_chapters_for_download`` so the
+        displayed count matches the downloaded count. When ``consensus_set``
+        is None or empty (single-source run / direct URL), the function
+        falls through to in-source heuristics — same numbers as today.
+
+    Examples (collapse_splits=True, consensus_set=None):
       {1, 2, 3}                 → (3, 3)   — all integers, no decimals
       {1.1, 1.2, 1.3, 1.4}      → (1, 1)   — split-cluster, no integer parent
       {4, 4.5}                  → (1, 2)   — main + side story (Rule 2)
@@ -155,6 +277,10 @@ def _classify_main_chapters(numbers, *, collapse_splits: bool = True) -> Tuple[i
       {1.1, 1.2, 2, 3}          → (3, 3)   — 1.x splits collapse, then 2 + 3
       {8, 8.1, 8.2, 8.3}        → (1, 1)   — sequential splits collapse
       {8, 8.1, 8.5}             → (1, 2)   — scattered: integer + highest .5
+
+    Examples (collapse_splits=True, consensus_set={52}):
+      {52, 52.1}                → (1, 1)   — Rule 2 refined: 52.1 is source-only fragment
+      {52, 52.5}                → (1, 2)   — Rule 2 unchanged: .5 not fragment-shaped
 
     Examples (collapse_splits=False):
       Each example above yields (unique_main, len(numbers)) instead.
@@ -178,19 +304,105 @@ def _classify_main_chapters(numbers, *, collapse_splits: bool = True) -> Tuple[i
     effective = 0
     for floor, group in by_floor.items():
         integer_present = any(n == floor for n in group)
-        decimals_rel = [n - floor for n in group if n != floor]
+        decimal_values = sorted(n for n in group if n != floor)
+        decimals_rel = [n - floor for n in decimal_values]
         if integer_present:
             effective += 1  # the integer
-            if len(decimals_rel) == 1:
-                effective += 1  # Rule 2: true side story
-            elif len(decimals_rel) >= 2 and not _is_sequential_split_decimals(decimals_rel):
-                # Rule 3 scattered: highest decimal is a canonical side story.
-                # Sequential splits (Rule 3 sequential) contribute nothing.
-                effective += 1
+            if len(decimal_values) == 1:
+                # Rule 2 refined: drop fragment-shaped source-only decimal
+                # (the .1 in {52, 52.1} when peers don't have 52.1). The
+                # check matches group_chapters_for_download's Rule 2 branch.
+                if not _is_source_only_fragment(
+                    decimal_values[0], floor, consensus_set,
+                ):
+                    effective += 1  # Rule 2 kept: true side story
+            elif len(decimal_values) >= 2 and not _is_sequential_split_decimals(decimals_rel):
+                # Rule 3b scattered: highest decimal is a canonical side
+                # story IF not a source-only fragment. Mirrors the Rule 3b
+                # refinement in group_chapters_for_download.
+                highest = decimal_values[-1]
+                if not _is_source_only_fragment(highest, floor, consensus_set):
+                    effective += 1
+            # else: Rule 3a sequential splits — decimals contribute nothing.
         else:
-            # Rule 4/5/6: no integer; the cluster collapses to one chapter.
-            effective += 1
+            # Rule 4/5/6: no integer.
+            if len(decimal_values) == 1:
+                # Rule 4: singleton partial — always kept (the only entry).
+                effective += 1
+            elif _is_sequential_split_decimals(decimals_rel):
+                # Rule 5: sequential split-cluster collapses to one chapter.
+                effective += 1
+            else:
+                # Rule 6 refined: highest decimal kept UNLESS it's a source-
+                # only fragment AND the integer parent is in consensus
+                # (peer says floor is the canonical chapter). Mirrors the
+                # Rule 6 refinement in group_chapters_for_download.
+                highest = decimal_values[-1]
+                parent_in_consensus = float(floor) in (consensus_set or set())
+                if not (
+                    parent_in_consensus
+                    and _is_source_only_fragment(highest, floor, consensus_set)
+                ):
+                    effective += 1
     return unique_main, effective
+
+
+def _classify_chapter_breakdown(
+    chapters: List[Dict],
+    consensus_set: Optional[Set[float]],
+    consensus_max: Optional[float],
+) -> ChapterBreakdown:
+    """Route each chapter dict into exactly one ChapterBreakdown bucket.
+
+    Mirrors the predicates in ``group_chapters_for_download`` (same
+    fragment-shape and consensus checks) so the displayed bucket counts
+    always match what the download path actually emits when collapse is on.
+
+    When ``consensus_set`` is empty / None (single-source run or no peer
+    overlap), there's no signal: integers go to ``consensus_main`` (we
+    can't downgrade them), decimals ≥ .5 go to ``safe_decimals``, fragment-
+    shaped decimals also go to ``safe_decimals`` (not ``fragments_dropped``)
+    because the download path won't drop them either without peer signal.
+
+    Note: this operates on the post-handler-dedup chapter dicts (one entry
+    per chapter number). align_chapter_lists deduplicates per source before
+    calling this, so we don't see the same number twice from one source.
+    """
+    bd = ChapterBreakdown()
+    has_consensus = bool(consensus_set)
+    for ch in chapters:
+        num = _extract_chapter_num(ch.get("chap"))
+        if num is None:
+            bd.unparseable_passthrough += 1
+            continue
+        if num <= 0:
+            bd.prologue_count += 1
+            continue
+        floor = int(num)
+        is_integer = (num == floor)
+        if is_integer:
+            if has_consensus and num in consensus_set:
+                bd.consensus_main += 1
+            elif has_consensus and consensus_max is not None and num > consensus_max:
+                bd.source_only_latest += 1
+            elif has_consensus:
+                # Peer signal exists but this integer is mid-range and source-only.
+                bd.source_only_orphans += 1
+            else:
+                # No peer signal — treat as main (can't downgrade without data).
+                bd.consensus_main += 1
+        else:
+            # Fractional > 0
+            if has_consensus and num in consensus_set:
+                bd.consensus_side_stories += 1
+            elif _is_source_only_fragment(num, floor, consensus_set):
+                # Fragment-shaped (.1-.4), source-only, peer signal exists →
+                # would be dropped by the download path when collapse ON.
+                bd.fragments_dropped += 1
+            else:
+                # Either no peer signal, or decimal ≥ .5 — kept as safe extra.
+                bd.safe_decimals += 1
+    return bd
 
 
 def _extract_chapter_num(label) -> Optional[float]:
@@ -283,6 +495,8 @@ def align_chapter_lists(
             chapter_map=[],
             merge_diagnostics={},
             collapse_splits_applied=collapse_splits,
+            consensus_set=set(),
+            consensus_max=None,
         )
 
     # Pick anchor by largest chapter set, breaking ties by orchestrator order
@@ -302,17 +516,29 @@ def align_chapter_lists(
     ]
     sources_with_chapters = reordered
     anchor_site, anchor_chapters = sources_with_chapters[0]
+
+    # Build per-source {chapter_num → chapter_dict} maps in a single upfront
+    # pass. Per-site dedup (keep first occurrence) matches the original loop
+    # behavior — multiple chapter entries with the same number on the same
+    # site (e.g. different scanlator versions on MangaDex) collapse to the
+    # first. Doing this upfront lets us compute consensus_set AFTER the
+    # cross-source merge but BEFORE writing diagnostics, so each source's
+    # breakdown is graded against the full peer set.
+    per_source_nums: Dict[str, Dict[float, Dict]] = {}
+    for site_name, chapters in sources_with_chapters:
+        source_nums: Dict[float, Dict] = {}
+        for ch in (chapters or []):
+            num = _extract_chapter_num(ch.get("chap"))
+            if num is None:
+                continue
+            if num in source_nums:
+                continue
+            source_nums[num] = ch
+        per_source_nums[site_name] = source_nums
+
+    # Seed anchor_index from the anchor's per-source map.
     anchor_index: Dict[float, ChapterMapEntry] = {}
-    for ch in anchor_chapters or []:
-        num = _extract_chapter_num(ch.get("chap"))
-        if num is None:
-            continue
-        if num in anchor_index:
-            # Multiple chapter entries with the same number on the same site
-            # (rare but happens — different scanlator versions of the same
-            # chapter on MangaDex). Keep the first; subsequent ones are
-            # ignored at the merger level. Per-site dedup happened upstream.
-            continue
+    for num, ch in per_source_nums[anchor_site].items():
         label = str(ch.get("chap") or "").strip() or f"{num:g}"
         anchor_index[num] = ChapterMapEntry(
             chapter_num=num,
@@ -320,83 +546,50 @@ def align_chapter_lists(
             sources=[(anchor_site, ch)],
         )
 
-    # Phase 2/3 diagnostic enrichment: compute (unique_main_chapters,
-    # effective_chapters) for the anchor as well so the UI can render its
-    # "X main / Y entries" badge consistently across all rows. The anchor's
-    # chapter-number set is anchor_index.keys() — by construction every
-    # number is unique because anchor_index dedupes by chapter number.
-    anchor_unique_main, anchor_effective = _classify_main_chapters(
-        list(anchor_index.keys()), collapse_splits=collapse_splits
-    )
-    diagnostics: Dict[str, Dict] = {
+    # Track per-source overlap / compatibility / skipped_reason now;
+    # _classify_main_chapters + breakdown computation is deferred until
+    # AFTER consensus is known so the diagnostic counts incorporate it.
+    per_source_meta: Dict[str, Dict] = {
         anchor_site: {
-            "role": "anchor",
-            "total_chapters": len(anchor_index),
-            "unique_main_chapters": anchor_unique_main,
-            "effective_chapters": anchor_effective,
-            "matched_with_anchor": len(anchor_index),
+            "overlap": len(anchor_index),
             "compatibility": 1.0,
+            "role": "anchor",
+            "skipped_reason": None,
         }
     }
 
-    # Process remaining sources.
-    for site_name, chapters in sources_with_chapters[1:]:
-        if not chapters:
-            diagnostics[site_name] = {
-                "role": "alternative",
-                "total_chapters": 0,
-                "unique_main_chapters": 0,
-                "effective_chapters": 0,
-                "matched_with_anchor": 0,
+    # Process remaining sources: compute overlap, merge into anchor_index.
+    for site_name, _chapters in sources_with_chapters[1:]:
+        source_nums = per_source_nums[site_name]
+        if not source_nums:
+            per_source_meta[site_name] = {
+                "overlap": 0,
                 "compatibility": 0.0,
+                "role": "alternative",
                 "skipped_reason": "empty chapter list",
             }
             continue
 
-        # Index this source's chapters by extracted number.
-        source_nums: Dict[float, Dict] = {}
-        for ch in chapters:
-            num = _extract_chapter_num(ch.get("chap"))
-            if num is None:
-                continue
-            if num in source_nums:
-                continue  # keep first occurrence
-            source_nums[num] = ch
-
-        # How many of this source's chapters have a number that exists in the
-        # anchor? Determines whether the source's numbering system is
-        # compatible enough for a full merge.
-        if source_nums:
-            overlap = len([n for n in source_nums if n in anchor_index])
-            compatibility = overlap / len(source_nums)
-        else:
-            overlap = 0
-            compatibility = 0.0
-
-        # Phase 2/3 enrichment — see anchor block above for rationale.
-        unique_main, effective = _classify_main_chapters(
-            list(source_nums.keys()), collapse_splits=collapse_splits
-        )
-        diagnostics[site_name] = {
+        overlap = len([n for n in source_nums if n in anchor_index])
+        compatibility = overlap / len(source_nums)
+        merge_orphans = compatibility >= compatibility_threshold
+        per_source_meta[site_name] = {
+            "overlap": overlap,
+            "compatibility": compatibility,
             "role": "alternative",
-            "total_chapters": len(source_nums),
-            "unique_main_chapters": unique_main,
-            "effective_chapters": effective,
-            "matched_with_anchor": overlap,
-            "compatibility": round(compatibility, 3),
+            "skipped_reason": (
+                None if merge_orphans else (
+                    f"compatibility {compatibility:.0%} below "
+                    f"{compatibility_threshold:.0%} threshold; only "
+                    "overlapping chapters merged"
+                )
+            ),
         }
 
-        # Always merge the overlapping chapters — they're definitionally a
-        # safe match per number. Non-overlapping chapters from this source are
-        # added as orphan entries ONLY if compatibility is high enough,
-        # signaling the source is using the same numbering scheme.
-        merge_orphans = compatibility >= compatibility_threshold
-        if not merge_orphans:
-            diagnostics[site_name]["skipped_reason"] = (
-                f"compatibility {compatibility:.0%} below {compatibility_threshold:.0%} "
-                "threshold; only overlapping chapters merged"
-            )
-
+        # Always merge overlapping chapters — definitionally a safe match
+        # per number. Non-overlapping chapters are added as orphan entries
+        # ONLY if compatibility is above threshold, signaling the source
+        # uses the same numbering scheme.
         for num, ch in source_nums.items():
             if num in anchor_index:
                 anchor_index[num].sources.append((site_name, ch))
@@ -407,6 +600,49 @@ def align_chapter_lists(
                     chapter_label=label,
                     sources=[(site_name, ch)],
                 )
+
+    # Compute cross-source consensus from the fully-populated anchor_index.
+    # A chapter number is "in consensus" iff ≥2 sources contributed it.
+    # Used by _classify_main_chapters / _classify_chapter_breakdown (display
+    # side) AND group_chapters_for_download (download side) to identify
+    # source-only fragment-shaped decimals for duplicate detection. See
+    # plan: ~/.claude/plans/ultrathink-mangafire-and-some-flickering-sparkle.md.
+    source_counts: Dict[float, int] = {}
+    for entry in anchor_index.values():
+        source_counts[entry.chapter_num] = len(entry.sources)
+    consensus_set: Set[float] = {n for n, c in source_counts.items() if c >= 2}
+    consensus_max: Optional[float] = max(consensus_set) if consensus_set else None
+
+    # Now compute per-source diagnostics with consensus in hand. The
+    # _classify_main_chapters call mirrors the consensus-refined drops in
+    # group_chapters_for_download, so the displayed "X main / Y entries"
+    # always matches what the download path emits when collapse is on.
+    diagnostics: Dict[str, Dict] = {}
+    for site_name, meta in per_source_meta.items():
+        source_nums = per_source_nums[site_name]
+        unique_main, effective = _classify_main_chapters(
+            list(source_nums.keys()),
+            collapse_splits=collapse_splits,
+            consensus_set=consensus_set,
+        )
+        breakdown = _classify_chapter_breakdown(
+            list(source_nums.values()),
+            consensus_set=consensus_set,
+            consensus_max=consensus_max,
+        )
+        diag: Dict = {
+            "role": meta["role"],
+            "total_chapters": len(source_nums),
+            "unique_main_chapters": unique_main,
+            "effective_chapters": effective,
+            "matched_with_anchor": meta["overlap"],
+            "compatibility": round(meta["compatibility"], 3),
+            "breakdown": asdict(breakdown),
+            "consensus_threshold_sources": 2,
+        }
+        if meta["skipped_reason"]:
+            diag["skipped_reason"] = meta["skipped_reason"]
+        diagnostics[site_name] = diag
 
     # Within each chapter row, prefer official-tagged sources. Stable sort
     # preserves the orchestrator's quality ranking for ties (both within
@@ -430,6 +666,8 @@ def align_chapter_lists(
         chapter_map=chapter_map,
         merge_diagnostics=diagnostics,
         collapse_splits_applied=collapse_splits,
+        consensus_set=consensus_set,
+        consensus_max=consensus_max,
     )
 
 
@@ -466,6 +704,7 @@ def group_chapters_for_download(
     chapters: List[Dict],
     *,
     collapse_splits: bool = True,
+    consensus_set: Optional[Set[float]] = None,
 ) -> List[ChapterGroup]:
     """Apply the cluster rule (snappy-forging-waffle.md item 8) to produce
     download-ready groups.
@@ -480,6 +719,13 @@ def group_chapters_for_download(
               → 2 groups: ChapterGroup(label="X", parts=[X])
                           ChapterGroup(label="X.k", parts=[X.k])
                 (true partial preserved)
+                Refinement (consensus_set): if k ∈ {.1,.2,.3,.4} AND X.k is
+                NOT in consensus_set AND consensus_set is non-empty, drop
+                X.k as a source-only fragment. Catches the user's
+                Shangri-La Frontier case where mangafire emits {52, 52.1}
+                but peers only have {52} — the .1 is an upload fragment,
+                not a real "Chapter 52.5: Side Story"-style sub-chapter.
+                See ~/.claude/plans/ultrathink-mangafire-and-some-flickering-sparkle.md.
         Rule 3. Integer X + ≥2 decimals — sub-classified:
               3a (sequential .1/.2/.3...): e.g. {1, 1.1, 1.2, 1.3}
                 → 1 group: ChapterGroup(label="X", parts=[X])
@@ -490,6 +736,11 @@ def group_chapters_for_download(
                   (the highest decimal is a canonical sub-chapter like
                   MangaFire's "X.5: Side Story"; intermediate .1/.2/etc. are
                   partial-upload fragments and dropped)
+                  Refinement (consensus_set): if the kept "highest" is
+                  itself a source-only fragment-shape (.1/.2/.3/.4), drop
+                  it too — peer evidence says it's noise. In practice
+                  this is rare since "scattered" means there ARE
+                  intermediate decimals, so the highest is usually .5+.
         Rule 4. No integer X, 1 decimal X.k
               → 1 group: ChapterGroup(label="X.k", parts=[X.k])
         Rule 5. No integer X, decimals form .1, .2, .3, ... starting at .1
@@ -502,6 +753,14 @@ def group_chapters_for_download(
                 Label uses the actual decimal value rather than the integer
                 floor so the on-disk tdir doesn't collide with a real
                 Chapter X from another source on resume.)
+                Refinement (consensus_set): if highest is source-only
+                fragment-shape AND the integer floor IS in consensus
+                (peer source has the canonical chapter X), drop the
+                whole cluster — it's fragment noise relative to the
+                peer-confirmed integer. If floor is NOT in consensus,
+                keep current behavior — we have no peer signal that
+                floor is the canonical chapter, so the cluster might be
+                its own legitimate sub-chapter.
 
     Why "highest decimal" in Rules 3b and 6:
         MangaFire (and similar aggregators) sometimes emit a chapter as
@@ -515,6 +774,8 @@ def group_chapters_for_download(
 
     When `collapse_splits=False`, returns one group per chapter with its
     original label preserved (passthrough — no merging, no dropping).
+    The ``consensus_set`` argument is also ignored in this mode — no
+    drops happen regardless.
 
     Unparseable chapters (label has no numeric token) are emitted unchanged
     at the end of the list as singleton groups — they can't be bucketed but
@@ -523,7 +784,12 @@ def group_chapters_for_download(
     Cross-file: caller is aio-dl.py's chapter download loop. For groups
     where `len(parts) > 1` (rule 5 only), the caller synthesizes a combined
     chapter dict by concatenating `get_chapter_images(part)` across parts
-    and uses `group.label` for the output filename.
+    and uses `group.label` for the output filename. ``consensus_set`` is
+    plumbed in from align_chapter_lists via the multi-source-prefetched
+    payload (aio_search_cli.py builds it; aio-dl.py reads it on the way
+    into this function). When peer data is unavailable (direct URL mode,
+    single-source run), ``consensus_set=None`` falls through to the
+    original in-source-only heuristics — no regressions.
     """
     if not chapters:
         return []
@@ -570,31 +836,52 @@ def group_chapters_for_download(
                         label=str(floor), parts=[integer_ch],
                     ))
                 else:
-                    # Rule 3b: scattered — keep integer X AND the highest
-                    # decimal (canonical sub-chapter). Highest is the
-                    # last after ascending sort.
+                    # Rule 3b refined: keep integer X always; keep highest
+                    # decimal UNLESS it's itself a source-only fragment-
+                    # shape (.1-.4). The intermediate decimals are always
+                    # dropped (existing behavior). When consensus_set is
+                    # None, _is_source_only_fragment returns False so the
+                    # behavior matches the original "always keep highest".
                     groups.append(ChapterGroup(
                         label=str(floor), parts=[integer_ch],
                     ))
                     highest_num, highest_ch = decimal_entries[-1]
-                    groups.append(ChapterGroup(
-                        label=_format_chapter_label(highest_num),
-                        parts=[highest_ch],
-                    ))
+                    if not _is_source_only_fragment(
+                        highest_num, floor, consensus_set,
+                    ):
+                        groups.append(ChapterGroup(
+                            label=_format_chapter_label(highest_num),
+                            parts=[highest_ch],
+                        ))
+                    # else: highest is a source-only fragment — dropped.
             elif len(decimal_entries) == 1:
-                # Rule 2: emit both X and the partial.
+                # Rule 2 refined: emit X always; emit the decimal UNLESS
+                # it's a source-only fragment-shape (.1-.4). This is the
+                # critical fix for mangafire's {52, 52.1} / {75, 75.1}
+                # etc. on Shangri-La Frontier where peers only have
+                # {52}, {75} (no peer .1). When consensus_set is None or
+                # empty, _is_source_only_fragment returns False so behavior
+                # matches the original "always emit both". Single .5+
+                # decimals are NEVER dropped here — they're overwhelmingly
+                # real "X.5: Side Story"-style canonical sub-chapters,
+                # so we treat them conservatively as content.
                 groups.append(ChapterGroup(label=str(floor), parts=[integer_ch]))
                 num, ch = decimal_entries[0]
-                groups.append(ChapterGroup(
-                    label=_format_chapter_label(num), parts=[ch],
-                ))
+                if not _is_source_only_fragment(num, floor, consensus_set):
+                    groups.append(ChapterGroup(
+                        label=_format_chapter_label(num), parts=[ch],
+                    ))
+                # else: lone source-only fragment — dropped.
             else:
                 # Rule 1: just X.
                 groups.append(ChapterGroup(label=str(floor), parts=[integer_ch]))
         else:
             # No integer X.
             if len(decimal_entries) == 1:
-                # Rule 4: singleton partial.
+                # Rule 4: singleton partial. Always kept — the only entry
+                # at this floor, dropping it would lose content with no
+                # signal that it's a duplicate. Left untouched by the
+                # consensus refinement.
                 num, ch = decimal_entries[0]
                 groups.append(ChapterGroup(
                     label=_format_chapter_label(num), parts=[ch],
@@ -611,21 +898,37 @@ def group_chapters_for_download(
                         parts=[e[1] for e in decimal_entries],
                     ))
                 else:
-                    # Rule 6: scattered decimals. Keep the HIGHEST (the
-                    # canonical "X.5"-style sub-chapter); drop the rest
-                    # as duplicate partial uploads. Label uses the actual
-                    # decimal value rather than the integer floor so the
-                    # on-disk tdir doesn't collide with a real Chapter X
-                    # from another source on resume — with label="X",
-                    # `main_tmp_dir/ch_X` would match both the rule-6
-                    # group and a real X from a separate source on
-                    # subsequent runs, falsely treating one as the resume
-                    # target for the other.
+                    # Rule 6 refined: keep the HIGHEST decimal UNLESS it's
+                    # a source-only fragment-shape AND the implied integer
+                    # parent (floor) is in consensus. The parent-in-
+                    # consensus guard distinguishes "fragment noise around
+                    # a peer-confirmed canonical chapter" (drop) from
+                    # "scattered decimals at a floor no peer has either"
+                    # (keep — it might be its own legitimate sub-chapter
+                    # with no integer counterpart).
+                    #
+                    # The on-disk-tdir-collision rationale for using the
+                    # decimal as the label (not the floor) still applies:
+                    # main_tmp_dir/ch_<floor> would match both this rule-6
+                    # group and a real X from a separate source on resume.
                     highest_num, highest_ch = decimal_entries[-1]  # ascending sort
-                    groups.append(ChapterGroup(
-                        label=_format_chapter_label(highest_num),
-                        parts=[highest_ch],
-                    ))
+                    parent_in_consensus = (
+                        consensus_set is not None
+                        and float(floor) in consensus_set
+                    )
+                    drop_as_fragment_noise = (
+                        parent_in_consensus
+                        and _is_source_only_fragment(
+                            highest_num, floor, consensus_set,
+                        )
+                    )
+                    if not drop_as_fragment_noise:
+                        groups.append(ChapterGroup(
+                            label=_format_chapter_label(highest_num),
+                            parts=[highest_ch],
+                        ))
+                    # else: peer-confirmed parent exists; this scattered
+                    # cluster of source-only fragments is noise — dropped.
 
     # Pass unparseable chapters through as singletons rather than dropping
     # them — these are typically "Oneshot" / "Omake" / non-numeric labels
@@ -642,6 +945,7 @@ def group_chapters_for_download(
 __all__ = [
     "ChapterMapEntry",
     "AlignmentResult",
+    "ChapterBreakdown",
     "align_chapter_lists",
     "DEFAULT_COMPATIBILITY_THRESHOLD",
     "ChapterGroup",

--- a/sites/comix.py
+++ b/sites/comix.py
@@ -54,6 +54,32 @@ class ComixSiteHandler(BaseSiteHandler):
     name = "comix"
     domains = ("comix.to", "www.comix.to")
 
+    # Opt out of the orchestrator's image-quality probe entirely. Two
+    # facts make probing comix uneconomic at search time:
+    #   1. comix's chapter list AND every chapter page require the
+    #      single-threaded Patchright bridge (encrypted /chapters API +
+    #      JS-decrypted canvas-rendered pages). The probe phase runs
+    #      up to 6 sources in parallel — they all serialize on the
+    #      bridge worker thread, so adding comix to the probe set
+    #      uniformly trips the orchestrator's 240 s probe-phase
+    #      deadline before any comix candidate completes.
+    #   2. Canvas-captured pages come back as synthetic `comix-page://`
+    #      URLs. sites/base.py:_fetch_probe_item_bytes uses
+    #      scraper.get(url) which doesn't know that scheme, so even
+    #      when the probe DOES finish it scores 0.0 on every chapter.
+    # Resolution: the comix seed in sites/quality_seed.json is
+    # calibrated offline (run comix_seed_calibration.py — drives the
+    # full T1+T2 ML pipeline against one good + one bad title; the
+    # current 0.74 is the median across both). The comparator
+    # `_quality_for` (sites/search_orchestrator.py:~5329) falls back
+    # to seed_quality when img_quality_score is None, so leaving the
+    # score un-set IS the mechanism by which the calibrated seed
+    # becomes the effective ranking signal.
+    # Cross-file: sites/search_orchestrator.py:~5425 honors this attr
+    # in the per-source probe loop (skips both the persistent-cache
+    # lookup and the worker enqueue).
+    SKIP_QUALITY_PROBE = True
+
     # comix.to API endpoints are token-gated with per-URL HMAC signatures
     # (`_=<sig>` param) we can't reproduce in Python. The only tractable
     # path is letting Patchright navigate the page and either capturing the

--- a/sites/comix.py
+++ b/sites/comix.py
@@ -80,6 +80,24 @@ class ComixSiteHandler(BaseSiteHandler):
     # lookup and the worker enqueue).
     SKIP_QUALITY_PROBE = True
 
+    # Opt out of --multi-source merging too. Even with the probe phase
+    # already skipped (above), comix's calibrated seed (0.74 — see
+    # quality_seed.json) clears the default --multi-source-quality-min
+    # of 0.65, so without this flag comix candidates survive
+    # _filter_and_rank_alt_sources and reach _fetch_chapters_for_winner,
+    # where each one pays a ~25 s bridge-DOM-scrape just to enumerate
+    # chapters. Those scrapes serialize through the single-threaded
+    # Patchright bridge with no concurrency benefit — they pile up
+    # while the user's primary download is waiting for multi-source
+    # alignment to finish. And the merged result almost never actually
+    # uses comix as a fallback: the primary site (mangafire / mangadex
+    # / etc.) has the same chapters, so the alt is dead weight.
+    # Cross-file: aio_search_cli.py:_filter_and_rank_alt_sources honors
+    # this attribute alongside the existing primary_host filter so
+    # comix is dropped from the alts list before any chapter-list
+    # fetch is queued.
+    SKIP_MULTI_SOURCE = True
+
     # comix.to API endpoints are token-gated with per-URL HMAC signatures
     # (`_=<sig>` param) we can't reproduce in Python. The only tractable
     # path is letting Patchright navigate the page and either capturing the

--- a/sites/quality_seed.json
+++ b/sites/quality_seed.json
@@ -23,7 +23,7 @@
   "zeroscans": 0.80,
   "asmotoon": 0.80,
   "atsumaru": 0.80,
-  "comix": 0.80,
+  "comix": 0.74,
   "boratscans": 0.78,
   "weebcentral": 0.72,
   "mangapill": 0.70,

--- a/sites/search_orchestrator.py
+++ b/sites/search_orchestrator.py
@@ -5424,6 +5424,24 @@ def search_all(
         # every repeat search (cache hit path was returning score-only).
         cache_misses: List[SourceEntry] = []
         for src in sources_to_probe:
+            # SKIP_QUALITY_PROBE handlers (currently only comix — see
+            # sites/comix.py for the rationale) opt out of probing
+            # entirely: their per-source probe cost is dominated by a
+            # single-threaded browser bridge that would trip the 240 s
+            # probe-phase deadline before any candidate completed. The
+            # comparator `_quality_for` (~line 5329) falls back to
+            # seed_quality when img_quality_score is None, so leaving
+            # the score un-set IS how the calibrated seed becomes the
+            # effective ranking signal. We also skip the persistent-
+            # cache read so stale per-URL scores from earlier buggy
+            # probes (which scored 0.0 because synthetic
+            # `comix-page://` URLs aren't HTTP-fetchable) don't leak
+            # back into ranking.
+            handler = get_handler_by_name(src.site)
+            if handler is not None and getattr(
+                handler, "SKIP_QUALITY_PROBE", False,
+            ):
+                continue
             cached = img_cache.get_with_metadata(src.site, src.url)
             if cached is not None:
                 score, metadata = cached

--- a/sites/search_orchestrator.py
+++ b/sites/search_orchestrator.py
@@ -5060,8 +5060,18 @@ def search_all(
     for h in handlers:
         host = (h.domains[0] if getattr(h, "domains", None) else "") or ""
         if h.name in seeded_sites:
-            if on_status:
-                on_status(f"  skipping {h.name} (seeded from URL)")
+            # Skip silently — mangafire (or whichever site the URL maps to)
+            # is already represented by a seed_hit that goes into
+            # candidates. The seed_hit gets probed for image quality just
+            # like any other source (the probe loop keys on src.site, not
+            # on whether the source came from seed_hits vs. parallel
+            # search), so this 'continue' only skips the redundant
+            # typeahead re-query. Logging "skipping mangafire" used to
+            # appear here, but it was misleading: users read it as
+            # "mangafire is excluded from the run," when in fact mangafire
+            # IS in the candidate list, IS probed, IS ranked, and IS the
+            # primary download target. Removed 2026-05-27 in the cleanup
+            # round after reverting the search-mode probe-skip experiment.
             continue
         if cache and host and cache.is_blocked(host):
             if on_status:

--- a/sites/search_orchestrator.py
+++ b/sites/search_orchestrator.py
@@ -33,7 +33,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from functools import cmp_to_key
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from .base import BaseSiteHandler, SearchHit
@@ -4959,6 +4959,7 @@ def search_all(
     probe_failure_cache: Optional[ProbeFailureCache] = None,
     img_quality_cache: Optional[ImageQualityCache] = None,
     seed_hits: Optional[List[SearchHit]] = None,
+    skip_probe_sites: Optional[Set[str]] = None,
     on_status: Optional[Callable[[str], None]] = None,
     seeded_only: bool = False,
 ) -> List[SeriesCandidate]:
@@ -4981,6 +4982,18 @@ def search_all(
         MangaFire's flaky typeahead). Seeded hits go through the same
         rapidfuzz scoring + union-find merge as parallel-search results, so
         they end up in the right candidate cluster.
+      skip_probe_sites: optional set of site names whose candidates should
+        be excluded from the image-quality probe loop. Used when the caller
+        already knows it's going to download from this site regardless of
+        what the probe says — direct-URL mode (aio-dl.py URL) treats the
+        URL's host as the committed primary, and the --search URL mode
+        treats every seed_hits[i].site the same way. Skipped sources read
+        the persistent cache (free) but never get enqueued for a fresh
+        probe; their img_quality_score stays None and the comparator falls
+        back to seed_quality. Skipping is per-site (not per-URL) because
+        once the user has committed to a host we don't care about scoring
+        any OTHER candidates from that host either — they wouldn't be
+        used for the download.
       on_status: optional progress callback for human output (e.g., the
         "[*] Probing image quality across N sources..." line in Phase 2).
 
@@ -5441,6 +5454,26 @@ def search_all(
             if handler is not None and getattr(
                 handler, "SKIP_QUALITY_PROBE", False,
             ):
+                continue
+            if skip_probe_sites and src.site in skip_probe_sites:
+                # Caller marked this site as already-committed: we're
+                # going to download from this URL regardless of any
+                # quality score, so the score has no operational effect
+                # on the download decision. Skip both the persistent-
+                # cache read AND a fresh probe — feeding a cached score
+                # in here would push the seed source through the same
+                # sort as alternatives (e.g. a different site that
+                # happens to have a higher cached score outranks the
+                # seed and steals the primary slot in the candidate's
+                # sources list, contradicting "this is the URL the
+                # user picked"). Leave img_quality_score=None so the
+                # comparator's `_quality_for` (~line 5329) falls back
+                # to seed_quality — that's the per-site prior the user
+                # implicitly trusts when they hand us a URL from that
+                # site. Cross-file: callers populate this set from
+                # aio_search_cli.run_search_mode (seed_hits[*].site)
+                # and aio_search_cli.find_alternatives_for_direct_url
+                # (primary_handler.name).
                 continue
             cached = img_cache.get_with_metadata(src.site, src.url)
             if cached is not None:

--- a/sites/search_orchestrator.py
+++ b/sites/search_orchestrator.py
@@ -4983,17 +4983,21 @@ def search_all(
         rapidfuzz scoring + union-find merge as parallel-search results, so
         they end up in the right candidate cluster.
       skip_probe_sites: optional set of site names whose candidates should
-        be excluded from the image-quality probe loop. Used when the caller
-        already knows it's going to download from this site regardless of
-        what the probe says — direct-URL mode (aio-dl.py URL) treats the
-        URL's host as the committed primary, and the --search URL mode
-        treats every seed_hits[i].site the same way. Skipped sources read
-        the persistent cache (free) but never get enqueued for a fresh
-        probe; their img_quality_score stays None and the comparator falls
+        be excluded from the image-quality probe loop. Reserved for the
+        direct-URL --multi-source path (aio_search_cli.find_alternatives_
+        for_direct_url, called from aio-dl.py main() at the multi-source
+        alternatives-lookup site) where we're going to download from the
+        URL's primary host regardless of what the probe says, so scoring
+        it is pure waste. Search mode (--search) intentionally passes
+        None here so the seed source IS probed — the JSON output is
+        informational and the user expects a comparable score for every
+        candidate including any URL they handed in. Skipped sources stay
+        out of both the persistent-cache read and the probe-worker
+        enqueue: img_quality_score stays None and the comparator falls
         back to seed_quality. Skipping is per-site (not per-URL) because
-        once the user has committed to a host we don't care about scoring
-        any OTHER candidates from that host either — they wouldn't be
-        used for the download.
+        once we've committed to a host we don't care about scoring any
+        OTHER candidates from that host either — they wouldn't be used
+        for the download.
       on_status: optional progress callback for human output (e.g., the
         "[*] Probing image quality across N sources..." line in Phase 2).
 

--- a/tests/test_chapter_merger.py
+++ b/tests/test_chapter_merger.py
@@ -10,10 +10,16 @@ into _process_chapter_impl's part-by-part fetch path.
 from __future__ import annotations
 
 from sites.chapter_merger import (
+    AlignmentResult,
+    ChapterBreakdown,
     ChapterGroup,
+    _classify_chapter_breakdown,
     _classify_main_chapters,
     _format_chapter_label,
     _extract_chapter_num,
+    _is_fragment_shaped_decimal,
+    _is_source_only_fragment,
+    align_chapter_lists,
     group_chapters_for_download,
 )
 
@@ -307,3 +313,431 @@ def test_rule_5_synthesized_merged_dict_carries_metadata():
     assert len(groups) == 1
     assert groups[0].label == "1"
     assert groups[0].parts == parts  # same objects, same order
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Cross-source duplicate detection (2026-05-27 refinement)
+#
+# These tests cover the Rule 2 / 3b / 6 refinement that uses a peer-source
+# consensus_set to drop source-only .1/.2/.3/.4 fragments without touching
+# real side stories. See ~/.claude/plans/ultrathink-mangafire-and-some-
+# flickering-sparkle.md for the design and sites/chapter_merger.py for
+# the implementation (_is_source_only_fragment, _classify_chapter_breakdown).
+# ────────────────────────────────────────────────────────────────────────
+
+def test_is_fragment_shaped_decimal_dot_one_through_four():
+    """Fragment-shaped decimals are exactly .1/.2/.3/.4 (the conventional
+    upload-fragment suffixes). .5 and higher are real side-story numbers."""
+    assert _is_fragment_shaped_decimal(52.1, 52) is True
+    assert _is_fragment_shaped_decimal(52.2, 52) is True
+    assert _is_fragment_shaped_decimal(52.3, 52) is True
+    assert _is_fragment_shaped_decimal(52.4, 52) is True
+    assert _is_fragment_shaped_decimal(52.5, 52) is False
+    assert _is_fragment_shaped_decimal(52.6, 52) is False
+    assert _is_fragment_shaped_decimal(52.9, 52) is False
+    # Integer chapter is not "fragment-shaped" (rel == 0).
+    assert _is_fragment_shaped_decimal(52.0, 52) is False
+
+
+def test_is_source_only_fragment_requires_non_empty_consensus():
+    """Without consensus (None or empty set), the predicate must return
+    False so the rest of the rule table behaves identically to today."""
+    assert _is_source_only_fragment(52.1, 52, None) is False
+    assert _is_source_only_fragment(52.1, 52, set()) is False
+
+
+def test_is_source_only_fragment_returns_false_when_peer_confirms():
+    """Peer source has 52.1 → it's a real chapter, NOT a fragment to drop."""
+    assert _is_source_only_fragment(52.1, 52, {52.0, 52.1, 53.0}) is False
+
+
+def test_is_source_only_fragment_returns_true_for_lone_dot_one():
+    """The Shangri-La Frontier case: mangafire has 52.1, peers don't."""
+    assert _is_source_only_fragment(52.1, 52, {52.0, 53.0}) is True
+
+
+def test_is_source_only_fragment_keeps_dot_five():
+    """.5 is never fragment-shaped, regardless of consensus state.
+    Matches the user's 'we're not trying to remove extras, just duplicates'
+    constraint — .5 is the canonical side-story suffix."""
+    assert _is_source_only_fragment(52.5, 52, {52.0}) is False
+    assert _is_source_only_fragment(52.5, 52, set()) is False
+
+
+# ────────────────────────────────────────────────────────────────────────
+# group_chapters_for_download with consensus_set — the critical fixes
+# ────────────────────────────────────────────────────────────────────────
+
+def test_rule_2_refined_drops_source_only_dot_one():
+    """THE critical case from the user's Shangri-La Frontier data: mangafire
+    has {52, 52.1}, peer sources have {52} only. With consensus_set={52},
+    52.1 is identified as a source-only fragment and dropped — exactly
+    what the user asked for ('make rule 2 harsher for .1 chapters if no
+    other providers have it')."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.1")],
+        consensus_set={52.0},
+    )
+    assert [g.label for g in groups] == ["52"]
+
+
+def test_rule_2_refined_keeps_dot_five_even_when_source_only():
+    """Per the user's 'don't remove extras' constraint, .5 is treated
+    conservatively: even if no peer has the .5, it's kept as a side story
+    because .5 is overwhelmingly used for canonical sub-chapters, not
+    fragments."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.5")],
+        consensus_set={52.0},
+    )
+    assert [g.label for g in groups] == ["52", "52.5"]
+
+
+def test_rule_2_refined_keeps_dot_one_when_peer_confirms():
+    """If a peer source also lists 52.1, it's NOT a duplicate — keep both."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.1")],
+        consensus_set={52.0, 52.1},
+    )
+    assert [g.label for g in groups] == ["52", "52.1"]
+
+
+def test_rule_2_unchanged_without_consensus_set():
+    """consensus_set=None → fall back to pre-refinement Rule 2 behavior
+    (always keep the decimal). Critical for direct-URL / single-source
+    runs where there's no peer data."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.1")],
+        consensus_set=None,
+    )
+    assert [g.label for g in groups] == ["52", "52.1"]
+
+
+def test_rule_2_unchanged_when_collapse_off_even_with_consensus():
+    """collapse_splits=False → no drops regardless of consensus signal.
+    The opt-out lets the user keep everything if they want to."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.1")],
+        collapse_splits=False,
+        consensus_set={52.0},
+    )
+    assert [g.label for g in groups] == ["52", "52.1"]
+
+
+def test_rule_3b_refined_drops_source_only_fragment_highest():
+    """Rule 3b case where the kept 'highest' is itself a source-only
+    fragment shape: {52, 52.1, 52.3}, peer has {52} only. Intermediate
+    .1 is dropped by the unchanged Rule 3b; the refinement additionally
+    drops .3 (fragment-shaped + source-only). Rare in practice but the
+    refinement should fire."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.1"), _ch("52.3")],
+        consensus_set={52.0},
+    )
+    assert [g.label for g in groups] == ["52"]
+
+
+def test_rule_3b_keeps_dot_five_highest():
+    """Rule 3b standard case: {52, 52.1, 52.5}, peer has {52}. Existing
+    Rule 3b drops 52.1 (intermediate); 52.5 is the highest decimal and
+    NOT fragment-shaped, so it's kept regardless of consensus."""
+    groups = group_chapters_for_download(
+        [_ch("52"), _ch("52.1"), _ch("52.5")],
+        consensus_set={52.0},
+    )
+    assert [g.label for g in groups] == ["52", "52.5"]
+
+
+def test_rule_6_refined_drops_when_parent_in_consensus():
+    """Rule 6 (scattered, not sequential): {1.2, 1.3} — no integer, doesn't
+    start at .1 so it's Rule 6 territory, NOT Rule 5 (sequential split).
+    Peer has the integer parent {1}. Refinement drops the cluster as
+    fragment noise: highest 1.3 is fragment-shaped AND parent in consensus."""
+    groups = group_chapters_for_download(
+        [_ch("1.2"), _ch("1.3")],
+        consensus_set={1.0},
+    )
+    assert [g.label for g in groups] == []
+
+
+def test_rule_6_keeps_when_parent_not_in_consensus():
+    """Rule 6: {1.2, 1.3}, no peer has the integer parent 1 either (peer
+    consensus is on different chapter numbers). No peer signal that 1 is
+    the canonical chapter → keep current behavior (highest decimal, label
+    '1.3'). Conservative — we only drop when peers explicitly confirm
+    the parent as canonical."""
+    groups = group_chapters_for_download(
+        [_ch("1.2"), _ch("1.3")],
+        consensus_set={5.0, 10.0},  # peer consensus exists, but not for floor=1
+    )
+    assert [g.label for g in groups] == ["1.3"]
+
+
+def test_rule_6_keeps_dot_five_regardless_of_consensus():
+    """Rule 6: {1.5, 1.6}, parent in consensus. .6 isn't fragment-shaped,
+    so it's kept even though the parent IS in consensus. The refinement
+    only fires on fragment-shaped (.1-.4) decimals."""
+    groups = group_chapters_for_download(
+        [_ch("1.5"), _ch("1.6")],
+        consensus_set={1.0},
+    )
+    assert [g.label for g in groups] == ["1.6"]
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _classify_main_chapters with consensus_set
+# (Mirrors the same scenarios above but checks the diagnostic-count side)
+# ────────────────────────────────────────────────────────────────────────
+
+def test_classify_rule_2_refined_drops_dot_one():
+    """{52, 52.1} with consensus={52} → (1 unique main, 1 effective).
+    Mirrors test_rule_2_refined_drops_source_only_dot_one for the
+    display side."""
+    assert _classify_main_chapters(
+        [52.0, 52.1],
+        collapse_splits=True,
+        consensus_set={52.0},
+    ) == (1, 1)
+
+
+def test_classify_rule_2_keeps_dot_five():
+    """{52, 52.5} with consensus={52} → (1 unique main, 2 effective)
+    — .5 preserved as side story, matches the download path."""
+    assert _classify_main_chapters(
+        [52.0, 52.5],
+        collapse_splits=True,
+        consensus_set={52.0},
+    ) == (1, 2)
+
+
+def test_classify_rule_2_peer_confirmed_dot_one_kept():
+    """{52, 52.1} with consensus={52, 52.1} → (1 unique main, 2 effective).
+    Peer-confirmed decimals count as effective entries."""
+    assert _classify_main_chapters(
+        [52.0, 52.1],
+        collapse_splits=True,
+        consensus_set={52.0, 52.1},
+    ) == (1, 2)
+
+
+def test_classify_no_consensus_matches_pre_refinement_behavior():
+    """When consensus_set is None, the count must match the pre-2026-05-27
+    behavior exactly so single-source / direct-URL runs don't see any
+    surprise changes."""
+    # Same {8, 8.1, 8.5} Kagurabachi case as the existing
+    # test_classify_collapse_integer_plus_scattered_decimals test.
+    assert _classify_main_chapters(
+        [8.0, 8.1, 8.5],
+        collapse_splits=True,
+        consensus_set=None,
+    ) == (1, 2)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _classify_chapter_breakdown
+# ────────────────────────────────────────────────────────────────────────
+
+def test_breakdown_empty_input():
+    bd = _classify_chapter_breakdown([], consensus_set=set(), consensus_max=None)
+    assert isinstance(bd, ChapterBreakdown)
+    assert all(getattr(bd, f) == 0 for f in [
+        "consensus_main", "source_only_latest", "consensus_side_stories",
+        "safe_decimals", "prologue_count", "source_only_orphans",
+        "fragments_dropped", "unparseable_passthrough",
+    ])
+
+
+def test_breakdown_routes_each_bucket_correctly():
+    """Synthetic dataset hitting every bucket exactly once. Catches any
+    routing bug where a chapter falls into the wrong bucket."""
+    chapters = [
+        _ch("0"),         # prologue_count
+        _ch("1"),         # consensus_main
+        _ch("2"),         # consensus_main
+        _ch("3"),         # source_only_orphans (in range but not in consensus)
+        _ch("3.1"),       # fragments_dropped
+        _ch("3.5"),       # safe_decimals (source-only, .5+)
+        _ch("4.5"),       # consensus_side_stories (peer-confirmed)
+        _ch("10"),        # source_only_latest (> consensus_max)
+        _ch("Oneshot"),   # unparseable_passthrough
+    ]
+    bd = _classify_chapter_breakdown(
+        chapters,
+        consensus_set={1.0, 2.0, 4.5},  # peers have 1, 2, 4.5
+        consensus_max=4.5,
+    )
+    assert bd.prologue_count == 1
+    assert bd.consensus_main == 2  # 1, 2
+    assert bd.source_only_orphans == 1  # 3 (in range, not in consensus)
+    assert bd.fragments_dropped == 1  # 3.1
+    assert bd.safe_decimals == 1  # 3.5
+    assert bd.consensus_side_stories == 1  # 4.5
+    assert bd.source_only_latest == 1  # 10
+    assert bd.unparseable_passthrough == 1  # "Oneshot"
+
+
+def test_breakdown_no_consensus_treats_everything_as_main_or_safe():
+    """Without peer signal, integers all go to consensus_main and decimals
+    all go to safe_decimals — nothing is dropped or flagged orphan because
+    we have no basis to judge."""
+    bd = _classify_chapter_breakdown(
+        [_ch("1"), _ch("2"), _ch("2.1"), _ch("2.5")],
+        consensus_set=set(),
+        consensus_max=None,
+    )
+    assert bd.consensus_main == 2  # 1, 2
+    assert bd.safe_decimals == 2  # both 2.1 AND 2.5 → safe (no peer signal)
+    assert bd.fragments_dropped == 0  # NEVER fires without consensus
+    assert bd.source_only_orphans == 0
+
+
+def test_breakdown_shangri_la_frontier_dataset():
+    """End-to-end test on the exact mangafire chapter list from the user's
+    Shangri-La Frontier example (305 entries). Expected per the design
+    plan:
+      consensus_main:    266  (integers 1..266, peer-confirmed)
+      safe_decimals:      16  (the .5 entries — mangafire-only, .5+ kept)
+      prologue_count:      1  (chapter 0)
+      fragments_dropped:  22  (all .1 entries dropped)
+      others:              0
+      sum:               305
+    """
+    # The actual mangafire chapter list per user-supplied data.
+    int_chapters = [_ch(str(n)) for n in range(0, 267)]
+    dot_one = [
+        _ch("5.1"), _ch("15.1"), _ch("35.1"), _ch("45.1"), _ch("52.1"),
+        _ch("55.1"), _ch("65.1"), _ch("75.1"), _ch("85.1"), _ch("95.1"),
+        _ch("105.1"), _ch("115.1"), _ch("125.1"), _ch("135.1"), _ch("145.1"),
+        _ch("155.1"), _ch("165.1"), _ch("175.1"), _ch("185.1"), _ch("195.1"),
+        _ch("205.1"), _ch("215.1"),
+    ]
+    dot_five = [
+        _ch("5.5"), _ch("15.5"), _ch("25.5"), _ch("35.5"), _ch("45.5"),
+        _ch("55.5"), _ch("65.5"), _ch("95.5"), _ch("105.5"), _ch("115.5"),
+        _ch("125.5"), _ch("135.5"), _ch("145.5"), _ch("155.5"), _ch("195.5"),
+        _ch("205.5"),
+    ]
+    chapters = int_chapters + dot_one + dot_five
+    assert len(chapters) == 305  # sanity
+
+    # Peer consensus: all 5 peer sources agree on integers 1..266
+    # (chapter 0 isn't on peers; the .5s and .1s aren't on peers either).
+    peer_consensus = {float(n) for n in range(1, 267)}
+
+    bd = _classify_chapter_breakdown(
+        chapters,
+        consensus_set=peer_consensus,
+        consensus_max=266.0,
+    )
+    assert bd.consensus_main == 266
+    assert bd.safe_decimals == 16
+    assert bd.prologue_count == 1
+    assert bd.fragments_dropped == 22
+    assert bd.consensus_side_stories == 0  # peers don't carry the .5s
+    assert bd.source_only_latest == 0
+    assert bd.source_only_orphans == 0
+    assert bd.unparseable_passthrough == 0
+    # Sanity: bucket sum must equal input length.
+    total = (
+        bd.consensus_main + bd.source_only_latest + bd.consensus_side_stories
+        + bd.safe_decimals + bd.prologue_count + bd.source_only_orphans
+        + bd.fragments_dropped + bd.unparseable_passthrough
+    )
+    assert total == 305
+
+
+def test_breakdown_shangri_la_frontier_group_count():
+    """Same Shangri-La Frontier dataset, but exercising the download path:
+    group_chapters_for_download should emit 283 groups (266 + 16 + 1)
+    when collapse is on with the peer consensus. The 22 .1 fragments
+    are dropped (15 by existing Rule 3b — chapters with both .1 and .5
+    — plus 7 by the new Rule 2 refinement — lone .1 with no peer)."""
+    int_chapters = [_ch(str(n)) for n in range(0, 267)]
+    dot_one = [
+        _ch("5.1"), _ch("15.1"), _ch("35.1"), _ch("45.1"), _ch("52.1"),
+        _ch("55.1"), _ch("65.1"), _ch("75.1"), _ch("85.1"), _ch("95.1"),
+        _ch("105.1"), _ch("115.1"), _ch("125.1"), _ch("135.1"), _ch("145.1"),
+        _ch("155.1"), _ch("165.1"), _ch("175.1"), _ch("185.1"), _ch("195.1"),
+        _ch("205.1"), _ch("215.1"),
+    ]
+    dot_five = [
+        _ch("5.5"), _ch("15.5"), _ch("25.5"), _ch("35.5"), _ch("45.5"),
+        _ch("55.5"), _ch("65.5"), _ch("95.5"), _ch("105.5"), _ch("115.5"),
+        _ch("125.5"), _ch("135.5"), _ch("145.5"), _ch("155.5"), _ch("195.5"),
+        _ch("205.5"),
+    ]
+    chapters = int_chapters + dot_one + dot_five
+    peer_consensus = {float(n) for n in range(1, 267)}
+
+    groups = group_chapters_for_download(
+        chapters,
+        collapse_splits=True,
+        consensus_set=peer_consensus,
+    )
+    # 266 main + 1 prologue (chapter 0) + 16 .5 side stories = 283
+    assert len(groups) == 283
+    # No .1 labels survive
+    assert not any(".1" in g.label for g in groups)
+    # All .5 labels survive
+    survived_fives = sum(1 for g in groups if g.label.endswith(".5"))
+    assert survived_fives == 16
+
+
+# ────────────────────────────────────────────────────────────────────────
+# align_chapter_lists exposes consensus_set + breakdown
+# ────────────────────────────────────────────────────────────────────────
+
+def test_align_exposes_consensus_set():
+    """align_chapter_lists must populate consensus_set and consensus_max
+    on the AlignmentResult. Two sources with overlapping chapter numbers
+    yields a consensus = the overlap."""
+    a = [_ch("1"), _ch("2"), _ch("3")]
+    b = [_ch("1"), _ch("2"), _ch("4")]
+    result = align_chapter_lists([("a", a), ("b", b)])
+    assert isinstance(result, AlignmentResult)
+    # 1.0 and 2.0 are in both → consensus. 3 and 4 are source-only → not.
+    assert result.consensus_set == {1.0, 2.0}
+    assert result.consensus_max == 2.0
+
+
+def test_align_consensus_empty_for_single_source():
+    """Single source → no peer → empty consensus, None max. Critical for
+    direct-URL flows to fall through to the pre-refinement behavior."""
+    result = align_chapter_lists([("a", [_ch("1"), _ch("2"), _ch("2.1")])])
+    assert result.consensus_set == set()
+    assert result.consensus_max is None
+
+
+def test_align_includes_breakdown_in_diagnostics():
+    """Each merge_diagnostics entry must carry a 'breakdown' dict that
+    sums to the source's total_chapters. SearchChapterMap.jsx reads
+    these fields to render the bucket chips."""
+    a = [_ch("1"), _ch("2"), _ch("3")]
+    b = [_ch("1"), _ch("2"), _ch("4"), _ch("4.1")]
+    result = align_chapter_lists([("a", a), ("b", b)])
+    for site in ("a", "b"):
+        diag = result.merge_diagnostics[site]
+        assert "breakdown" in diag
+        bd = diag["breakdown"]
+        # Sum of buckets equals total_chapters (excluding unparseable
+        # which is also a bucket).
+        total = sum(bd.values())
+        assert total == diag["total_chapters"]
+
+
+def test_align_classifies_source_only_dot_one_as_fragment():
+    """Verifies the cross-source-consensus signal: source A has a lone
+    {3, 3.1}, source B has only {3}. 3.1 lands in fragments_dropped
+    on source A's breakdown."""
+    a = [_ch("3"), _ch("3.1")]
+    b = [_ch("3")]
+    result = align_chapter_lists([("a", a), ("b", b)])
+    # source a is the anchor (most chapters)
+    bd_a = result.merge_diagnostics["a"]["breakdown"]
+    assert bd_a["fragments_dropped"] == 1
+    assert bd_a["consensus_main"] == 1  # just chapter 3
+    assert bd_a["safe_decimals"] == 0
+    # source b has only chapter 3 (consensus_main)
+    bd_b = result.merge_diagnostics["b"]["breakdown"]
+    assert bd_b["consensus_main"] == 1
+    assert bd_b["fragments_dropped"] == 0


### PR DESCRIPTION
## Summary

Two fixes addressing the 2026-05-27 Shangri-La Frontier failure where chapter 0 (a mangafire placeholder entry whose image URLs all return identical 5051-byte CF 403 responses) aborted the whole 290-chapter queue. Follow-up to merged #38 — same branch, single new commit.

- **Comix bypass via `--multi-source-prefetched`.** The `SKIP_MULTI_SOURCE` class attribute landed in #38 was honored by `_filter_and_rank_alt_sources` (direct-URL path) but not by `build_alternatives_from_prefetched` (UI's prefetched-JSON path). Mirror the filter check at the prefetched entry point.

- **Ghost-chapter detection + consecutive-ghost escalation.** New `ghost_chapter` reason in `ChapterSkippedError` fires when every recorded failure on a chapter shares the EXACT same `(status, body_size)` signature AND the shared status is a 4xx — distinguishing structural "this chapter doesn't exist" failures from transient CDN issues. `_process_chapter_strict` short-circuits the inline-retry sleep on ghost detection and raises `ChapterGhostError`, which the main loop catches as skip-and-continue. Safety net: when 3 chapters ghost consecutively (counter resets on success), escalate to abort — without this, a host-level CF block (auth expired, etc.) would silently slog through hundreds of chapters.

## Detection signal (4xx-only, exact-match)

- `pages_ok == 0` (literally nothing succeeded)
- `pages_total >= 5` (lowered to 3 when alignment shows the chapter is primary-only — Idea B cross-source quorum folded into the threshold knob)
- `len(set(signatures)) == 1` (every failure exactly identical — CF Ray IDs are fixed-format so byte-length is constant across responses with different IDs)
- Status is 4xx (`None`/timeouts and 5xx still flow through `host_poison` → `inline-retry` → `abort`)

## Real-world validation

End-to-end on the user's exact failing URL (Shangri-La Frontier, chapters 0-4):

| Chapter | Outcome | Counter |
|---|---|---|
| 0 | ghost (193 pages, host `l1n.mfcdn2.xyz`) | 1/3 |
| 1 | ghost (61 pages, host `k99.mfcdn2.xyz`) | 2/3 (warning shown) |
| 2 | CBZ saved (54 pages) | reset to 0 |
| 3 | CBZ saved | 0 |
| 4 | ghost (21 pages, host `l1n.mfcdn2.xyz`) | 1/3 |

Before the fix this exact run aborted at chapter 0 with **zero downloads**. After: 2 valid CBZs salvaged.

Comix-bypass smoke test on the same URL with `--multi-source --multi-source-prefetched <json-with-comix>` shows `[*] Multi-source: dropping 1 prefetched alternative(s) marked SKIP_MULTI_SOURCE: comix` and a 7.3 s run (vs. the ~8 min comix Patchright bridge would have added).

## Test plan

- [x] 13 unit-style ghost-detector cases (uniform 4xx ghosts, mixed signatures, network-timeout-only failures, status-mismatched mixes, sub-floor sample counts, primary_only threshold relaxation, 5xx/timeout exclusion)
- [x] 6 escalation-arithmetic assertions (back-to-back triplets, success-interrupted chains, exception resets)
- [x] Real-world Shangri-La Frontier chapters 0-4 verified end-to-end
- [x] Real-world comix-bypass via `--multi-source-prefetched` verified end-to-end
- [x] `CLAUDE.md` verification suite: 302/41 handlers, both CLIs `--help` clean, mangafire inherits `fast_download_images`, no torch on bare orchestrator load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
