### PR TITLE
resume: fix nested output_dir on resume + ML rating UI toggle

### DIFF
--- a/UI-source/src/components/SearchTab.jsx
+++ b/UI-source/src/components/SearchTab.jsx
@@ -88,6 +88,14 @@ const DEFAULT_OPTS = {
   searchTimeout: 20,
   searchMinMatch: 0.55,
   searchParallelism: 6,
+  // ML image-quality rating (CLIP-IQA + NIQE + paired DISTS). Default OFF
+  // because torch's Windows import path hits platform.machine() which Python
+  // 3.13 routes through WMI — that can hang indefinitely on degraded hosts,
+  // bricking --search for the whole session. See search_orchestrator.py's
+  // _ML_RATING_ENABLED docstring for the full rationale. The toggle wires
+  // through to electron/searcher.js (opts.enableMlRating → --enable-ml-rating)
+  // and aio_search_cli sets the orchestrator gate before search_all runs.
+  enableMlRating: false,
 };
 
 const DOWNLOAD_FORMATS = [
@@ -549,6 +557,27 @@ export default function SearchTab({
                 onChange={(e) => set("searchParallelism", parseInt(e.target.value, 10) || 6)}
                 disabled={isRunning}
                 className="w-20 h-8 text-xs"
+              />
+            </div>
+            {/* ML image-quality rating — opt-in. Forwards to --enable-ml-rating
+                via electron/searcher.js (opts.enableMlRating). Off by default;
+                see DEFAULT_OPTS above for the WMI-hang rationale. */}
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <Label htmlFor="opt-ml-rating" className="text-xs font-medium">
+                  ML image rating
+                </Label>
+                <p className="text-[10px] text-muted-foreground">
+                  Torch-backed CLIP-IQA + NIQE + DISTS for sharper ranking
+                  on borderline matches. Adds ~5 s startup and ~150 MB of
+                  model weights on first use. Default off.
+                </p>
+              </div>
+              <Switch
+                id="opt-ml-rating"
+                checked={opts.enableMlRating}
+                onCheckedChange={(v) => set("enableMlRating", v)}
+                disabled={isRunning}
               />
             </div>
           </div>

--- a/UI-source/src/components/SettingsTab.jsx
+++ b/UI-source/src/components/SettingsTab.jsx
@@ -38,6 +38,11 @@ const DEFAULT_SEARCH_OPTS = {
   searchTimeout: 20,
   searchMinMatch: 0.55,
   searchParallelism: 6,
+  // Mirror of SearchTab.jsx DEFAULT_OPTS.enableMlRating. The UI control is
+  // in SearchTab's "Advanced search options" Collapsible (not surfaced here)
+  // so the shared settings.searchOpts namespace stays schema-aligned across
+  // both surfaces. See SearchTab.jsx for the WMI-hang rationale.
+  enableMlRating: false,
 };
 
 // ── DEFAULT VALUES ──

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -6514,6 +6514,19 @@ def main():
         sys.exit(0)
 
     # Output goes into a per-title folder under ./manga (title, with hid only on collision)
+    # Capture the user-facing ROOT before mutating args.output_dir / args.epub_dir to the
+    # per-series folder. Downstream chapter writes, final-file writes, cover writes etc.
+    # expect the per-series value (grep `getattr(args, "output_dir"`), so the mutation is
+    # intentional for the rest of the current run; but get_resumable_params (grep that name)
+    # reads args.output_dir to persist run_params.json, and on resume the restore block
+    # (grep `if args.restore_parameters:`) setattr's it back onto args BEFORE this line
+    # runs again, which would feed the per-series path back into allocate_series_output_dir
+    # and nest (manga/Tekyuu → manga/Tekyuu/Tekyuu). The override after get_resumable_params
+    # restores the root in the saved dict. Cross-file: UI-source/electron/downloader.js
+    # builds the resume CLI without --output-dir, so the persisted root is the only source
+    # of truth on resume.
+    _output_dir_root_for_resume = args.output_dir
+    _epub_dir_root_for_resume = getattr(args, "epub_dir", None)
     out_dir = allocate_series_output_dir(title, hid, root=args.output_dir)
     setattr(args, "output_dir", out_dir)
     epub_dir_base = getattr(args, "epub_dir", None)
@@ -6694,6 +6707,15 @@ def main():
     resume_mode = False
     params_path = os.path.join(main_tmp_dir, "run_params.json")
     current_params = get_resumable_params(args, p, width, aspect_ratio_str)
+    # Persist the user-facing ROOT (captured pre-mutation; grep `_output_dir_root_for_resume`),
+    # not the per-series folder args.output_dir / args.epub_dir hold by now. Without this,
+    # the resumed run restores the per-series value and the allocate_series_output_dir call
+    # at the top of this section nests one level deeper every resume (manga/Tekyuu →
+    # manga/Tekyuu/Tekyuu → manga/Tekyuu/Tekyuu/Tekyuu…). Neither dest is in
+    # _RESUME_GATING_DESTS, so gating_hash is unaffected by this override.
+    current_params["output_dir"] = _output_dir_root_for_resume
+    if "epub_dir" in current_params:
+        current_params["epub_dir"] = _epub_dir_root_for_resume
     current_hash = gating_hash(current_params)
 
     if os.path.isdir(main_tmp_dir):

--- a/aio_search_cli.py
+++ b/aio_search_cli.py
@@ -338,6 +338,19 @@ def run_search_mode(
     if not query:
         sys.exit("--search requires a non-empty title.")
 
+    # Set the ML-rating gate BEFORE the orchestrator imports torch-backed
+    # modules. When False (the default), all torch/pyiqa/torchmetrics
+    # imports stay deferred — search startup never loads torch. This
+    # avoids the Python 3.13 + Windows WMI hang that bricked --search
+    # before the 2026-05-20 lazy-import refactor. set_ml_rating_enabled
+    # is idempotent so direct-URL multi-source paths can also call it.
+    # Cross-file: aio-dl.py argparse defines --enable-ml-rating;
+    # UI-source/src/components/SearchTab.jsx writes enableMlRating to
+    # settings.searchOpts; UI-source/electron/searcher.js translates that
+    # back to --enable-ml-rating on the spawn line — grep enableMlRating.
+    from sites.search_orchestrator import set_ml_rating_enabled
+    set_ml_rating_enabled(bool(getattr(args, "enable_ml_rating", False)))
+
     # URL-mode: if the user supplied a MangaFire URL instead of a title text,
     # scrape the series page once via Playwright and turn it into a seed hit.
     # The orchestrator then runs the normal cross-site search using the
@@ -789,6 +802,12 @@ def find_alternatives_for_direct_url(
 
     if on_status:
         on_status(f"[*] Multi-source: searching for alternatives to '{title}'...")
+
+    # Direct-URL multi-source enters here, separate from run_search_mode. Set
+    # the ML-rating gate here too so the orchestrator's lazy torch checks see
+    # the right state. Idempotent — calling twice in the same process is fine.
+    from sites.search_orchestrator import set_ml_rating_enabled
+    set_ml_rating_enabled(bool(getattr(args, "enable_ml_rating", False)))
 
     # Step 2: search.
     timeout = float(getattr(args, "search_timeout", DEFAULT_PER_SITE_TIMEOUT_S) or DEFAULT_PER_SITE_TIMEOUT_S)


### PR DESCRIPTION
## Summary

- **Fix nested-folder bug on resume** (`aio-dl.py`): `args.output_dir` was being mutated to the per-series folder (e.g. `manga/Tekyuu`) before `get_resumable_params` ran, so the polluted value got persisted to `tmp_<hid>/run_params.json`. On resume, the per-series value was re-fed into `allocate_series_output_dir`, producing `manga/Tekyuu/Tekyuu` — invisible to the library scanner because both the outer and inner folder carry a `.series_hid` marker. Now persists the pre-mutation root.
- **ML image-rating UI toggle** (`SearchTab` + `SettingsTab` + `aio_search_cli`): surface `--enable-ml-rating` as a toggle in the advanced search options. Default OFF (matches the CLI default and the WMI-hang rationale in `_ML_RATING_ENABLED`'s docstring). Also calls `set_ml_rating_enabled()` at the top of both `run_search_mode` and `find_alternatives_for_direct_url` so the orchestrator's lazy-torch gate is set before any search work runs.

Resume-fix mechanics: capture the pre-mutation root in two locals (`_output_dir_root_for_resume`, `_epub_dir_root_for_resume`) just before the `allocate_series_output_dir` call, then override `current_params["output_dir"]` / `["epub_dir"]` back to the root after `get_resumable_params` and before `json.dump`. Downstream chapter writes, final-file writes, cover writes etc. continue reading the mutated `args.output_dir` (per-series). Neither dest is in `_RESUME_GATING_DESTS`, so `gating_hash` is unaffected (verified: identical hash with or without the override). Legacy tmp folders carry the polluted per-series value and will nest once on first resume; the next fresh run rewrites `run_params.json` with the corrected root and nesting stops.

## Test plan

- [x] `py_compile` clean on `aio-dl.py` and `aio_search_cli.py`
- [x] `python aio-dl.py --help` exit 0
- [x] `python aio_search_cli.py --help` exit 0
- [x] End-to-end simulation of the resume-fix override: persisted `output_dir` is the root (`"manga"`), not the mutated per-series value (`"manga\Tekyuu"`); `args.output_dir` still holds the per-series value for downstream writes; `gating_hash` identical before/after the override
- [ ] Manual: start a download in the Electron UI, cancel mid-run, resume from the resume bar, confirm chapters land in `manga/<Title>/` not `manga/<Title>/<Title>/`
- [ ] Manual: toggle "ML image rating" in advanced search options and run a search; confirm `--enable-ml-rating` is on the spawn line (via search log) when enabled and absent when disabled