### PR TITLE
Multi-source collapse-aware alignment + Settings save-button UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,24 @@ settings-full.png
 probe_*.py
 aio_config.json
 test_downloads.py
+
+# Per-session diagnostic probe scripts + their outputs. Kept locally for
+# reference but never shipped — these are ad-hoc, NOT part of the tests/
+# suite (committing them under tests/ would pollute pytest collection).
+# Root-anchored (leading /) so underscore-prefixed SOURCE modules like
+# sites/_image_io.py / sites/_publishers.py are never accidentally matched.
+/investigate_*.py
+/_diag_*.py
+/_test_*.py
+/_verify_*.py
+/_build_*.py
+/_calib_*.log
+/_slf_search.*
+
+# Local Electron build output (the runnable app staged by npm run dist:*,
+# distinct from the gitignored UI-source/dist bundle) + Claude tooling state
+# + bench scratch. Build dirs can be hundreds of MB; .claude/ holds
+# per-machine scheduler locks, not source.
+/UI/
+/bench/
+.claude/

--- a/UI-source/electron/downloader.js
+++ b/UI-source/electron/downloader.js
@@ -220,9 +220,20 @@ function buildCliArgs(args) {
     cliArgs.push(flag, String(value));
   }
 
+  // --webtoon-recompress requires an archive output. aio-dl.py hard-errors on
+  // --format pdf/none for it; --komikku coerces format→cbz BEFORE that check
+  // (~aio-dl.py:5999 then ~6028), so it stays valid then. This buildCliArgs is
+  // the single chokepoint for every spawn path (manual, search-, library-
+  // initiated, resume), so strip the flag + its valued knobs here whenever the
+  // effective format is incompatible — defense-in-depth behind the
+  // DownloadTab / SettingsTab UI guards, covering any path that didn't clear it.
+  const recompressIncompatible =
+    (args.format === "none" || args.format === "pdf") && args.komikku !== true;
+
   // Add boolean flags
   for (const [key, flag] of Object.entries(boolMap)) {
     if (args[key] === true) {
+      if (key === "webtoonRecompress" && recompressIncompatible) continue;
       cliArgs.push(flag);
     }
   }
@@ -259,7 +270,7 @@ function buildCliArgs(args) {
   // valued flags when --webtoon-recompress is absent — they're argparse
   // metadata for the helper function, gated independently in
   // _process_chapter_impl — so this is purely about spawn-line cleanliness.
-  if (args.webtoonRecompress === true) {
+  if (args.webtoonRecompress === true && !recompressIncompatible) {
     if (args.webtoonRecompressQuality != null && args.webtoonRecompressQuality !== 85) {
       cliArgs.push("--webtoon-recompress-quality", String(args.webtoonRecompressQuality));
     }

--- a/UI-source/electron/library.js
+++ b/UI-source/electron/library.js
@@ -25,6 +25,16 @@
 //           0001.jpg ...
 //     One Piece/
 //       One Piece.epub
+//     Tower of God/            ← --format none (images only, NO archive)
+//       .aio_series.json       ← still written (format:"none", cover, chapters)
+//       images/                ← always present for --format none
+//         Chapter_1/
+//           0001.webp ...
+//
+// IMAGE-ONLY SERIES: a --format none download produces no pdf/epub/cbz, only
+// the images/ tree above. The scanner treats such a folder as a first-class
+// series (isImageOnly entry) instead of skipping it for having no archive.
+// See the IMAGE-ONLY SERIES helper block + the gate in scanLibrary().
 // ============================================================
 
 const fs = require("fs");
@@ -33,6 +43,13 @@ const crypto = require("crypto");
 
 // File extensions we care about (the final output files)
 const OUTPUT_EXTENSIONS = new Set(["pdf", "epub", "cbz"]);
+
+// Image file extensions written into images/<Chapter_n>/ by aio-dl.py's
+// --keep-images copytree. `--format none` forces keep_images on and writes
+// NO archive, so for those series this is the ONLY payload on disk. Phase A
+// (2026-05-07) made downloads keep their real extension, so this must cover
+// webp/avif/png/gif, not just jpg. Cross-file: grep _IMG_EXTS in aio-dl.py.
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif"]);
 
 // ── CONFIGURABLE ──
 // Width of generated thumbnails in pixels.
@@ -217,6 +234,158 @@ function getChaptersOnDevice(files, siteChapters) {
 }
 
 // ============================================================
+// IMAGE-ONLY SERIES (--format none)
+//
+// A --format none download writes no pdf/epub/cbz — only raw pages under
+// <Title>/images/Chapter_<n>/ (aio-dl.py forces keep_images=True for none;
+// grep 'keep_images = True' + 'Chapter_{n}'). These helpers let the scanner
+// treat such a folder as a first-class series: count chapters cheaply for
+// the grid badge (countImageChapterDirs), recover size/cover/rows for the
+// detail view (scanImagesTree — a DEEP per-page statSync walk, so callers
+// MUST gate it to image-only folders or big archive+keep-images libraries
+// pay the walk on every scan), and recover the on-device chapter set for the
+// file-based update check (getImageChaptersOnDevice). The legacy 'ch_' dir
+// prefix is accepted alongside the current 'Chapter_' one.
+// ============================================================
+
+// Parse the chapter number token out of an images/ subfolder name.
+// Returns "5" / "5.5" (raw token) or null for non-numeric / non-chapter dirs.
+function _imageChapterToken(dirName) {
+  const m = dirName.match(/^(?:Chapter_|ch_)(-?\d+(?:\.\d+)?)/i);
+  return m ? m[1] : null;
+}
+
+// Cheap chapter-dir count (no per-file stat). Drives the "N ch" grid badge
+// for EVERY series (archive + image-only), mirroring the historical behavior.
+function countImageChapterDirs(imagesDir) {
+  try {
+    return fs
+      .readdirSync(imagesDir, { withFileTypes: true })
+      .filter(
+        (d) =>
+          d.isDirectory() &&
+          (d.name.startsWith("Chapter_") || d.name.startsWith("ch_"))
+      ).length;
+  } catch {
+    return 0;
+  }
+}
+
+// Deep walk of images/: per-chapter image counts + byte sizes, the first page
+// (cover fallback), total bytes, and the freshest mtime. Stats every page, so
+// callers MUST gate this to image-only folders.
+function scanImagesTree(imagesDir) {
+  const result = {
+    chapters: [],          // [{ name, path, imageCount, size, mtime }]
+    chapterCount: 0,
+    imageCount: 0,
+    imageBytes: 0,
+    firstImagePath: null,  // first page of the lowest-numbered chapter
+    latestMtime: "",
+  };
+
+  let dirEntries;
+  try {
+    dirEntries = fs.readdirSync(imagesDir, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  // Sort chapter folders by parsed number so the cover comes from the first
+  // chapter and detail-view rows read in chapter order. Numeric-aware
+  // localeCompare is the tiebreaker for non-parseable / named chapters.
+  const chapterDirs = dirEntries
+    .filter(
+      (d) =>
+        d.isDirectory() &&
+        (d.name.startsWith("Chapter_") || d.name.startsWith("ch_"))
+    )
+    .map((d) => d.name)
+    .sort((a, b) => {
+      const na = parseFloat(_imageChapterToken(a));
+      const nb = parseFloat(_imageChapterToken(b));
+      if (!isNaN(na) && !isNaN(nb) && na !== nb) return na - nb;
+      return a.localeCompare(b, undefined, { numeric: true });
+    });
+
+  for (const name of chapterDirs) {
+    const chapterPath = path.join(imagesDir, name);
+    let inner;
+    try {
+      inner = fs.readdirSync(chapterPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    const images = inner
+      .filter(
+        (f) =>
+          f.isFile() &&
+          IMAGE_EXTENSIONS.has(path.extname(f.name).toLowerCase().slice(1))
+      )
+      .map((f) => f.name)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    if (images.length === 0) continue;
+
+    let size = 0;
+    let mtime = "";
+    for (const img of images) {
+      try {
+        const st = fs.statSync(path.join(chapterPath, img));
+        size += st.size;
+        const iso = st.mtime.toISOString();
+        if (iso > mtime) mtime = iso;
+      } catch {}
+    }
+
+    if (!result.firstImagePath) {
+      result.firstImagePath = path.join(chapterPath, images[0]);
+    }
+    result.chapters.push({
+      name,
+      path: chapterPath,
+      imageCount: images.length,
+      size,
+      mtime,
+    });
+    result.chapterCount += 1;
+    result.imageCount += images.length;
+    result.imageBytes += size;
+    if (mtime > result.latestMtime) result.latestMtime = mtime;
+  }
+
+  return result;
+}
+
+/**
+ * On-device chapter NUMBERS for an image-only series, parsed from the
+ * images/Chapter_<n>/ tree. Mirrors getChaptersOnDevice's return contract
+ * (Set<string> of normalized number tokens like "5" / "5.5") so main.js's
+ * file-based update check can union them in. Non-numeric chapter folders are
+ * skipped — they can't be diffed against the numeric --list-chapters output.
+ *
+ * @param {string} folderPath - the series folder (NOT the images/ subdir)
+ * @returns {Set<string>}
+ */
+function getImageChaptersOnDevice(folderPath) {
+  const out = new Set();
+  const imagesDir = path.join(folderPath, "images");
+  let dirEntries;
+  try {
+    dirEntries = fs.readdirSync(imagesDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const d of dirEntries) {
+    if (!d.isDirectory()) continue;
+    const token = _imageChapterToken(d.name);
+    if (token == null) continue;
+    const num = parseFloat(token);
+    if (!isNaN(num)) out.add(String(num));
+  }
+  return out;
+}
+
+// ============================================================
 // SCAN LIBRARY
 // ============================================================
 
@@ -284,30 +453,42 @@ function scanLibrary(mangasDir, thumbCacheDir) {
       }
     }
 
-    // Skip empty folders (no output files)
-    if (files.length === 0) continue;
-
-    // ── Count chapters (if images/ exists from --keep-images) ──
-    let chapterCount = 0;
+    // ── Recognize the series + gather its stats ──
+    // Two shapes: archive series (≥1 pdf/epub/cbz) and image-only series
+    // (--format none → no archive, only images/Chapter_<n>/). For archive
+    // series we keep the historical cheap path (size from the archive files,
+    // chapter count from a dir-count). For image-only series we deep-walk
+    // images/ to recover the size/cover/rows that would otherwise come from
+    // the absent archive. Payload-required gate: a folder with neither an
+    // archive nor any image chapter isn't a real series — skip it (covers
+    // failed/empty downloads and metadata-only folders).
     const imagesDir = path.join(folderPath, "images");
-    if (fs.existsSync(imagesDir)) {
-      try {
-        chapterCount = fs
-          .readdirSync(imagesDir, { withFileTypes: true })
-          .filter(
-            (d) =>
-              d.isDirectory() &&
-              (d.name.startsWith("ch_") || d.name.startsWith("Chapter_"))
-          ).length;
-      } catch {}
-    }
+    const isImageOnly = files.length === 0;
 
-    // ── Compute totals ──
-    const totalSize = files.reduce((sum, f) => sum + f.size, 0);
-    const lastModified = files.reduce(
-      (latest, f) => (f.modifiedAt > latest ? f.modifiedAt : latest),
-      ""
-    );
+    let chapterCount = 0;
+    let totalSize = 0;
+    let lastModified = "";
+    let imageCount = 0;
+    let coverImagePath = null;
+    let imageChapters = null;
+
+    if (isImageOnly) {
+      const tree = scanImagesTree(imagesDir);
+      if (tree.chapterCount === 0) continue; // no payload → not a series
+      chapterCount = tree.chapterCount;
+      imageCount = tree.imageCount;
+      totalSize = tree.imageBytes;
+      coverImagePath = tree.firstImagePath;
+      imageChapters = tree.chapters;
+      lastModified = tree.latestMtime; // metadata-stamp fallback applied below
+    } else {
+      chapterCount = countImageChapterDirs(imagesDir);
+      totalSize = files.reduce((sum, f) => sum + f.size, 0);
+      lastModified = files.reduce(
+        (latest, f) => (f.modifiedAt > latest ? f.modifiedAt : latest),
+        ""
+      );
+    }
 
     // ── Check for series metadata (written by aio-dl.py) ──
     // .aio_series.json contains the source URL, downloaded chapters,
@@ -319,6 +500,12 @@ function scanLibrary(mangasDir, thumbCacheDir) {
       try {
         seriesMeta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
       } catch {}
+    }
+
+    // Image-only series can have undatable pages (rare). Fall back to the
+    // metadata download stamp so sort-by-date and "Modified …" still work.
+    if (isImageOnly && !lastModified && seriesMeta?.last_downloaded_at) {
+      lastModified = seriesMeta.last_downloaded_at;
     }
 
     // ── Check for cached thumbnail ──
@@ -363,6 +550,13 @@ function scanLibrary(mangasDir, thumbCacheDir) {
       totalSize,
       lastModified,
       seriesMeta,
+      // Image-only (--format none) extras. For archive series: false/0/null.
+      // coverImagePath = first page on disk (cover fallback when no web cover
+      // or PDF thumb). imageChapters = per-chapter rows for the detail view.
+      isImageOnly,
+      imageCount,
+      coverImagePath,
+      imageChapters,
     });
   }
 
@@ -666,4 +860,4 @@ function cleanupOrphanCovers(entries, thumbCacheDir) {
   return removed;
 }
 
-module.exports = { scanLibrary, saveThumbnail, generateMissingThumbnails, downloadMissingCovers, cleanupOrphanCovers, extractChaptersFromFiles, getChaptersOnDevice };
+module.exports = { scanLibrary, saveThumbnail, generateMissingThumbnails, downloadMissingCovers, cleanupOrphanCovers, extractChaptersFromFiles, getChaptersOnDevice, getImageChaptersOnDevice };

--- a/UI-source/electron/main.js
+++ b/UI-source/electron/main.js
@@ -24,7 +24,7 @@ const { Downloader } = require("./downloader");
 const { Searcher } = require("./searcher");
 const { HistoryManager } = require("./history");
 const { PythonSetup, isSetupComplete, deleteEnv, PYTHON_VERSION } = require("./setup");
-const { scanLibrary, generateMissingThumbnails, downloadMissingCovers, cleanupOrphanCovers, getChaptersOnDevice } = require("./library");
+const { scanLibrary, generateMissingThumbnails, downloadMissingCovers, cleanupOrphanCovers, getChaptersOnDevice, getImageChaptersOnDevice } = require("./library");
 
 // ── DEV MODE DEFAULTS ──
 // When running from source (npm run electron:dev), the app uses
@@ -1012,6 +1012,17 @@ function setupIPC() {
           diskFiles,
           (result.chapters || []).map(String)
         );
+        // --format none (image-only) series have no archive files for
+        // getChaptersOnDevice to read, so the diff above would mark every
+        // chapter "new". Recover the on-device set from the
+        // images/Chapter_<n>/ tree and union it in. (JSON mode below is
+        // unaffected — it reads chapters_downloaded, which aio-dl.py writes
+        // for every format including none.) grep getImageChaptersOnDevice.
+        if (diskFiles.length === 0) {
+          for (const c of getImageChaptersOnDevice(folderPath)) {
+            downloadedChapters.add(c);
+          }
+        }
         checkMode = "files";
       } else {
         // Use the JSON metadata list (what aio-dl.py recorded as downloaded)

--- a/UI-source/src/components/DownloadTab.jsx
+++ b/UI-source/src/components/DownloadTab.jsx
@@ -155,6 +155,15 @@ export default function DownloadTab({
   // Helper to update one form field
   const set = (key, value) => updateForm((prev) => ({ ...prev, [key]: value }));
 
+  // --webtoon-recompress needs an archive to write the converted pages into,
+  // so aio-dl.py rejects it for --format pdf/none (hard error at startup,
+  // see the --webtoon-recompress validation block ~aio-dl.py:6028). --komikku
+  // coerces format→cbz BEFORE that check (~aio-dl.py:5999), so recompress
+  // stays valid when Komikku is on regardless of the selected format button.
+  // Drives the toggle's disabled state + the handleStart emit guard below.
+  const recompressAllowed =
+    form.komikku || form.format === "cbz" || form.format === "epub";
+
   // Build CLI args from form state and trigger download
   const handleStart = () => {
     const urls = form.urls.split("\n").map((u) => u.trim()).filter(Boolean);
@@ -202,7 +211,10 @@ export default function DownloadTab({
     // through too so buildCliArgs can decide whether to forward them
     // (it only does when the master toggle is on AND the value differs
     // from the Python-side default, to keep the spawn line clean).
-    if (form.webtoonRecompress) {
+    // Guard on recompressAllowed so an incompatible combo (pdf/none without
+    // komikku) never reaches the CLI even if form.webtoonRecompress is stale-
+    // true from a saved default — aio-dl.py would hard-error on it otherwise.
+    if (form.webtoonRecompress && recompressAllowed) {
       args.webtoonRecompress = true;
       args.webtoonRecompressQuality = form.webtoonRecompressQuality;
       args.webtoonRecompressMethod = form.webtoonRecompressMethod;
@@ -291,6 +303,14 @@ export default function DownloadTab({
                   ...prev,
                   format: f.value,
                   ...(f.value === "none" ? { keepImages: true } : {}),
+                  // Picking PDF or None makes --webtoon-recompress invalid
+                  // (no archive to write the converted pages into), so auto-
+                  // clear it — the user can't launch the rejected combo. Skip
+                  // when Komikku is on: it coerces format→cbz, keeping
+                  // recompress valid (mirror of recompressAllowed).
+                  ...((f.value === "pdf" || f.value === "none") && !prev.komikku
+                    ? { webtoonRecompress: false }
+                    : {}),
                 }));
               }}
               className={cn(
@@ -485,12 +505,13 @@ export default function DownloadTab({
           <div className="flex items-start gap-3">
             <Switch
               id="webtoonRecompress"
-              checked={form.webtoonRecompress}
-              onCheckedChange={(v) => set("webtoonRecompress", v)}
+              checked={form.webtoonRecompress && recompressAllowed}
+              onCheckedChange={(v) => recompressAllowed && set("webtoonRecompress", v)}
+              disabled={!recompressAllowed}
               className="mt-0.5"
             />
             <div className="flex-1">
-              <Label htmlFor="webtoonRecompress" className="text-xs cursor-pointer">
+              <Label htmlFor="webtoonRecompress" className={cn("text-xs cursor-pointer", !recompressAllowed && "opacity-40")}>
                 Recompress lossless PNG pages to WebP (webtoons.com only)
               </Label>
               <p className="text-[10px] text-muted-foreground mt-0.5">
@@ -501,9 +522,16 @@ export default function DownloadTab({
                 files at q85 with no visible quality loss on phone-screen
                 viewing of color webtoons. Requires CBZ or EPUB output.
               </p>
+              {!recompressAllowed && (
+                <p className="text-[10px] text-yellow-500 dark:text-yellow-400 mt-1 leading-snug animate-slide-up">
+                  Unavailable with <span className="font-mono">{form.format.toUpperCase()}</span>{" "}
+                  output — recompression needs a CBZ or EPUB archive to write
+                  into. Switch to CBZ/EPUB (or enable Komikku) to use it.
+                </p>
+              )}
             </div>
           </div>
-          {form.webtoonRecompress && (
+          {form.webtoonRecompress && recompressAllowed && (
             <div className="pl-12 animate-slide-up grid grid-cols-2 gap-x-6 gap-y-3">
               <div>
                 <div className="flex items-center justify-between mb-1">

--- a/UI-source/src/components/LibraryTab.jsx
+++ b/UI-source/src/components/LibraryTab.jsx
@@ -37,6 +37,9 @@ const FORMAT_COLORS = {
   pdf: "bg-blue-500/20 text-blue-400 border-blue-500/30",
   epub: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
   cbz: "bg-orange-500/20 text-orange-400 border-orange-500/30",
+  // --format none (image-only) series. Badge text is "images" (see
+  // getEntryFormats); the per-chapter rows in the detail view reuse this too.
+  images: "bg-violet-500/20 text-violet-400 border-violet-500/30",
 };
 
 const STATUS_COLORS = {
@@ -72,8 +75,16 @@ function formatDate(isoString) {
   return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
-function getFormats(files) {
-  return [...new Set(files.map((f) => f.ext))];
+// Format badges for a series. Archive series derive them from their file
+// extensions; an image-only (--format none) series has no archive files, so
+// it gets a single synthetic "images" badge. Returns [] only for the
+// degenerate case of no files and not image-only (shouldn't happen — the
+// scanner's payload-required gate filters those out).
+function getEntryFormats(entry) {
+  const fileFormats = [...new Set((entry.files || []).map((f) => f.ext))];
+  if (fileFormats.length > 0) return fileFormats;
+  if (entry.isImageOnly) return ["images"];
+  return [];
 }
 
 /**
@@ -111,6 +122,21 @@ function PdfCover({ entry }) {
       />
     );
   }
+  // Image-only (--format none) fallback: no PDF to render and maybe no cached
+  // web cover yet, so show the first downloaded page straight from disk.
+  // Chromium decodes webp/avif/png/jpg/gif natively; object-cover crops the
+  // long-strip aspect. If a web cover later downloads, thumbPath wins on the
+  // next render (it's checked first). coverImagePath comes from library.js.
+  if (entry.coverImagePath) {
+    return (
+      <img
+        src={fileToUrl(entry.coverImagePath)}
+        alt={entry.title}
+        className="w-full h-full object-cover rounded"
+        loading="lazy"
+      />
+    );
+  }
   if (entry.coverPdfPath) {
     return <div className="w-full h-full bg-muted animate-pulse rounded" />;
   }
@@ -131,7 +157,7 @@ function PdfCover({ entry }) {
 // MANGA CARD (grid item)
 // ============================================================
 function MangaCard({ entry, newCount, onClick }) {
-  const formats = getFormats(entry.files);
+  const formats = getEntryFormats(entry);
   const status = entry.seriesMeta?.status;
 
   return (
@@ -190,7 +216,11 @@ function MangaCard({ entry, newCount, onClick }) {
         <div className="flex items-center gap-2 text-[10px] text-muted-foreground mt-0.5">
           <span>{formatSize(entry.totalSize)}</span>
           <span>&middot;</span>
-          <span>{entry.files.length} file{entry.files.length !== 1 ? "s" : ""}</span>
+          {entry.isImageOnly ? (
+            <span>{entry.imageCount} image{entry.imageCount !== 1 ? "s" : ""}</span>
+          ) : (
+            <span>{entry.files.length} file{entry.files.length !== 1 ? "s" : ""}</span>
+          )}
           {entry.chapterCount > 0 && (
             <>
               <span>&middot;</span>
@@ -540,6 +570,16 @@ function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, se
     }
   };
 
+  // Open a single chapter's image folder in the OS file explorer. Image-only
+  // (--format none) series have no archive files to "open", so the per-chapter
+  // rows in the Files section call this instead. openFolder → shell.openPath
+  // accepts any path (see main.js "open-folder" handler).
+  const handleOpenChapter = (chapterPath) => {
+    if (window.electronAPI?.openFolder) {
+      window.electronAPI.openFolder(chapterPath);
+    }
+  };
+
   const handleDelete = async () => {
     if (!confirmDelete) {
       // First click — show confirmation
@@ -563,7 +603,7 @@ function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, se
     }
   };
 
-  const formats = getFormats(entry.files);
+  const formats = getEntryFormats(entry);
   const meta = entry.seriesMeta;
 
   return (
@@ -620,7 +660,9 @@ function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, se
             <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
               <div className="flex items-center gap-1">
                 <FileText className="w-3.5 h-3.5" />
-                {entry.files.length} file{entry.files.length !== 1 ? "s" : ""}
+                {entry.isImageOnly
+                  ? `${entry.imageCount} image${entry.imageCount !== 1 ? "s" : ""}`
+                  : `${entry.files.length} file${entry.files.length !== 1 ? "s" : ""}`}
               </div>
               <div>{formatSize(entry.totalSize)}</div>
               {meta?.chapters_downloaded?.length > 0 && (
@@ -661,15 +703,21 @@ function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, se
                   Source
                 </Button>
               )}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowMetadataEditor((value) => !value)}
-                className="gap-1.5 text-xs"
-              >
-                <PencilLine className="w-3.5 h-3.5" />
-                Metadata
-              </Button>
+              {/* Embedded-metadata editing writes into a ComicInfo.xml inside
+                  the archive; image-only (--format none) series have no
+                  archive, so the editor has nothing to act on. Hide it there
+                  (MetadataEditorPanel also self-guards by returning null). */}
+              {entry.files.length > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowMetadataEditor((value) => !value)}
+                  className="gap-1.5 text-xs"
+                >
+                  <PencilLine className="w-3.5 h-3.5" />
+                  Metadata
+                </Button>
+              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -713,38 +761,70 @@ function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, se
           />
         </div>
 
-        {/* File list */}
+        {/* File list (archives) — or per-chapter image folders for image-only
+            (--format none) series, which have no archive to open. Each chapter
+            row opens its images/Chapter_<n>/ folder in the OS file explorer
+            (handleOpenChapter). imageChapters comes from library.js. */}
         <div className="mt-5">
           <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Files
+            {entry.isImageOnly ? "Chapters" : "Files"}
           </h3>
           <div className="space-y-1">
-            {entry.files.map((file) => (
-              <button
-                key={file.path}
-                onClick={() => handleOpenFile(file.path)}
-                className={cn(
-                  "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left",
-                  "bg-card/40 border border-border/30",
-                  "hover:bg-card/80 hover:border-primary/30",
-                  "transition-all duration-100 group"
-                )}
-              >
-                <span
-                  className={cn(
-                    "text-[9px] font-bold uppercase px-1.5 py-0.5 rounded border shrink-0",
-                    FORMAT_COLORS[file.ext] || "bg-muted text-muted-foreground border-border"
-                  )}
-                >
-                  {file.ext}
-                </span>
-                <span className="text-xs font-medium truncate flex-1">{file.name}</span>
-                <span className="text-[10px] text-muted-foreground shrink-0">
-                  {formatSize(file.size)}
-                </span>
-                <ExternalLink className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
-              </button>
-            ))}
+            {entry.isImageOnly
+              ? (entry.imageChapters || []).map((chap) => (
+                  <button
+                    key={chap.path}
+                    onClick={() => handleOpenChapter(chap.path)}
+                    className={cn(
+                      "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left",
+                      "bg-card/40 border border-border/30",
+                      "hover:bg-card/80 hover:border-primary/30",
+                      "transition-all duration-100 group"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "text-[9px] font-bold uppercase px-1.5 py-0.5 rounded border shrink-0",
+                        FORMAT_COLORS.images
+                      )}
+                    >
+                      IMG
+                    </span>
+                    <span className="text-xs font-medium truncate flex-1">
+                      {chap.name.replace(/_/g, " ")}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {chap.imageCount} img &middot; {formatSize(chap.size)}
+                    </span>
+                    <FolderOpen className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                  </button>
+                ))
+              : entry.files.map((file) => (
+                  <button
+                    key={file.path}
+                    onClick={() => handleOpenFile(file.path)}
+                    className={cn(
+                      "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left",
+                      "bg-card/40 border border-border/30",
+                      "hover:bg-card/80 hover:border-primary/30",
+                      "transition-all duration-100 group"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "text-[9px] font-bold uppercase px-1.5 py-0.5 rounded border shrink-0",
+                        FORMAT_COLORS[file.ext] || "bg-muted text-muted-foreground border-border"
+                      )}
+                    >
+                      {file.ext}
+                    </span>
+                    <span className="text-xs font-medium truncate flex-1">{file.name}</span>
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {formatSize(file.size)}
+                    </span>
+                    <ExternalLink className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                  </button>
+                ))}
           </div>
         </div>
       </div>

--- a/UI-source/src/components/SearchChapterMap.jsx
+++ b/UI-source/src/components/SearchChapterMap.jsx
@@ -18,6 +18,7 @@
 //   amber  = side stories       (X.5+ kept as content)
 //   cyan   = prologue           (chapter 0 / negatives)
 //   emerald = source-only latest (above peer max — fresh releases)
+//   sky    = merged split parts (X.1/X.2/X.3 with no integer X → one chapter)
 //   orange = source-only orphans (mid-range, suspicious but kept)
 //   rose   = fragments dropped  (.1/.2/.3/.4 source-only duplicates)
 // Grep target: buildBuckets in this file; classifier source in
@@ -82,6 +83,21 @@ function buildBuckets(breakdown, collapseApplied) {
       label: "orph",
       color: "text-orange-400/80",
       tooltip: `${breakdown.source_only_orphans} mid-range chapter${breakdown.source_only_orphans === 1 ? "" : "s"} peers don't have. Suspicious (possible re-released duplicates) but kept — could also be legit content.`,
+    });
+  }
+  if (breakdown.merged_split_fragments > 0) {
+    out.push({
+      key: "merged",
+      count: breakdown.merged_split_fragments,
+      sign: "+",
+      label: "merged",
+      color: "text-sky-400/75",
+      // Distinct from "drop": these are the extra rows of a no-integer
+      // split-cluster (X.1/X.2/X.3 → one chapter). The download path
+      // concatenates them into the parent — kept content, not duplicates.
+      // Sits right before the drop chip so "+N merged −M drop" reads as
+      // the two possible fates of fractional rows.
+      tooltip: `${breakdown.merged_split_fragments} split-upload part${breakdown.merged_split_fragments === 1 ? "" : "s"} concatenated into their parent chapter (an X.1/X.2/X.3 cluster with no plain integer X — joined into one downloaded chapter). Kept, not dropped.`,
     });
   }
   if (breakdown.fragments_dropped > 0) {
@@ -336,6 +352,10 @@ export default function SearchChapterMap({ chapterMap }) {
               <span className="inline-flex items-center gap-1">
                 <span className="inline-block w-1.5 h-1.5 rounded-sm bg-emerald-400/70" />
                 <span>ahead of peers</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-sm bg-sky-400/70" />
+                <span>merged splits</span>
               </span>
               <span className="inline-flex items-center gap-1">
                 <span className="inline-block w-1.5 h-1.5 rounded-sm bg-orange-400/70" />

--- a/UI-source/src/components/SettingsTab.jsx
+++ b/UI-source/src/components/SettingsTab.jsx
@@ -1,8 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import {
   Button, Input, Label, Select, Checkbox, Card, SectionHeader, Slider, Badge, Switch,
 } from "@/components/ui/primitives";
-import { Save, RotateCcw, FolderOpen, FileText, Package, Terminal, RefreshCw } from "lucide-react";
+import {
+  Save, RotateCcw, FolderOpen, FileText, Package, Terminal, RefreshCw,
+  Check, AlertTriangle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 
 // Same language list as DownloadTab/SearchTab. Duplicated rather than
 // importing to avoid pulling unrelated module deps; one row to add when
@@ -76,6 +80,202 @@ const DEV_DEFAULTS = {
   scriptPath: "",
   workingDir: "",
 };
+
+// ── Dirty diff for the Save Settings button ──
+// Compares the local in-memory settings draft against the most recently
+// hydrated `settings` prop (mirrors what's on disk via get-settings IPC).
+// Counts every key that differs across the top level + the two known
+// nested namespaces (defaults, searchOpts). `isPackaged` is excluded —
+// it's read-only from main.js and never persisted (see handleSave below).
+// Returns 0 when `settings` is nullish so the button doesn't blink an
+// inflated count during the ~50ms before the first get-settings IPC
+// resolves on mount.
+//
+// IMPORTANT: walks ONLY local's keys, not the union of local + settings.
+// history.js:saveSettings does a defensive merge (`{...this._settings,
+// ...filtered}`) so legacy or obsolete keys on disk (e.g. the
+// pre-2026-05-13 `mangafireImageConcurrency` left over after the rename
+// migration) survive every save indefinitely. Counting those in the
+// dirty diff would produce a phantom count the user can't act on —
+// the UI doesn't surface those fields, so there's no control to flip,
+// and clicking Save wouldn't bring the count down. By walking only
+// local's keys we count exactly the keys the user CAN influence via the
+// UI, which is the contract "Save Settings · N changed" implies.
+//
+// New-feature defaults backfilling missing keys (a new field added in
+// the UI's initial useState that older settings.json files don't have
+// yet) still surface as dirty — local has the key, settings doesn't,
+// `local[k] !== settings[k]` → counted. Saving flushes them to disk
+// and the count drops to 0 on the next render. That's correct: those
+// one-time inflations represent genuine on-disk work.
+// Cross-file: matches the shape of the initial useState below + the
+// migration logic in the settings-hydration useEffect + the merge in
+// electron/history.js:saveSettings.
+function countDirtySettings(local, settings) {
+  if (!settings) return 0;
+  const SKIP_TOP = new Set(["isPackaged"]);
+  const NESTED = ["defaults", "searchOpts"];
+  let count = 0;
+
+  for (const k of Object.keys(local)) {
+    if (SKIP_TOP.has(k) || NESTED.includes(k)) continue;
+    if (local[k] !== settings[k]) count++;
+  }
+
+  for (const ns of NESTED) {
+    const a = local[ns] || {};
+    const b = settings[ns] || {};
+    for (const k of Object.keys(a)) {
+      if (a[k] !== b[k]) count++;
+    }
+  }
+
+  return count;
+}
+
+// ── Save Settings button with dirty-state + confirmation sweep ──
+// Replaces the bare <Button> the footer used to render. Visual states:
+//   - idle/clean:   muted primary (bg-primary/60), Check icon, "Up to date"
+//   - idle/dirty:   full primary + amber ring + amber dot, Save icon,
+//                   "Save Settings · N changed"
+//   - in:           emerald-500 fill grows L→R from a pseudo-overlay span
+//                   over 280ms; label flips to "Saved" + Check icon
+//   - hold:         emerald fill held at scaleX(1) for ~900ms (driven
+//                   by the timer gap, not a separate phase)
+//   - out:          emerald fill shrinks scaleX(1)→scaleX(0) with the
+//                   origin flipped to right; takes 320ms then → idle
+//   - error:        bg-destructive, AlertTriangle icon, "Save failed";
+//                   auto-dismisses after 2500ms back to idle (which then
+//                   renders dirty because the hydration round-trip
+//                   never happened — dirty count stayed > 0)
+//
+// The L→R origin flip when entering 'out' is invisible: transform-origin
+// is NOT in the transition-property list, so it snaps instantly while
+// scaleX is still 1 (visually identical regardless of origin at scale 1),
+// then the scaleX(1)→scaleX(0) shrink runs against the new right origin.
+//
+// Cross-file coupling: `cn` from @/lib/utils (clsx + tailwind-merge).
+// Async onSave threads through SettingsTab.handleSave → useDownloader.
+// saveSettings (await window.electronAPI.saveSettings + setSettings) →
+// preload.js → electron/main.js's "save-settings" IPC handler →
+// history.js:saveSettings (volatile-path filter + atomic file write).
+// IPC currently resolves in <50ms locally, so the sweep is the dominant
+// duration the user actually perceives — any "loading" spinner state
+// would flash by too fast to register and isn't worth wiring up.
+function SaveSettingsButton({ dirty, onSave }) {
+  const [phase, setPhase] = useState("idle"); // 'idle' | 'in' | 'out' | 'error'
+  const timers = useRef([]);
+
+  useEffect(() => () => timers.current.forEach(clearTimeout), []);
+
+  const cancelTimers = () => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+  };
+
+  const handleClick = async () => {
+    if (phase !== "idle") return;
+
+    try {
+      await onSave();
+    } catch {
+      cancelTimers();
+      setPhase("error");
+      timers.current.push(setTimeout(() => setPhase("idle"), 2500));
+      return;
+    }
+
+    cancelTimers();
+    setPhase("in");
+    // 280ms sweep-in + 900ms hold + 320ms sweep-out ≈ 1500ms total. Two
+    // timers fire at the in→out boundary (1180ms) and the final reset
+    // to idle (1500ms); the sweep visual itself is driven by CSS
+    // transitions off the phase-derived className below.
+    timers.current.push(setTimeout(() => setPhase("out"), 1180));
+    timers.current.push(setTimeout(() => setPhase("idle"), 1500));
+  };
+
+  const isAnimating = phase === "in" || phase === "out";
+  const isErrored = phase === "error";
+  const isClean = dirty === 0;
+
+  const sweepScale = phase === "in" ? "scale-x-100" : "scale-x-0";
+  const sweepOrigin = phase === "out" ? "origin-right" : "origin-left";
+  const sweepDuration =
+    phase === "in" ? "duration-[280ms]" :
+    phase === "out" ? "duration-[320ms]" :
+    "duration-0";
+
+  let icon, label, baseColor, showAmberDot, ring;
+  if (isErrored) {
+    icon = <AlertTriangle className="w-4 h-4" />;
+    label = "Save failed";
+    baseColor = "bg-destructive text-destructive-foreground";
+    showAmberDot = false;
+    ring = "";
+  } else if (isAnimating) {
+    icon = <Check className="w-4 h-4" />;
+    label = "Saved";
+    // text-white reads cleanly over both bg-primary (under-sweep) and
+    // bg-emerald-500 (over-sweep) in both light + dark themes.
+    baseColor = "bg-primary text-white";
+    showAmberDot = false;
+    ring = "";
+  } else if (isClean) {
+    icon = <Check className="w-4 h-4" />;
+    label = "Up to date";
+    baseColor = "bg-primary/60 text-primary-foreground/90 hover:bg-primary/70";
+    showAmberDot = false;
+    ring = "";
+  } else {
+    icon = <Save className="w-4 h-4" />;
+    label = `Save Settings · ${dirty} changed`;
+    baseColor = "bg-primary text-primary-foreground hover:bg-primary/90";
+    showAmberDot = true;
+    ring = "ring-2 ring-amber-500/30";
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isAnimating || isErrored}
+      aria-busy={isAnimating}
+      aria-live="polite"
+      className={cn(
+        "relative overflow-hidden inline-flex flex-1 items-center justify-center gap-2",
+        "h-9 px-4 py-2 text-sm rounded-md font-medium shadow-sm",
+        "transition-colors duration-200",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        baseColor,
+        ring,
+      )}
+    >
+      {/* Sweep overlay — emerald fill driven by phase-derived classes.
+          Sits absolutely inside overflow-hidden so the rounded corners
+          clip the sweep; z-0 (implicit) keeps it behind the label span. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 bg-emerald-500 transition-transform ease-out",
+          sweepScale,
+          sweepOrigin,
+          sweepDuration,
+        )}
+      />
+      <span className="relative z-10 inline-flex items-center gap-2">
+        {showAmberDot && (
+          <span
+            aria-hidden="true"
+            className="w-1.5 h-1.5 rounded-full bg-amber-400 shadow-[0_0_4px_rgba(245,158,11,0.7)]"
+          />
+        )}
+        {icon}
+        {label}
+      </span>
+    </button>
+  );
+}
 
 export default function SettingsTab({ settings, onSave }) {
   // Local copy of settings so changes don't apply until you click Save
@@ -351,10 +551,22 @@ export default function SettingsTab({ settings, onSave }) {
       searchOpts: { ...prev.searchOpts, [key]: value },
     }));
 
-  const handleSave = () => {
-    // Don't save isPackaged — it's read-only from main.js
+  // Dirty count drives the SaveSettingsButton's pre-click visual
+  // ("Save Settings · N changed" + amber ring/dot when > 0, "Up to date"
+  // when 0). Recomputed cheaply on any local-state change; the diff
+  // walks ~30 top-level keys + ~25 nested keys, well under a frame.
+  // See countDirtySettings above for the migration-edge-case rationale.
+  const dirty = useMemo(() => countDirtySettings(local, settings), [local, settings]);
+
+  // Awaited (not fire-and-forget) so SaveSettingsButton can chain its
+  // sweep-in only after the IPC round-trip resolves successfully — and
+  // route to the 'error' branch if history.saveSettings throws (disk
+  // full, EACCES, etc.). Pre-change behavior dropped the promise; the
+  // failure was an unhandled rejection. `await onSave(saveable)`
+  // preserves the rejection so the button's try/catch sees it.
+  const handleSave = async () => {
     const { isPackaged, ...saveable } = local;
-    onSave(saveable);
+    await onSave(saveable);
   };
 
   const handleReset = () => {
@@ -1494,12 +1706,11 @@ export default function SettingsTab({ settings, onSave }) {
         </div>
       </div>
 
-      {/* Save/Reset buttons */}
+      {/* Save/Reset buttons. SaveSettingsButton (defined above) carries
+          its own dirty-state visual + post-save sweep + error branch;
+          the Reset stays a plain outline Button. */}
       <div className="flex-shrink-0 p-4 border-t bg-background/80 backdrop-blur-sm flex gap-2">
-        <Button onClick={handleSave} className="flex-1 gap-2">
-          <Save className="w-4 h-4" />
-          Save Settings
-        </Button>
+        <SaveSettingsButton dirty={dirty} onSave={handleSave} />
         <Button variant="outline" onClick={handleReset}>
           <RotateCcw className="w-4 h-4" />
         </Button>

--- a/UI-source/src/components/SettingsTab.jsx
+++ b/UI-source/src/components/SettingsTab.jsx
@@ -551,6 +551,16 @@ export default function SettingsTab({ settings, onSave }) {
       searchOpts: { ...prev.searchOpts, [key]: value },
     }));
 
+  // Whether the default --webtoon-recompress toggle is valid for the current
+  // default format. aio-dl.py rejects recompress with --format pdf/none (no
+  // archive to write into); --komikku coerces format→cbz first, so it's
+  // allowed then. Mirrors DownloadTab's recompressAllowed. Drives the default
+  // toggle's disabled state + the format-select auto-clear below.
+  const recompressAllowedDefault =
+    local.defaults.komikku ||
+    local.defaults.format === "cbz" ||
+    local.defaults.format === "epub";
+
   // Dirty count drives the SaveSettingsButton's pre-click visual
   // ("Save Settings · N changed" + amber ring/dot when > 0, "Up to date"
   // when 0). Recomputed cheaply on any local-state change; the diff
@@ -811,6 +821,13 @@ export default function SettingsTab({ settings, onSave }) {
                     ...prev.defaults,
                     format: next,
                     ...(next === "none" ? { keepImages: true } : {}),
+                    // PDF/None can't carry --webtoon-recompress (no archive to
+                    // write into; aio-dl.py hard-errors). Auto-clear the
+                    // default so we never save a contradictory combo. Skip
+                    // when Komikku is on — it coerces format→cbz.
+                    ...((next === "pdf" || next === "none") && !prev.defaults.komikku
+                      ? { webtoonRecompress: false }
+                      : {}),
                   },
                 }));
               }}
@@ -1406,21 +1423,30 @@ export default function SettingsTab({ settings, onSave }) {
         <div className="space-y-3">
           <div className="flex items-start gap-3">
             <Switch
-              checked={!!local.defaults.webtoonRecompress}
-              onCheckedChange={(v) => setDefault("webtoonRecompress", v)}
+              checked={!!local.defaults.webtoonRecompress && recompressAllowedDefault}
+              onCheckedChange={(v) => recompressAllowedDefault && setDefault("webtoonRecompress", v)}
+              disabled={!recompressAllowedDefault}
               className="mt-0.5"
             />
             <div className="flex-1">
-              <Label className="text-xs cursor-pointer">
+              <Label className={cn("text-xs cursor-pointer", !recompressAllowedDefault && "opacity-40")}>
                 Recompress webtoons.com pages to WebP
               </Label>
               <p className="text-[10px] text-muted-foreground mt-0.5">
                 Applies to every webtoons.com download — direct URL, search-
                 initiated, and library re-downloads.
               </p>
+              {!recompressAllowedDefault && (
+                <p className="text-[10px] text-yellow-500 dark:text-yellow-400 mt-1 leading-snug">
+                  Unavailable while the default format is{" "}
+                  <span className="font-mono">{(local.defaults.format || "").toUpperCase()}</span>{" "}
+                  — recompression needs CBZ or EPUB output. Change the default
+                  format above (or enable Komikku) to use it.
+                </p>
+              )}
             </div>
           </div>
-          {local.defaults.webtoonRecompress && (
+          {local.defaults.webtoonRecompress && recompressAllowedDefault && (
             <div className="pl-12 animate-slide-up grid grid-cols-2 gap-x-6 gap-y-3">
               <div>
                 <div className="flex items-center justify-between mb-1">

--- a/sites/chapter_merger.py
+++ b/sites/chapter_merger.py
@@ -355,6 +355,7 @@ def _classify_chapter_breakdown(
     chapters: List[Dict],
     consensus_set: Optional[Set[float]],
     consensus_max: Optional[float],
+    collapse_splits: bool = True,
 ) -> ChapterBreakdown:
     """Route each chapter dict into exactly one ChapterBreakdown bucket.
 
@@ -378,6 +379,16 @@ def _classify_chapter_breakdown(
     are dropped by the download path, and a genuine source-only fragment is
     never in the collapsed-floor consensus_set, so they keep landing in
     ``fragments_dropped``.
+
+    ``collapse_splits`` MUST match the value align_chapter_lists used to build
+    ``consensus_set`` (and that group_chapters_for_download will download
+    with). When False, group_chapters_for_download is in passthrough mode —
+    X.1/X.2/X.3 each download as their own chapter, nothing is merged — so the
+    Rule-5 branch is skipped entirely and every entry is classified per-decimal
+    against the (raw, un-collapsed) consensus_set. Surfacing a
+    ``merged_split_fragments`` count in that mode would claim a concatenation
+    the download never performs. Mirrors ``_classify_main_chapters``, which
+    returns ``len(numbers)`` (no collapse) under the same flag.
 
     When ``consensus_set`` is empty / None (single-source run or no peer
     overlap), there's no signal: integers go to ``consensus_main`` (we
@@ -432,21 +443,25 @@ def _classify_chapter_breakdown(
         decimals_rel = [n - floor for n in decimals]
 
         if (
-            not integer_present
+            collapse_splits
+            and not integer_present
             and len(decimals) >= 2
             and _is_sequential_split_decimals(decimals_rel)
         ):
             # Rule 5: {X.1, X.2, X.3} with no integer X → one merged chapter
             # at floor X. Count the floor once, the rest as merged (kept).
             # Mirrors group_chapters_for_download's Rule 5 (parts combined)
-            # and _classify_main_chapters' Rule 5 (effective += 1).
+            # and _classify_main_chapters' Rule 5 (effective += 1). Gated on
+            # collapse_splits: with collapse off the download path is
+            # passthrough (no merge), so we fall through to per-entry below.
             _bucket_integer_like(float(floor))
             bd.merged_split_fragments += len(decimals) - 1
             continue
 
-        # Rule 1/2/3a/3b/4/6: classify each raw entry independently. Identical
-        # to the pre-2026-05-29 per-chapter pass, so existing bucket counts
-        # for every non-Rule-5 shape are unchanged.
+        # Rule 1/2/3a/3b/4/6 (and EVERY shape when collapse_splits=False):
+        # classify each raw entry independently. Identical to the
+        # pre-2026-05-29 per-chapter pass, so existing bucket counts for every
+        # non-Rule-5 shape — and all shapes under collapse-off — are unchanged.
         for num, _ch in entries:
             if num == floor:
                 _bucket_integer_like(num)
@@ -742,6 +757,7 @@ def align_chapter_lists(
             list(raw_nums.values()),
             consensus_set=consensus_set,
             consensus_max=consensus_max,
+            collapse_splits=collapse_splits,
         )
         diag: Dict = {
             "role": meta["role"],

--- a/sites/chapter_merger.py
+++ b/sites/chapter_merger.py
@@ -464,18 +464,33 @@ def align_chapter_lists(
         Source order is the orchestrator's quality ranking (best first), but
         we pick the anchor as the source with the MOST chapters since the
         top-ranked source can be incomplete (DMCA-affected MangaDex with 1
-        chapter, or get_chapters parse failures returning 0 entries).
+        chapter, or get_chapters parse failures returning 0 entries). When
+        ``collapse_splits=True``, "most chapters" means most post-collapse
+        groups (so a 290-raw-row source dominated by sequential splits
+        doesn't outrank a 119-row source with cleanly numbered integers
+        covering the same canonical chapters).
       compatibility_threshold: minimum fraction of source's chapters that
         must overlap with the anchor's chapter-number set for a full merge.
         Sources below this threshold are partially merged (they appear in
         the map ONLY for chapter numbers that match anchor entries).
-      collapse_splits: controls how the diagnostic counts are reported.
-        When True (default), per-source `effective_chapters` collapses
-        split-cluster decimals (X.1/X.2/X.3 with no X) to ONE main chapter
-        each. When False, `effective_chapters == total_chapters`. See
-        `_classify_main_chapters` for the full rules. The chapter_map's
-        structure does NOT depend on this flag — collapse only affects the
-        displayed counts, not the per-chapter download alternatives.
+        Measured against post-collapse groups when ``collapse_splits=True``.
+      collapse_splits: when True (default), each source's chapter list is
+        pre-collapsed via ``_collapse_source_for_alignment`` BEFORE the
+        chapter_map is built — so a Rule-5 split-cluster {X.1, X.2, X.3}
+        on one source aligns with an integer {X} on another at the group's
+        floor X. The ``chapter_map`` ChapterMapEntry's ``chapter_num`` is
+        the post-collapse group key; the ``sources`` list carries the
+        synthesized chapter dict (with ``_merged_parts`` set on Rule-5
+        clusters) so a downstream alt-fetch via
+        ``_process_chapter_strict`` → ``_process_chapter_impl`` iterates
+        the parts and concatenates image streams.
+
+        When False, alignment keys are the raw chapter numbers from each
+        source's handler.get_chapters output — same shape as pre-2026-05-29.
+
+        Diagnostics (``total_chapters``, ``breakdown``) are ALWAYS computed
+        from the raw per-source counts regardless of this flag, so the UI's
+        "total entries" vs "effective chapters" gap remains visible.
 
     Returns:
       AlignmentResult with chapter_map (list of ChapterMapEntry sorted by
@@ -489,6 +504,8 @@ def align_chapter_lists(
     if the source's overall compatibility is above threshold).
 
     See snappy-forging-waffle.md for the design rationale (Phase 4 plan).
+    Collapse-aware alignment landed 2026-05-29 — see
+    ``_collapse_source_for_alignment`` for the motivating case.
     """
     if not sources_with_chapters:
         return AlignmentResult(
@@ -499,46 +516,73 @@ def align_chapter_lists(
             consensus_max=None,
         )
 
-    # Pick anchor by largest chapter set, breaking ties by orchestrator order
-    # (lower index = higher quality rank). A source returning 0 chapters
-    # (handler parse failure, DMCA hollowing) cannot be a useful anchor.
+    # Build BOTH a raw and a (possibly collapsed) per-source map upfront:
+    #   per_source_raw_nums  — raw {chap_num → chapter_dict}; used for
+    #     diagnostics (total_chapters, breakdown, _classify_main_chapters
+    #     input). Stable across collapse_splits so the UI's headline
+    #     entry-vs-main gap stays visible.
+    #   per_source_groups   — alignment view. When collapse_splits=True,
+    #     each source is run through _collapse_source_for_alignment so a
+    #     Rule-5 split-cluster {X.1, X.2, X.3} reduces to a single floor-X
+    #     entry whose dict carries _merged_parts. This is what feeds
+    #     anchor pick + anchor_index + consensus_set, so cross-source
+    #     matches happen at the user-facing chapter granularity.
+    # When collapse_splits=False, per_source_groups is literally identical
+    # to per_source_raw_nums (no work skipped, no behavior change).
+    per_source_raw_nums: Dict[str, Dict[float, Dict]] = {}
+    per_source_groups: Dict[str, Dict[float, Dict]] = {}
+    for site_name, chapters in sources_with_chapters:
+        # Raw view: every numeric chap once, dedup by first occurrence.
+        # Mirrors the original behavior — multiple entries with the same
+        # number on the same site (different scanlator versions on
+        # MangaDex, etc.) collapse to the first.
+        raw_nums: Dict[float, Dict] = {}
+        for ch in (chapters or []):
+            num = _extract_chapter_num(ch.get("chap"))
+            if num is None:
+                continue
+            if num in raw_nums:
+                continue
+            raw_nums[num] = ch
+        per_source_raw_nums[site_name] = raw_nums
+
+        if collapse_splits:
+            group_nums: Dict[float, Dict] = {}
+            for ch in _collapse_source_for_alignment(chapters or []):
+                num = _extract_chapter_num(ch.get("chap"))
+                if num is None or num in group_nums:
+                    continue
+                group_nums[num] = ch
+            per_source_groups[site_name] = group_nums
+        else:
+            per_source_groups[site_name] = raw_nums
+
+    # Pick anchor by largest GROUP set (post-collapse when collapse=True;
+    # raw otherwise — same as per_source_groups in that case). Breaks ties
+    # by orchestrator order (lower index = higher quality rank). A source
+    # returning 0 chapters (handler parse failure, DMCA hollowing) cannot
+    # be a useful anchor.
     def _anchor_priority(idx_and_pair):
-        idx, (_, chs) = idx_and_pair
-        return (-len(chs or []), idx)
+        idx, (site, _) = idx_and_pair
+        return (-len(per_source_groups.get(site, {})), idx)
 
     indexed = list(enumerate(sources_with_chapters))
     indexed.sort(key=_anchor_priority)
-    anchor_idx, (anchor_site, anchor_chapters) = indexed[0]
+    anchor_idx, (anchor_site, _) = indexed[0]
 
     # Reorder so anchor is first; the rest stay in original orchestrator order.
     reordered = [sources_with_chapters[anchor_idx]] + [
         sources_with_chapters[i] for i in range(len(sources_with_chapters)) if i != anchor_idx
     ]
     sources_with_chapters = reordered
-    anchor_site, anchor_chapters = sources_with_chapters[0]
+    anchor_site, _ = sources_with_chapters[0]
 
-    # Build per-source {chapter_num → chapter_dict} maps in a single upfront
-    # pass. Per-site dedup (keep first occurrence) matches the original loop
-    # behavior — multiple chapter entries with the same number on the same
-    # site (e.g. different scanlator versions on MangaDex) collapse to the
-    # first. Doing this upfront lets us compute consensus_set AFTER the
-    # cross-source merge but BEFORE writing diagnostics, so each source's
-    # breakdown is graded against the full peer set.
-    per_source_nums: Dict[str, Dict[float, Dict]] = {}
-    for site_name, chapters in sources_with_chapters:
-        source_nums: Dict[float, Dict] = {}
-        for ch in (chapters or []):
-            num = _extract_chapter_num(ch.get("chap"))
-            if num is None:
-                continue
-            if num in source_nums:
-                continue
-            source_nums[num] = ch
-        per_source_nums[site_name] = source_nums
-
-    # Seed anchor_index from the anchor's per-source map.
+    # Seed anchor_index from the anchor's GROUP map. When collapse_splits=True
+    # and the anchor has a Rule-5 cluster, ch here is the synthesized
+    # {chap=label, _merged_parts=[…]} dict so downstream alt selection feeds
+    # _process_chapter_impl's _merged_parts iterator with the right shape.
     anchor_index: Dict[float, ChapterMapEntry] = {}
-    for num, ch in per_source_nums[anchor_site].items():
+    for num, ch in per_source_groups[anchor_site].items():
         label = str(ch.get("chap") or "").strip() or f"{num:g}"
         anchor_index[num] = ChapterMapEntry(
             chapter_num=num,
@@ -549,6 +593,9 @@ def align_chapter_lists(
     # Track per-source overlap / compatibility / skipped_reason now;
     # _classify_main_chapters + breakdown computation is deferred until
     # AFTER consensus is known so the diagnostic counts incorporate it.
+    # Overlap + compatibility are measured against per_source_groups (the
+    # alignment view) — denominator is collapsed groups when collapse=True,
+    # matching the merge decision's granularity.
     per_source_meta: Dict[str, Dict] = {
         anchor_site: {
             "overlap": len(anchor_index),
@@ -560,8 +607,8 @@ def align_chapter_lists(
 
     # Process remaining sources: compute overlap, merge into anchor_index.
     for site_name, _chapters in sources_with_chapters[1:]:
-        source_nums = per_source_nums[site_name]
-        if not source_nums:
+        source_groups = per_source_groups[site_name]
+        if not source_groups:
             per_source_meta[site_name] = {
                 "overlap": 0,
                 "compatibility": 0.0,
@@ -570,8 +617,8 @@ def align_chapter_lists(
             }
             continue
 
-        overlap = len([n for n in source_nums if n in anchor_index])
-        compatibility = overlap / len(source_nums)
+        overlap = len([n for n in source_groups if n in anchor_index])
+        compatibility = overlap / len(source_groups)
         merge_orphans = compatibility >= compatibility_threshold
         per_source_meta[site_name] = {
             "overlap": overlap,
@@ -590,7 +637,7 @@ def align_chapter_lists(
         # per number. Non-overlapping chapters are added as orphan entries
         # ONLY if compatibility is above threshold, signaling the source
         # uses the same numbering scheme.
-        for num, ch in source_nums.items():
+        for num, ch in source_groups.items():
             if num in anchor_index:
                 anchor_index[num].sources.append((site_name, ch))
             elif merge_orphans:
@@ -607,32 +654,46 @@ def align_chapter_lists(
     # side) AND group_chapters_for_download (download side) to identify
     # source-only fragment-shaped decimals for duplicate detection. See
     # plan: ~/.claude/plans/ultrathink-mangafire-and-some-flickering-sparkle.md.
+    #
+    # With collapse_splits=True, consensus_set is keyed at post-collapse
+    # floors. Downstream group_chapters_for_download still queries this set
+    # with the raw chap_num (e.g. 52.1 not in {52.0} → fragment → drop),
+    # which is the same answer as the pre-fix consensus_set produced for
+    # Rule 2 fragments — the consensus shape only changes for Rule 3a/5
+    # (sequential splits), and those rules don't consult consensus_set.
     source_counts: Dict[float, int] = {}
     for entry in anchor_index.values():
         source_counts[entry.chapter_num] = len(entry.sources)
     consensus_set: Set[float] = {n for n, c in source_counts.items() if c >= 2}
     consensus_max: Optional[float] = max(consensus_set) if consensus_set else None
 
-    # Now compute per-source diagnostics with consensus in hand. The
-    # _classify_main_chapters call mirrors the consensus-refined drops in
-    # group_chapters_for_download, so the displayed "X main / Y entries"
-    # always matches what the download path emits when collapse is on.
+    # Per-source diagnostics: compute from per_source_raw_nums (RAW) so the
+    # UI's "total entries" vs "effective chapters" gap stays meaningful
+    # regardless of collapse_splits. The breakdown buckets use consensus_set
+    # to classify fragment-shaped source-only decimals; consensus_set is in
+    # collapsed-floor units when collapse=True, but the per-decimal `num in
+    # consensus_set` check still works because fragment decimals are never
+    # in a collapsed-floor consensus_set (52.1 never equals 52.0). For Rule
+    # 2 (X + X.k where peer also has X.k as a true side story), peer's X.k
+    # is preserved through collapse via Rule 2's "keep both when no
+    # consensus drop" path, so X.k still lands in consensus_set when peers
+    # confirm it.
     diagnostics: Dict[str, Dict] = {}
     for site_name, meta in per_source_meta.items():
-        source_nums = per_source_nums[site_name]
+        raw_nums = per_source_raw_nums[site_name]
         unique_main, effective = _classify_main_chapters(
-            list(source_nums.keys()),
+            list(raw_nums.keys()),
             collapse_splits=collapse_splits,
             consensus_set=consensus_set,
         )
         breakdown = _classify_chapter_breakdown(
-            list(source_nums.values()),
+            list(raw_nums.values()),
             consensus_set=consensus_set,
             consensus_max=consensus_max,
         )
         diag: Dict = {
             "role": meta["role"],
-            "total_chapters": len(source_nums),
+            "total_chapters": len(raw_nums),
             "unique_main_chapters": unique_main,
             "effective_chapters": effective,
             "matched_with_anchor": meta["overlap"],
@@ -940,6 +1001,72 @@ def group_chapters_for_download(
         ))
 
     return groups
+
+
+def _collapse_source_for_alignment(chapters: List[Dict]) -> List[Dict]:
+    """Pre-process a single source's chapter list into the same shape the
+    aio-dl.py download loop produces from ``group_chapters_for_download``.
+
+    Used by ``align_chapter_lists`` when ``collapse_splits=True`` so cross-
+    source matches happen at the GROUP LABEL's chapter number rather than at
+    each part's raw chapter number. Motivating case: mangafire emits chapter
+    29 as three rows {29.1, 29.2, 29.3} with no integer 29; peers
+    (atsumaru/weebcentral/etc.) emit it as a single integer 29. Without this
+    pre-collapse, alignment keys mangafire's parts at 29.1/29.2/29.3 and the
+    peer's chapter at 29.0 — they never match, so ``_process_chapter_strict``
+    looks up alts at chap_float=29.0 (the merged-group label) and finds
+    nothing. With pre-collapse, mangafire's Rule-5 cluster becomes a
+    synthesized dict labeled "29" keyed at 29.0, matching peers regardless of
+    whether the peer also splits or uses an integer.
+
+    Each output dict matches a shape downstream code already handles:
+      - Rule 1/2/3a/3b/4/6 (``len(parts) == 1``): the original chapter dict
+        with ``chap`` overridden to the group label when they differ (Rule 6
+        scattered-decimals case; everything else has matching labels by
+        construction).
+      - Rule 5 (sequential split-cluster, ``len(parts) > 1``): a synthesized
+        ``{**parts[0], "chap": group.label, "_merged_parts": parts}`` so
+        ``_process_chapter_impl`` iterates ``_merged_parts`` and concatenates
+        the per-part image streams. Mirrors aio-dl.py:7024-7028 which
+        produces the same shape for the primary's download list.
+
+    Always called with ``consensus_set=None``: the consensus IS what the
+    surrounding alignment is computing — chicken-and-egg. The download path
+    re-collapses the primary's list with the proper consensus_set returned
+    from alignment, which is where Rule 2 / 3b / 6 fragment drops actually
+    fire. This pre-collapse only needs to homogenize the keying across
+    sources for cross-source match — Rule 5 (sequential splits) does that
+    without needing consensus.
+
+    Cross-file:
+      - aio-dl.py:7003-7028 builds the same synthesized dicts for the
+        primary's download list; this helper mirrors that synthesis for each
+        alt source so alignment can match by post-collapse key.
+      - _process_chapter_impl reads ``ch.get("_merged_parts")`` at ~7488 and
+        iterates per-part. The alt's chapter dict in the alts payload feeds
+        directly into that path via _process_chapter_strict's alt loop.
+    """
+    if not chapters:
+        return []
+    groups = group_chapters_for_download(
+        chapters,
+        collapse_splits=True,
+        consensus_set=None,
+    )
+    collapsed: List[Dict] = []
+    for group in groups:
+        if len(group.parts) == 1:
+            ch = group.parts[0]
+            if str(ch.get("chap")) != group.label:
+                ch = {**ch, "chap": group.label}
+            collapsed.append(ch)
+        else:
+            collapsed.append({
+                **group.parts[0],
+                "chap": group.label,
+                "_merged_parts": group.parts,
+            })
+    return collapsed
 
 
 __all__ = [

--- a/sites/chapter_merger.py
+++ b/sites/chapter_merger.py
@@ -162,7 +162,8 @@ class ChapterBreakdown:
       safe_decimals            — fractional > 0, source-only, value ≥ .5 (kept as side story; cannot confidently call duplicate)
       prologue_count           — chapter num ≤ 0 (chapter 0, negatives — kept but not in main count)
       source_only_orphans      — integer ≥ 1, ≤ consensus_max, NOT in consensus (suspicious re-release; kept but flagged)
-      fragments_dropped        — fractional > 0, value ∈ {.1,.2,.3,.4}, NOT in consensus (Rule 2 refinement target: dropped when collapse ON)
+      fragments_dropped        — fractional > 0, value ∈ {.1,.2,.3,.4}, NOT in consensus, AND its floor group is NOT a no-integer sequential split (Rule 2/3a/3b/6 drop target: actually dropped when collapse ON)
+      merged_split_fragments   — the (parts-1) extra rows of a no-integer sequential split-cluster (Rule 5: {X.1,X.2,X.3} with no integer X). group_chapters_for_download CONCATENATES these into one downloaded chapter at floor X — they are kept, not dropped. The floor itself is counted once in consensus_main/source_only_latest/source_only_orphans. Distinguishing this from fragments_dropped is the whole reason this bucket exists (see _classify_chapter_breakdown).
       unparseable_passthrough  — _extract_chapter_num returned None (oneshots, omakes by name only)
 
     Why this dataclass exists alongside _classify_main_chapters:
@@ -185,6 +186,9 @@ class ChapterBreakdown:
     consensus_side_stories: int = 0
     safe_decimals: int = 0
     prologue_count: int = 0
+    # MERGED — no-integer sequential split parts concatenated into one
+    # downloaded chapter (Rule 5). Kept content, NOT dropped.
+    merged_split_fragments: int = 0
     # SUSPICIOUS — kept but flagged
     source_only_orphans: int = 0
     # DROPPED when collapse ON — flagged in UI as "N fragments dropped"
@@ -358,6 +362,23 @@ def _classify_chapter_breakdown(
     fragment-shape and consensus checks) so the displayed bucket counts
     always match what the download path actually emits when collapse is on.
 
+    GROUPS BY FLOOR (like ``_classify_main_chapters``) rather than judging
+    each decimal in isolation. This is load-bearing for the collapsed-
+    consensus world (2026-05-29): ``consensus_set`` is keyed at post-collapse
+    floors, so a no-integer sequential split-cluster {X.1, X.2, X.3} (Rule 5)
+    has its floor X.0 in consensus but none of its raw parts. A naive
+    per-decimal pass would test each part against consensus, miss it, and
+    dump all parts into ``fragments_dropped`` — but ``group_chapters_for_
+    download`` Rule 5 CONCATENATES those parts into one downloaded chapter,
+    so reporting them as "dropped" tells the user peer-confirmed content was
+    lost. Instead the cluster's floor is counted once (consensus_main /
+    source_only_latest / source_only_orphans) and the remaining parts go to
+    ``merged_split_fragments`` (kept). Every OTHER shape (Rule 1/2/3a/3b/4/6)
+    is still classified per-entry exactly as before — those decimals really
+    are dropped by the download path, and a genuine source-only fragment is
+    never in the collapsed-floor consensus_set, so they keep landing in
+    ``fragments_dropped``.
+
     When ``consensus_set`` is empty / None (single-source run or no peer
     overlap), there's no signal: integers go to ``consensus_main`` (we
     can't downgrade them), decimals ≥ .5 go to ``safe_decimals``, fragment-
@@ -370,6 +391,31 @@ def _classify_chapter_breakdown(
     """
     bd = ChapterBreakdown()
     has_consensus = bool(consensus_set)
+
+    def _bucket_integer_like(value: float) -> None:
+        # An integer chapter, OR the floor of a Rule-5 merged cluster.
+        # Same classification the original per-entry integer branch used.
+        if has_consensus and value in consensus_set:
+            bd.consensus_main += 1
+        elif has_consensus and consensus_max is not None and value > consensus_max:
+            bd.source_only_latest += 1
+        elif has_consensus:
+            bd.source_only_orphans += 1
+        else:
+            bd.consensus_main += 1
+
+    def _bucket_decimal(num: float, floor: int) -> None:
+        if has_consensus and num in consensus_set:
+            bd.consensus_side_stories += 1
+        elif _is_source_only_fragment(num, floor, consensus_set):
+            # Fragment-shaped (.1-.4), source-only, peer signal exists →
+            # would be dropped by the download path when collapse ON.
+            bd.fragments_dropped += 1
+        else:
+            # Either no peer signal, or decimal ≥ .5 — kept as safe extra.
+            bd.safe_decimals += 1
+
+    by_floor: Dict[int, List[Tuple[float, Dict]]] = {}
     for ch in chapters:
         num = _extract_chapter_num(ch.get("chap"))
         if num is None:
@@ -378,30 +424,35 @@ def _classify_chapter_breakdown(
         if num <= 0:
             bd.prologue_count += 1
             continue
-        floor = int(num)
-        is_integer = (num == floor)
-        if is_integer:
-            if has_consensus and num in consensus_set:
-                bd.consensus_main += 1
-            elif has_consensus and consensus_max is not None and num > consensus_max:
-                bd.source_only_latest += 1
-            elif has_consensus:
-                # Peer signal exists but this integer is mid-range and source-only.
-                bd.source_only_orphans += 1
+        by_floor.setdefault(int(num), []).append((num, ch))
+
+    for floor, entries in by_floor.items():
+        integer_present = any(n == floor for n, _ in entries)
+        decimals = sorted(n for n, _ in entries if n != floor)
+        decimals_rel = [n - floor for n in decimals]
+
+        if (
+            not integer_present
+            and len(decimals) >= 2
+            and _is_sequential_split_decimals(decimals_rel)
+        ):
+            # Rule 5: {X.1, X.2, X.3} with no integer X → one merged chapter
+            # at floor X. Count the floor once, the rest as merged (kept).
+            # Mirrors group_chapters_for_download's Rule 5 (parts combined)
+            # and _classify_main_chapters' Rule 5 (effective += 1).
+            _bucket_integer_like(float(floor))
+            bd.merged_split_fragments += len(decimals) - 1
+            continue
+
+        # Rule 1/2/3a/3b/4/6: classify each raw entry independently. Identical
+        # to the pre-2026-05-29 per-chapter pass, so existing bucket counts
+        # for every non-Rule-5 shape are unchanged.
+        for num, _ch in entries:
+            if num == floor:
+                _bucket_integer_like(num)
             else:
-                # No peer signal — treat as main (can't downgrade without data).
-                bd.consensus_main += 1
-        else:
-            # Fractional > 0
-            if has_consensus and num in consensus_set:
-                bd.consensus_side_stories += 1
-            elif _is_source_only_fragment(num, floor, consensus_set):
-                # Fragment-shaped (.1-.4), source-only, peer signal exists →
-                # would be dropped by the download path when collapse ON.
-                bd.fragments_dropped += 1
-            else:
-                # Either no peer signal, or decimal ≥ .5 — kept as safe extra.
-                bd.safe_decimals += 1
+                _bucket_decimal(num, floor)
+
     return bd
 
 
@@ -669,15 +720,16 @@ def align_chapter_lists(
 
     # Per-source diagnostics: compute from per_source_raw_nums (RAW) so the
     # UI's "total entries" vs "effective chapters" gap stays meaningful
-    # regardless of collapse_splits. The breakdown buckets use consensus_set
-    # to classify fragment-shaped source-only decimals; consensus_set is in
-    # collapsed-floor units when collapse=True, but the per-decimal `num in
-    # consensus_set` check still works because fragment decimals are never
-    # in a collapsed-floor consensus_set (52.1 never equals 52.0). For Rule
-    # 2 (X + X.k where peer also has X.k as a true side story), peer's X.k
-    # is preserved through collapse via Rule 2's "keep both when no
-    # consensus drop" path, so X.k still lands in consensus_set when peers
-    # confirm it.
+    # regardless of collapse_splits. consensus_set is in collapsed-floor units
+    # when collapse=True, so BOTH diagnostic classifiers group raw numbers by
+    # floor before consulting it: _classify_main_chapters always has, and
+    # _classify_chapter_breakdown now does too (2026-05-29 fix). That grouping
+    # is what lets a no-integer sequential split-cluster {X.1, X.2, X.3} be
+    # recognized as the single merged chapter at floor X (peer-confirmed via
+    # X.0 in consensus_set) rather than three raw decimals that each miss the
+    # collapsed consensus and get mislabeled as dropped fragments. For Rule 2
+    # (X + X.k where the .k is a true side story) the .k survives collapse as
+    # its own group, so it still lands in consensus_set when peers confirm it.
     diagnostics: Dict[str, Dict] = {}
     for site_name, meta in per_source_meta.items():
         raw_nums = per_source_raw_nums[site_name]

--- a/sites/quality_seed.json
+++ b/sites/quality_seed.json
@@ -22,7 +22,7 @@
   "violetscans": 0.82,
   "zeroscans": 0.80,
   "asmotoon": 0.80,
-  "atsumaru": 0.80,
+  "atsumaru": 0.85,
   "comix": 0.74,
   "boratscans": 0.78,
   "weebcentral": 0.72,

--- a/tests/test_chapter_merger.py
+++ b/tests/test_chapter_merger.py
@@ -9,6 +9,8 @@ into _process_chapter_impl's part-by-part fetch path.
 
 from __future__ import annotations
 
+from dataclasses import asdict
+
 from sites.chapter_merger import (
     AlignmentResult,
     ChapterBreakdown,
@@ -543,8 +545,8 @@ def test_breakdown_empty_input():
     assert isinstance(bd, ChapterBreakdown)
     assert all(getattr(bd, f) == 0 for f in [
         "consensus_main", "source_only_latest", "consensus_side_stories",
-        "safe_decimals", "prologue_count", "source_only_orphans",
-        "fragments_dropped", "unparseable_passthrough",
+        "safe_decimals", "prologue_count", "merged_split_fragments",
+        "source_only_orphans", "fragments_dropped", "unparseable_passthrough",
     ])
 
 
@@ -592,6 +594,60 @@ def test_breakdown_no_consensus_treats_everything_as_main_or_safe():
     assert bd.source_only_orphans == 0
 
 
+def test_breakdown_rule5_no_integer_cluster_is_merged_not_dropped():
+    """Regression for the collapsed-consensus miscount (2026-05-29 review):
+    a no-integer sequential split-cluster {29.1, 29.2, 29.3} whose FLOOR is
+    peer-confirmed (consensus keyed at 29.0) must NOT be reported as dropped
+    fragments. group_chapters_for_download Rule 5 concatenates the parts into
+    one downloaded chapter, so the floor counts once (consensus_main) and the
+    remaining two parts land in merged_split_fragments. Pre-fix this dumped
+    all three into fragments_dropped, which the UI renders as lost content."""
+    bd = _classify_chapter_breakdown(
+        [_ch("29.1"), _ch("29.2"), _ch("29.3")],
+        consensus_set={29.0},          # collapsed-floor consensus (peer has ch 29)
+        consensus_max=29.0,
+    )
+    assert bd.consensus_main == 1
+    assert bd.merged_split_fragments == 2
+    assert bd.fragments_dropped == 0
+    assert bd.safe_decimals == 0
+    assert bd.consensus_side_stories == 0
+    # Sum still equals the 3 raw entries.
+    assert sum(asdict(bd).values()) == 3
+
+
+def test_breakdown_rule5_source_only_cluster_counts_floor_once():
+    """A no-integer split-cluster the peers don't have at all: still merged
+    (Rule 5 collapses unconditionally), floor counted once by its position
+    relative to consensus_max — here 29 > max 10 so it's source_only_latest,
+    NOT dropped."""
+    bd = _classify_chapter_breakdown(
+        [_ch("29.1"), _ch("29.2"), _ch("29.3")],
+        consensus_set={10.0},          # peers top out at 10
+        consensus_max=10.0,
+    )
+    assert bd.source_only_latest == 1
+    assert bd.merged_split_fragments == 2
+    assert bd.fragments_dropped == 0
+    assert sum(asdict(bd).values()) == 3
+
+
+def test_breakdown_rule3a_integer_plus_sequential_still_drops():
+    """Guard the other side: {8, 8.1, 8.2, 8.3} (integer PRESENT + sequential
+    decimals) is Rule 3a — the download path keeps only the integer and DROPS
+    the decimals. So those three really are fragments_dropped, NOT merged.
+    Confirms the Rule-5 special-case is gated on the no-integer shape."""
+    bd = _classify_chapter_breakdown(
+        [_ch("8"), _ch("8.1"), _ch("8.2"), _ch("8.3")],
+        consensus_set={8.0},
+        consensus_max=8.0,
+    )
+    assert bd.consensus_main == 1       # the integer 8
+    assert bd.fragments_dropped == 3    # 8.1/8.2/8.3 dropped by Rule 3a
+    assert bd.merged_split_fragments == 0
+    assert sum(asdict(bd).values()) == 4
+
+
 def test_breakdown_shangri_la_frontier_dataset():
     """End-to-end test on the exact mangafire chapter list from the user's
     Shangri-La Frontier example (305 entries). Expected per the design
@@ -637,12 +693,14 @@ def test_breakdown_shangri_la_frontier_dataset():
     assert bd.consensus_side_stories == 0  # peers don't carry the .5s
     assert bd.source_only_latest == 0
     assert bd.source_only_orphans == 0
+    assert bd.merged_split_fragments == 0  # every .1 here has its integer (Rule 2/3b, not Rule 5)
     assert bd.unparseable_passthrough == 0
     # Sanity: bucket sum must equal input length.
     total = (
         bd.consensus_main + bd.source_only_latest + bd.consensus_side_stories
-        + bd.safe_decimals + bd.prologue_count + bd.source_only_orphans
-        + bd.fragments_dropped + bd.unparseable_passthrough
+        + bd.safe_decimals + bd.prologue_count + bd.merged_split_fragments
+        + bd.source_only_orphans + bd.fragments_dropped
+        + bd.unparseable_passthrough
     )
     assert total == 305
 
@@ -1017,6 +1075,30 @@ def test_align_collapse_consensus_set_uses_collapsed_floors():
         collapse_splits=True,
     )
     assert result.consensus_set == {29.0}
+
+
+def test_align_collapse_rule5_breakdown_not_reported_as_dropped():
+    """End-to-end regression (2026-05-29 review, Codex P2 'avoid marking
+    merged split parts as dropped'): cross-shape Rule-5 case — primary emits
+    chapter 29 as {29.1, 29.2, 29.3}, alt emits integer 29. The parts collapse
+    to one downloaded chapter 29 (peer-confirmed at floor 29.0), so primary's
+    diagnostics must show ONE main chapter + two merged split parts, never
+    three dropped fragments. Pre-fix the collapsed consensus_set ({29.0}) made
+    each raw .k miss consensus and inflate fragments_dropped, which
+    SearchChapterMap renders to the user as lost content."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=True,
+    )
+    bd = result.merge_diagnostics["primary"]["breakdown"]
+    assert bd["fragments_dropped"] == 0
+    assert bd["merged_split_fragments"] == 2
+    assert bd["consensus_main"] == 1   # floor 29 confirmed by alt's integer
+    # total_chapters stays raw (3) and the breakdown still sums to it.
+    assert result.merge_diagnostics["primary"]["total_chapters"] == 3
+    assert sum(bd.values()) == 3
     assert result.consensus_max == 29.0
 
 

--- a/tests/test_chapter_merger.py
+++ b/tests/test_chapter_merger.py
@@ -648,6 +648,25 @@ def test_breakdown_rule3a_integer_plus_sequential_still_drops():
     assert sum(asdict(bd).values()) == 4
 
 
+def test_breakdown_collapse_off_keeps_rule5_parts_per_entry():
+    """collapse_splits=False (2026-05-29 review): group_chapters_for_download
+    runs in passthrough mode — 29.1/29.2/29.3 each download as their own
+    chapter, nothing is merged — so the breakdown must NOT use the Rule-5
+    merged bucket. It classifies each part per-entry against the raw
+    consensus_set instead. Here peers carry the same raw parts, so all three
+    are confirmed side entries; merged_split_fragments stays 0."""
+    bd = _classify_chapter_breakdown(
+        [_ch("29.1"), _ch("29.2"), _ch("29.3")],
+        consensus_set={29.1, 29.2, 29.3},   # raw consensus keys when collapse off
+        consensus_max=29.3,
+        collapse_splits=False,
+    )
+    assert bd.merged_split_fragments == 0
+    assert bd.consensus_side_stories == 3
+    assert bd.fragments_dropped == 0
+    assert sum(asdict(bd).values()) == 3
+
+
 def test_breakdown_shangri_la_frontier_dataset():
     """End-to-end test on the exact mangafire chapter list from the user's
     Shangri-La Frontier example (305 entries). Expected per the design
@@ -1075,6 +1094,7 @@ def test_align_collapse_consensus_set_uses_collapsed_floors():
         collapse_splits=True,
     )
     assert result.consensus_set == {29.0}
+    assert result.consensus_max == 29.0
 
 
 def test_align_collapse_rule5_breakdown_not_reported_as_dropped():
@@ -1099,7 +1119,26 @@ def test_align_collapse_rule5_breakdown_not_reported_as_dropped():
     # total_chapters stays raw (3) and the breakdown still sums to it.
     assert result.merge_diagnostics["primary"]["total_chapters"] == 3
     assert sum(bd.values()) == 3
-    assert result.consensus_max == 29.0
+
+
+def test_align_collapse_off_breakdown_has_no_merged_bucket():
+    """Complementary guard (2026-05-29 review, Codex P2 'keep split
+    diagnostics raw when collapse is off'): with collapse_splits=False the
+    chapter_map keeps 29.1/29.2/29.3 as three separate entries (passthrough
+    download) and consensus_set is keyed at the raw parts. The per-source
+    breakdown must therefore classify them per-entry — merged_split_fragments
+    stays 0 — so the UI never claims a concatenation the download didn't do."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=False,
+    )
+    bd = result.merge_diagnostics["primary"]["breakdown"]
+    assert bd["merged_split_fragments"] == 0
+    assert bd["consensus_side_stories"] == 3   # raw parts peer-confirmed
+    assert bd["fragments_dropped"] == 0
+    assert sum(bd.values()) == 3
 
 
 def test_align_collapse_alts_payload_shape_for_strict_wrapper():

--- a/tests/test_chapter_merger.py
+++ b/tests/test_chapter_merger.py
@@ -15,6 +15,7 @@ from sites.chapter_merger import (
     ChapterGroup,
     _classify_chapter_breakdown,
     _classify_main_chapters,
+    _collapse_source_for_alignment,
     _format_chapter_label,
     _extract_chapter_num,
     _is_fragment_shaped_decimal,
@@ -741,3 +742,318 @@ def test_align_classifies_source_only_dot_one_as_fragment():
     bd_b = result.merge_diagnostics["b"]["breakdown"]
     assert bd_b["consensus_main"] == 1
     assert bd_b["fragments_dropped"] == 0
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _collapse_source_for_alignment  (2026-05-29)
+#
+# Pre-collapse helper used by align_chapter_lists when collapse_splits=True
+# so cross-source matches happen at the post-collapse group label rather
+# than at each part's raw chapter number. Each test checks the helper's
+# output shape mirrors what aio-dl.py:7003-7028 produces for the primary's
+# download list — same labels, same _merged_parts on Rule-5 clusters.
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_collapse_helper_rule_5_synthesizes_merged_parts():
+    """Rule 5 (sequential split-cluster, no integer parent): output is a
+    single synthesized dict with chap=floor label and _merged_parts holding
+    the original part dicts in ascending order. This is the shape
+    _process_chapter_impl iterates when an alt is picked for a primary's
+    Rule-5 chapter (the angel-next-door ch 29 case)."""
+    parts = [_ch("29.2"), _ch("29.1"), _ch("29.3")]  # unsorted input
+    out = _collapse_source_for_alignment(parts)
+    assert len(out) == 1
+    assert out[0]["chap"] == "29"
+    mp = out[0].get("_merged_parts")
+    assert mp is not None
+    assert [p["chap"] for p in mp] == ["29.1", "29.2", "29.3"]
+
+
+def test_collapse_helper_rule_1_passthrough():
+    """Rule 1 (integer only, no decimals): chapter dict passes through
+    with chap unchanged; no _merged_parts."""
+    out = _collapse_source_for_alignment([_ch("29")])
+    assert len(out) == 1
+    assert out[0]["chap"] == "29"
+    assert "_merged_parts" not in out[0]
+
+
+def test_collapse_helper_rule_4_singleton_partial_keeps_label():
+    """Rule 4 (no integer, lone decimal like 29.5): keeps the decimal
+    label, no _merged_parts. Aligns with peer sources that also have a
+    standalone 29.5 — not with a peer's integer 29."""
+    out = _collapse_source_for_alignment([_ch("29.5")])
+    assert len(out) == 1
+    assert out[0]["chap"] == "29.5"
+    assert "_merged_parts" not in out[0]
+
+
+def test_collapse_helper_rule_3a_drops_decimals():
+    """Rule 3a (integer + sequential decimals): only the integer survives
+    — decimals are treated as upload fragments of the integer chapter.
+    The post-collapse view should be a single dict at the integer."""
+    out = _collapse_source_for_alignment(
+        [_ch("1"), _ch("1.1"), _ch("1.2"), _ch("1.3")],
+    )
+    assert len(out) == 1
+    assert out[0]["chap"] == "1"
+    assert "_merged_parts" not in out[0]
+
+
+def test_collapse_helper_empty_input():
+    assert _collapse_source_for_alignment([]) == []
+
+
+def test_collapse_helper_preserves_non_chap_fields():
+    """The synthesized dict for Rule 5 carries forward the original
+    fields from parts[0] (url, hid, etc.) — handlers downstream depend on
+    these to fetch images."""
+    parts = [
+        {"chap": "1.1", "url": "https://x/1.1", "hid": "abc"},
+        {"chap": "1.2", "url": "https://x/1.2", "hid": "def"},
+    ]
+    out = _collapse_source_for_alignment(parts)
+    assert len(out) == 1
+    # parts[0] (after sort) is the 1.1 dict
+    assert out[0]["url"] == "https://x/1.1"
+    assert out[0]["hid"] == "abc"
+    # And _merged_parts holds the originals untouched.
+    assert out[0]["_merged_parts"][0] is parts[0] or out[0]["_merged_parts"][0]["chap"] == "1.1"
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Collapse-aware align_chapter_lists  (2026-05-29)
+#
+# The chapter_map's keys depend on collapse_splits when True. This is the
+# fix for the bug where mangafire's {29.1, 29.2, 29.3} cluster never
+# matched peers' integer 29 (or peers' identical Rule-5 cluster) at the
+# strict-wrapper's chap_float=29.0 lookup. See git log for context and
+# the diagnostic script _diag_ch29_alts.py.
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_align_collapse_rule_5_both_sides_match_at_floor():
+    """Same-shape case: both sources emit chapter 29 as {29.1, 29.2, 29.3}
+    with no integer 29. With collapse_splits=True, alignment keys them at
+    the floor (29.0) so the strict-wrapper's lookup finds the alt; without
+    the fix it would key at 29.1/29.2/29.3 separately and the wrapper's
+    chap_float=29.0 lookup would miss."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=True,
+    )
+    nums = sorted(e.chapter_num for e in result.chapter_map)
+    assert nums == [29.0]
+    entry = result.chapter_map[0]
+    assert entry.chapter_label == "29"
+    sites = {s for s, _ in entry.sources}
+    assert sites == {"primary", "alt"}
+    # Alt's stored chapter dict carries _merged_parts so a downstream
+    # alt-fetch via _process_chapter_impl iterates the parts.
+    for site, ch_dict in entry.sources:
+        assert ch_dict.get("chap") == "29"
+        assert [p["chap"] for p in ch_dict["_merged_parts"]] == [
+            "29.1", "29.2", "29.3",
+        ]
+
+
+def test_align_collapse_rule_5_cross_shape_matches_integer_peer():
+    """Cross-shape case (the canonical reason for the fix): primary emits
+    chapter 29 as Rule-5 splits {29.1, 29.2, 29.3}; alt emits integer 29.
+    Both must align at floor 29.0 so the strict-wrapper finds the alt.
+    Primary's stored dict carries _merged_parts (for primary-side
+    download); alt's stored dict is the integer (no _merged_parts)."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=True,
+    )
+    nums = sorted(e.chapter_num for e in result.chapter_map)
+    assert nums == [29.0]
+    entry = result.chapter_map[0]
+    sites = {s for s, _ in entry.sources}
+    assert sites == {"primary", "alt"}
+    # Primary's stored dict has the synthesized merged-parts shape;
+    # alt's stored dict is the raw integer (no _merged_parts).
+    for site, ch_dict in entry.sources:
+        assert ch_dict.get("chap") == "29"
+        if site == "primary":
+            assert "_merged_parts" in ch_dict
+            assert [p["chap"] for p in ch_dict["_merged_parts"]] == [
+                "29.1", "29.2", "29.3",
+            ]
+        else:
+            assert "_merged_parts" not in ch_dict
+
+
+def test_align_collapse_off_preserves_raw_keying():
+    """When collapse_splits=False, the chapter_map keys are the raw
+    per-source chapter numbers — same as pre-fix behavior. The Rule-5
+    cluster on the primary stays as three separate entries; alt's
+    integer 29 lands at 29.0 IFF its compatibility with the anchor
+    passes the merge-orphans threshold. Here primary is anchor (3 vs 1
+    entries) and alt has 0 overlap with primary's {29.1, 29.2, 29.3},
+    so compatibility=0 and alt's 29.0 is NOT added as orphan. This is
+    the canonical pre-fix shape that motivated collapse-aware alignment."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=False,
+    )
+    nums = sorted(e.chapter_num for e in result.chapter_map)
+    # Only the primary's raw entries — alt's 29.0 dropped by compatibility
+    # threshold. The whole point of the collapse-aware fix is that with
+    # collapse_splits=True these collapse to a single 29.0 entry that
+    # picks up the alt naturally (see test_align_collapse_rule_5_*).
+    assert nums == [29.1, 29.2, 29.3]
+    by_num = {e.chapter_num: e for e in result.chapter_map}
+    assert {s for s, _ in by_num[29.1].sources} == {"primary"}
+    assert {s for s, _ in by_num[29.2].sources} == {"primary"}
+    assert {s for s, _ in by_num[29.3].sources} == {"primary"}
+
+
+def test_align_collapse_off_with_high_compatibility_keeps_alt_orphan():
+    """When collapse_splits=False AND the alt's overall overlap with the
+    anchor is high enough (≥50%), an integer-29 alt CAN appear as an
+    orphan at 29.0 even though mangafire's split shape didn't match.
+    This is the historical 'mangafire as anchor, atsumaru's overlap on
+    integer chapters carries' shape — but the strict-wrapper lookup at
+    chap_float=29.0 (post-merged-group label) still misses because the
+    primary's per-source-nums view doesn't have 29.0 either. That bug
+    is exactly what collapse_splits=True now fixes."""
+    primary = [_ch(str(n)) for n in range(1, 29)] + [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch(str(n)) for n in range(1, 30)]  # integers 1..29
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=False,
+    )
+    nums = sorted(e.chapter_num for e in result.chapter_map)
+    # 29.0 IS in the map (alt orphan, compatibility ~96%).
+    assert 29.0 in nums
+    assert 29.1 in nums
+    assert 29.2 in nums
+    assert 29.3 in nums
+    by_num = {e.chapter_num: e for e in result.chapter_map}
+    assert {s for s, _ in by_num[29.0].sources} == {"alt"}
+    assert {s for s, _ in by_num[29.1].sources} == {"primary"}
+
+
+def test_align_collapse_anchor_pick_uses_collapsed_counts():
+    """Anchor pick uses post-collapse group counts so a source with many
+    raw split entries doesn't outrank a source with fewer entries but
+    more user-facing chapters. Source A has 5 raw entries collapsing to
+    2 groups; source B has 3 raw entries that are 3 distinct chapters.
+    Anchor should be B (3 collapsed groups > 2)."""
+    a = [_ch("1.1"), _ch("1.2"), _ch("1.3"), _ch("2.1"), _ch("2.2")]
+    b = [_ch("1"), _ch("2"), _ch("3")]
+    result = align_chapter_lists(
+        [("a", a), ("b", b)],
+        collapse_splits=True,
+    )
+    # b becomes anchor because it has 3 groups vs a's 2.
+    anchor_site = next(
+        site for site, d in result.merge_diagnostics.items()
+        if d.get("role") == "anchor"
+    )
+    assert anchor_site == "b"
+
+
+def test_align_collapse_diagnostics_use_raw_counts():
+    """total_chapters and breakdown remain raw-counted regardless of
+    collapse_splits, so the UI's "X entries vs Y main" gap stays visible.
+    Source A has 5 raw entries that collapse to 2 groups — total_chapters
+    must still be 5, and the breakdown must still sum to 5."""
+    a = [_ch("1.1"), _ch("1.2"), _ch("1.3"), _ch("2.1"), _ch("2.2")]
+    b = [_ch("1"), _ch("2")]
+    result = align_chapter_lists(
+        [("a", a), ("b", b)],
+        collapse_splits=True,
+    )
+    diag_a = result.merge_diagnostics["a"]
+    assert diag_a["total_chapters"] == 5
+    # Breakdown should sum to total (every raw chapter lands in exactly
+    # one bucket).
+    bd = diag_a["breakdown"]
+    assert sum(bd.values()) == 5
+
+
+def test_align_collapse_orphan_path_uses_collapsed_keys():
+    """Source B is anchor; source A's collapsed cluster {1.1, 1.2, 1.3} →
+    floor 1 should land in anchor_index via the orphan path (because A
+    has high compatibility with B for the other chapters), keyed at 1.0
+    not 1.1/1.2/1.3. Critical for the case where primary doesn't have
+    chapter X but an alt does as a Rule-5 cluster — the alt's cluster
+    contributes to the chapter_map at the floor."""
+    a = [_ch("1.1"), _ch("1.2"), _ch("1.3"), _ch("2"), _ch("3")]
+    b = [_ch("2"), _ch("3"), _ch("4"), _ch("5")]
+    result = align_chapter_lists(
+        [("a", a), ("b", b)],
+        collapse_splits=True,
+    )
+    nums = sorted(e.chapter_num for e in result.chapter_map)
+    # b is anchor (4 groups vs a's 3). a's 1 → orphan at floor.
+    # Expected: 1, 2, 3, 4, 5 — five floors, no fractional splits.
+    assert nums == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+
+def test_align_collapse_consensus_set_uses_collapsed_floors():
+    """consensus_set is keyed at collapsed floors when collapse_splits=True.
+    For the canonical case ({29.1, .2, .3} on both sources), consensus is
+    {29.0}, not {29.1, 29.2, 29.3}. Critical: downstream
+    group_chapters_for_download still checks `num in consensus_set` per
+    decimal — fragment decimals (52.1) are never in a collapsed-floor
+    consensus_set ({52.0}), which is the correct answer for Rule 2's
+    fragment drop, so the consensus shape change doesn't regress that
+    rule's behavior."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=True,
+    )
+    assert result.consensus_set == {29.0}
+    assert result.consensus_max == 29.0
+
+
+def test_align_collapse_alts_payload_shape_for_strict_wrapper():
+    """End-to-end shape check: when collapse_splits=True and primary has
+    a Rule-5 cluster while an alt has the same cluster, the per-chapter
+    alternatives_by_chap_num shape (as built by find_alternatives_for_direct_url
+    and build_alternatives_from_prefetched) keys at the floor and stores
+    the alt's synthesized merged-parts dict.
+
+    This test mirrors what those callers do — iterating chapter_map
+    entries, filtering out the primary, and packaging the alt's stored
+    chapter dict. _process_chapter_strict's lookup at chap_float=floor
+    should now find this entry."""
+    primary = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    alt = [_ch("29.1"), _ch("29.2"), _ch("29.3")]
+    result = align_chapter_lists(
+        [("primary", primary), ("alt", alt)],
+        collapse_splits=True,
+    )
+    alts_by_floor = {}
+    for entry in result.chapter_map:
+        alts = [
+            {"site": site, "chapter": ch_dict}
+            for site, ch_dict in entry.sources
+            if site != "primary"
+        ]
+        if alts:
+            alts_by_floor[entry.chapter_num] = alts
+    # Strict wrapper looks up chap_float=29.0 (from synthesized
+    # primary group label "29"). Pre-fix would miss; post-fix hits.
+    assert 29.0 in alts_by_floor
+    alts_29 = alts_by_floor[29.0]
+    assert len(alts_29) == 1
+    assert alts_29[0]["site"] == "alt"
+    # Alt's chapter dict has _merged_parts so _process_chapter_impl
+    # iterates the parts using the swapped-in alt handler.
+    assert [p["chap"] for p in alts_29[0]["chapter"]["_merged_parts"]] == [
+        "29.1", "29.2", "29.3",
+    ]


### PR DESCRIPTION
## Summary

Two independent changes bundled together:

**1. Collapse-aware cross-source chapter alignment** (`sites/chapter_merger.py`, `sites/quality_seed.json`)
`align_chapter_lists` now pre-collapses each source's split-clusters *before* building the chapter_map, so cross-source matches happen at the user-facing chapter granularity instead of at raw decimal parts. Fixes the case where a split-heavy primary (mangafire emitting `{29.1, 29.2, 29.3}` with no integer 29) failed to align with integer-keyed peers (atsumaru/weebcentral/…), leaving a `--multi-source` alt-fetch empty at the merged-group label (29.0).

- New `_collapse_source_for_alignment()` mirrors the synthesized-dict shape the download loop produces from `group_chapters_for_download` (Rule-5 clusters carry `_merged_parts` so `_process_chapter_impl` concatenates the per-part image streams).
- Anchor pick + overlap/compatibility + `consensus_set` are measured against the post-collapse group view; diagnostics (`total_chapters`, `breakdown`) are still computed from RAW counts so the UI's "total entries vs effective chapters" gap stays visible.
- `collapse_splits=False` path is byte-identical to prior behavior.
- `quality_seed`: atsumaru prior `0.80 → 0.85` (reliable integer-keyed fallback for split-heavy primaries).

**2. Save-button confirmation UX** (`UI-source/src/components/SettingsTab.jsx`)
The Settings Save button gave no feedback on click and no signal that edits were pending. It now shows a dirty count ("Save Settings · N changed" + amber ring/dot when edits pending; muted "Up to date" when clean) and plays an emerald L→R confirmation sweep with a "Saved" label on success, plus a destructive "Save failed" branch (`handleSave` is now awaited). The dirty diff walks only the local draft's keys, so legacy on-disk keys preserved by the settings merge don't surface as a phantom, uncloseable count.

A `.gitignore` chore commit keeps per-session scratch probes and local build dirs out of `git status`.

## Test plan

- [x] `pytest tests/test_chapter_merger.py` — 74 passed (15 new `test_collapse_helper_*` / `test_align_collapse_*`)
- [x] `python -c "import sites.search_orchestrator"` — imports clean, torch stays lazy
- [x] `npm run build` (UI-source) — 1262 modules, no errors
- [ ] Manual UI: edit a Settings field → confirm dirty count + amber ring; click Save → confirm emerald sweep + "Saved" → settles to "Up to date"
- [ ] Manual e2e: `--multi-source` download of a split-heavy series (e.g. mangafire ch. 29) confirms alt-fetch now resolves against integer-keyed peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)