### PR TITLE
AniList genre normalization: drop site genre dumps, scope mangakatana, in-place library refresh

### DIFF
--- a/aio-dl.py
+++ b/aio-dl.py
@@ -5076,6 +5076,357 @@ def _consume_image_prefetch(chap_label: str) -> None:
         _image_prefetch_done.pop(chap_label, None)
 
 
+# ---------------------------------------------------------------------------
+# --refresh-library-metadata mode (in-place AniList re-enrichment)
+# ---------------------------------------------------------------------------
+# Repairs an existing library WITHOUT re-downloading images: re-pulls AniList
+# metadata for each already-downloaded series and rewrites details.json +
+# .aio_series.json (and optionally each CBZ's ComicInfo.xml). Exists because
+# the genre-normalization fix (external_metadata REPLACE semantics + the
+# mangakatana selector scoping, 2026-06-06) only affects FUTURE downloads;
+# series grabbed before the fix keep their 50+-tag taxonomy dumps on disk
+# until refreshed. Dispatched from main() right after --update-all.
+
+def _serialize_anilist_tag(t: Any) -> Dict[str, Any]:
+    """AnilistTag dataclass -> .aio_series.json tag dict.
+
+    Schema parity with the live-download writer (grep '_tag_to_dict' /
+    'anilist_tags' near series_meta). Duck-typed via getattr so a plain
+    dict already in the right shape would also pass through.
+    """
+    return {
+        "name": getattr(t, "name", "") or "",
+        "category": getattr(t, "category", "") or "",
+        "rank": int(getattr(t, "rank", 0) or 0),
+        "is_media_spoiler": bool(getattr(t, "is_media_spoiler", False)),
+        "is_general_spoiler": bool(getattr(t, "is_general_spoiler", False)),
+    }
+
+
+def _rewrite_cbz_comicinfo(
+    folder: str,
+    comic_data: Dict[str, Any],
+    series_title: str,
+    lang_default: str,
+) -> int:
+    """Rewrite enrichment elements in every chapter CBZ's ComicInfo.xml, in
+    place, preserving all per-chapter fields. Returns the count updated.
+
+    Used only by _refresh_library_metadata when --refresh-rewrite-cbz is set.
+    For each .cbz: parse the per-chapter fields we must NOT lose
+    (Title/Number/Volume/Translator/Web/Year-Month-Day/LanguageISO/PageCount/
+    Publisher), then rebuild the whole ComicInfo via
+    build_per_chapter_comic_info_xml with the enriched series-level
+    comic_data — so <Genre>/<Tags>/<SpoilerTags>/<TagsExtended>/<Summary>/
+    <CountryOfOrigin>/<MediaFormat>/<AnilistId>/<MalId> come out normalized,
+    byte-identical in shape to a fresh download. Per-member ZIP
+    compression is preserved (we don't re-deflate already-compressed art).
+    grep caller: _refresh_library_metadata.
+    """
+    import calendar
+    import xml.etree.ElementTree as ET
+
+    updated = 0
+    try:
+        names = sorted(os.listdir(folder))
+    except OSError:
+        return 0
+    for name in names:
+        if not name.lower().endswith(".cbz"):
+            continue
+        path = os.path.join(folder, name)
+        try:
+            with zipfile.ZipFile(path) as zin:
+                infos = zin.infolist()
+                blobs = {zi.filename: zin.read(zi.filename) for zi in infos}
+        except (OSError, zipfile.BadZipFile):
+            continue
+
+        ci_name = next(
+            (zi.filename for zi in infos
+             if os.path.basename(zi.filename).lower() == "comicinfo.xml"),
+            None,
+        )
+
+        chap_title = number = volume = translator = web = lang = None
+        page_count = 0
+        uploaded_epoch: Optional[int] = None
+        publishers: List[str] = []
+        if ci_name and blobs.get(ci_name):
+            root = None
+            try:
+                root = ET.fromstring(blobs[ci_name].decode("utf-8", "replace"))
+            except ET.ParseError:
+                root = None
+            if root is not None:
+                def _gx(tag: str) -> Optional[str]:
+                    el = root.find(tag)
+                    return el.text if (el is not None and el.text) else None
+                chap_title = _gx("Title")
+                number = _gx("Number")
+                volume = _gx("Volume")
+                translator = _gx("Translator")
+                web = _gx("Web")
+                lang = _gx("LanguageISO")
+                pub = _gx("Publisher")
+                if pub:
+                    publishers = [pub]
+                pc = _gx("PageCount")
+                if pc:
+                    try:
+                        page_count = int(pc)
+                    except ValueError:
+                        page_count = 0
+                y, m, d = _gx("Year"), _gx("Month"), _gx("Day")
+                if y and m and d:
+                    try:
+                        uploaded_epoch = calendar.timegm(
+                            (int(y), int(m), int(d), 0, 0, 0, 0, 0, 0)
+                        )
+                    except (ValueError, OverflowError):
+                        uploaded_epoch = None
+
+        new_ci = build_per_chapter_comic_info_xml(
+            series_title=series_title,
+            chapter_title=chap_title,
+            chapter_num=number,
+            volume=volume,
+            scanlator=translator,
+            web_url=web,
+            uploaded_epoch=uploaded_epoch,
+            comic_info=comic_data,
+            publishers=publishers,
+            lang=lang or lang_default or "",
+            page_count=page_count,
+        )
+        target = ci_name or "ComicInfo.xml"
+        had_ci = target in blobs
+        blobs[target] = new_ci.encode("utf-8")
+
+        tmp = path + ".refresh.tmp"
+        try:
+            with zipfile.ZipFile(tmp, "w") as zout:
+                for zi in infos:
+                    # writestr(ZipInfo, ...) keeps the member's original
+                    # compress_type — no re-deflating already-compressed art.
+                    zout.writestr(zi, blobs[zi.filename])
+                if not had_ci:
+                    zout.writestr(target, blobs[target])
+            os.replace(tmp, path)
+            updated += 1
+        except OSError:
+            try:
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+            except OSError:
+                pass
+    return updated
+
+
+def _refresh_library_metadata(args) -> int:
+    """--refresh-library-metadata mode. Returns a process exit code.
+
+    Re-pull AniList metadata for every already-downloaded series under
+    --output-dir and rewrite the on-disk metadata sinks WITHOUT
+    re-downloading images. Per series folder carrying a .aio_series.json:
+
+      1. Seed comic_data from the existing .aio_series.json (title, site
+         genres, authors, status, cached anilist_id, synonyms) + the
+         details.json description (so a failed match never blanks it).
+      2. enrich_from_anilist — cached-ID fast path; falls back to a title
+         search for series predating enrichment. Honors --metadata-refresh
+         (cache-bypass) and --metadata-tag-min-rank. Same merge as a live
+         download, so genres get the REPLACE normalization.
+      3. On a confident match: rewrite details.json + .aio_series.json; with
+         --refresh-rewrite-cbz also rewrite each CBZ's ComicInfo.xml.
+      4. On no match / error: leave the series untouched.
+
+    Cross-file: sites/external_metadata.enrich_from_anilist,
+    library_state.scan_library, _rewrite_cbz_comicinfo,
+    _komikku_status_to_digit, _serialize_anilist_tag.
+    """
+    from library_state import scan_library, SERIES_META_FILE
+    from sites.external_metadata import enrich_from_anilist
+
+    root = os.path.abspath(args.output_dir)
+    all_entries = scan_library(root)
+
+    # Optional positional filters: restrict to series whose folder name or
+    # source URL contains any of the given substrings (case-insensitive).
+    # Lets the user repair one series — `--refresh-library-metadata "Eleceed"`
+    # — instead of the whole library. Empty = every series.
+    filters = [
+        str(s).strip().lower()
+        for s in (getattr(args, "comic_url", None) or [])
+        if str(s).strip()
+    ]
+
+    def _matches(entry: Dict[str, Any]) -> bool:
+        if not filters:
+            return True
+        hay = (
+            str(entry.get("name", ""))
+            + " "
+            + str((entry.get("series_meta") or {}).get("url", ""))
+        ).lower()
+        return any(f in hay for f in filters)
+
+    entries = [e for e in all_entries if e.get("series_meta") and _matches(e)]
+    no_meta = (
+        [e for e in all_entries if not e.get("series_meta")]
+        if not filters
+        else []
+    )
+    if not entries:
+        scope = f" matching {filters}" if filters else ""
+        print(f"No series with .aio_series.json found in {root}{scope}.")
+        return 0
+
+    tag_min_rank = int(getattr(args, "metadata_tag_min_rank", 50) or 50)
+    force_refresh = bool(getattr(args, "metadata_refresh", False))
+    rewrite_cbz = bool(getattr(args, "refresh_rewrite_cbz", False))
+    print(
+        f"[*] Refreshing AniList metadata for {len(entries)} series in {root}"
+        + (" (+CBZ ComicInfo rewrite)" if rewrite_cbz else "")
+        + (" (cache-bypass)" if force_refresh else "")
+    )
+
+    matched: List[str] = []
+    skipped: List[str] = []
+    failed: List[str] = []
+
+    for e in entries:
+        folder = e["folder"]
+        meta = dict(e.get("series_meta") or {})
+        title = meta.get("title") or e.get("name") or ""
+        if not title:
+            skipped.append(e.get("name", "?"))
+            continue
+
+        comic_data: Dict[str, Any] = {
+            "title": title,
+            "hid": meta.get("hid", ""),
+            "authors": list(meta.get("authors") or []),
+            "genres": list(meta.get("genres") or []),
+            "status": meta.get("status"),
+            "cover": meta.get("cover"),
+        }
+        syn = list(meta.get("anilist_synonyms") or [])
+        if syn:
+            comic_data["alt_names"] = syn
+
+        details_path = os.path.join(folder, "details.json")
+        existing_details: Dict[str, Any] = {}
+        try:
+            with open(details_path, encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                existing_details = loaded
+        except (OSError, ValueError):
+            existing_details = {}
+        if existing_details.get("description"):
+            comic_data["desc"] = existing_details["description"]
+
+        try:
+            enrich_from_anilist(
+                comic_data,
+                hid=comic_data["hid"],
+                handler_name=meta.get("site", ""),
+                year=None,
+                cover_url=comic_data.get("cover"),
+                tag_min_rank=tag_min_rank,
+                force_refresh=force_refresh,
+                cached_anilist_id=meta.get("anilist_id"),
+            )
+        except Exception as exc:
+            print(f"  [!] {title}: enrichment error {type(exc).__name__}: {exc}")
+            failed.append(title)
+            continue
+
+        if not comic_data.get("anilist_id"):
+            best = comic_data.pop("_anilist_best_score", 0.0) or 0.0
+            print(
+                f"  [-] {title}: no confident AniList match "
+                f"(best {best:.0f}) — left unchanged"
+            )
+            skipped.append(title)
+            continue
+
+        # Rewrite Komikku details.json (preserve extra keys + existing artist).
+        new_details = dict(existing_details)
+        new_details["title"] = title
+        new_details["author"] = ", ".join(comic_data.get("authors") or [])
+        new_details.setdefault("artist", existing_details.get("artist", ""))
+        new_details["description"] = (
+            comic_data.get("desc") or existing_details.get("description", "")
+        )
+        new_details["genre"] = list(comic_data.get("genres") or [])
+        new_details["status"] = _komikku_status_to_digit(comic_data.get("status"))
+        try:
+            with open(details_path, "w", encoding="utf-8") as f:
+                json.dump(new_details, f, ensure_ascii=False, indent=2)
+        except OSError as exc:
+            print(f"  [!] {title}: details.json write failed: {exc}")
+            failed.append(title)
+            continue
+
+        # Rewrite .aio_series.json enrichment fields (preserve the rest).
+        meta["genres"] = list(comic_data.get("genres") or [])
+        if comic_data.get("status"):
+            meta["status"] = comic_data["status"]
+        meta["anilist_id"] = comic_data.get("anilist_id")
+        meta["mal_id"] = comic_data.get("mal_id")
+        meta["country_of_origin"] = comic_data.get("country_of_origin")
+        meta["media_format"] = comic_data.get("media_format")
+        meta["anilist_synonyms"] = list(comic_data.get("anilist_synonyms") or [])
+        meta["anilist_tags"] = [
+            _serialize_anilist_tag(t)
+            for t in (comic_data.get("anilist_tags") or [])
+        ]
+        meta["anilist_spoiler_tags"] = [
+            _serialize_anilist_tag(t)
+            for t in (comic_data.get("anilist_spoiler_tags") or [])
+        ]
+        try:
+            with open(
+                os.path.join(folder, SERIES_META_FILE), "w", encoding="utf-8"
+            ) as f:
+                json.dump(meta, f, indent=2)
+        except OSError as exc:
+            print(f"  [!] {title}: .aio_series.json write failed: {exc}")
+            failed.append(title)
+            continue
+
+        cbz_note = ""
+        if rewrite_cbz:
+            n = _rewrite_cbz_comicinfo(
+                folder,
+                comic_data,
+                title,
+                meta.get("language") or existing_details.get("language") or "",
+            )
+            cbz_note = f", {n} CBZ rewritten"
+
+        matched.append(title)
+        print(
+            f"  [+] {title}: matched id={comic_data['anilist_id']} "
+            f"({len(comic_data.get('anilist_tags', []))} tags, "
+            f"{len(comic_data.get('genres', []))} genres) "
+            f"— details.json + .aio_series.json{cbz_note}"
+        )
+
+    print(
+        f"\nRefresh complete: {len(matched)} updated, "
+        f"{len(skipped)} skipped, {len(failed)} failed"
+        + (
+            f", {len(no_meta)} folders without .aio_series.json ignored"
+            if no_meta
+            else ""
+        )
+    )
+    return 1 if failed else 0
+
+
 def main():
     p = argparse.ArgumentParser("comic downloader")
     p.add_argument("comic_url", nargs="*", help="One or more comic/manga URLs")
@@ -5541,6 +5892,29 @@ def main():
         help="Scan --output-dir for saved series metadata and download new chapters for each series.",
     )
     p.add_argument(
+        "--refresh-library-metadata",
+        action="store_true",
+        help="Re-pull AniList metadata for every already-downloaded series "
+             "under --output-dir and rewrite details.json + .aio_series.json "
+             "in place, WITHOUT re-downloading images. Pass a positional "
+             "substring (folder name or URL) to restrict to one series, e.g. "
+             "--refresh-library-metadata \"Eleceed\". Honors "
+             "--metadata-tag-min-rank and --metadata-refresh (cache-bypass). "
+             "Repairs libraries grabbed before the genre-normalization fix. "
+             "Add --refresh-rewrite-cbz to also rewrite chapter CBZ ComicInfo. "
+             "Then exits.",
+    )
+    p.add_argument(
+        "--refresh-rewrite-cbz",
+        action="store_true",
+        help="With --refresh-library-metadata, also rewrite the enrichment "
+             "elements inside each chapter CBZ's ComicInfo.xml "
+             "(<Genre>/<Tags>/<SpoilerTags>/<TagsExtended>/<Summary>/"
+             "<CountryOfOrigin>/<MediaFormat>/<AnilistId>/<MalId>). Per-chapter "
+             "fields are preserved. I/O-heavy (repackages every CBZ); "
+             "off by default.",
+    )
+    p.add_argument(
         "--serve",
         action="store_true",
         help="Start the FastAPI REST server instead of downloading.",
@@ -5921,6 +6295,11 @@ def main():
             print(f"Failed: {', '.join(failed)}")
             sys.exit(1)
         return
+
+    if getattr(args, "refresh_library_metadata", False):
+        # In-place AniList re-enrichment of an existing library; no
+        # downloads. Defined just above main(). Exits with its own code.
+        sys.exit(_refresh_library_metadata(args))
 
     # Phase B (2026-05-07) / Phase H follow-up (2026-05-16): snapshot which CLI
     # flags the user explicitly set on THIS invocation, BEFORE any later
@@ -6860,7 +7239,9 @@ def main():
     # enrichment writes into comic_data propagate to every downstream
     # sink: ComicInfo.xml builders (build_comic_info_xml +
     # build_per_chapter_comic_info_xml), Komikku details.json writer
-    # (genres union), and .aio_series.json writer (full ID + tag persist).
+    # (genres REPLACED by AniList's curated set on a confident match — see
+    # _apply_anilist_match), and .aio_series.json writer (full ID + tag
+    # persist).
     # Failures are swallowed — site-only metadata is the fallback path.
     # Cross-file: sites/external_metadata.py owns the client; CLI flags
     # registered near --enable-ml-rating; cache key in .aio_series.json

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -5149,6 +5149,7 @@ def _rewrite_cbz_comicinfo(
         )
 
         chap_title = number = volume = translator = web = lang = None
+        writer = penciller = None
         page_count = 0
         uploaded_epoch: Optional[int] = None
         publishers: List[str] = []
@@ -5168,6 +5169,8 @@ def _rewrite_cbz_comicinfo(
                 translator = _gx("Translator")
                 web = _gx("Web")
                 lang = _gx("LanguageISO")
+                writer = _gx("Writer")
+                penciller = _gx("Penciller")
                 pub = _gx("Publisher")
                 if pub:
                     publishers = [pub]
@@ -5186,6 +5189,17 @@ def _rewrite_cbz_comicinfo(
                     except (ValueError, OverflowError):
                         uploaded_epoch = None
 
+        # Preserve the archive's existing Writer/Penciller (authors/artists).
+        # AniList v1 supplies no staff, so the refresh must carry author/artist
+        # metadata through unchanged rather than dropping <Penciller> (Codex
+        # review on PR #47). Prefer the CBZ's own values; fall back to the
+        # series-level comic_data (seeded from details.json in
+        # _refresh_library_metadata).
+        per_cbz: Dict[str, Any] = dict(comic_data)
+        if writer:
+            per_cbz["authors"] = [s.strip() for s in writer.split(",") if s.strip()]
+        if penciller:
+            per_cbz["artists"] = [s.strip() for s in penciller.split(",") if s.strip()]
         new_ci = build_per_chapter_comic_info_xml(
             series_title=series_title,
             chapter_title=chap_title,
@@ -5194,7 +5208,7 @@ def _rewrite_cbz_comicinfo(
             scanlator=translator,
             web_url=web,
             uploaded_epoch=uploaded_epoch,
-            comic_info=comic_data,
+            comic_info=per_cbz,
             publishers=publishers,
             lang=lang or lang_default or "",
             page_count=page_count,
@@ -5326,6 +5340,19 @@ def _refresh_library_metadata(args) -> int:
             existing_details = {}
         if existing_details.get("description"):
             comic_data["desc"] = existing_details["description"]
+        # Seed artists from details.json's preserved `artist` field. AniList
+        # v1 fetches no staff, so without this the CBZ rewrite would emit an
+        # empty <Penciller> and drop artist metadata. _rewrite_cbz_comicinfo
+        # still prefers each archive's own <Penciller> when present; this is
+        # the fallback (and the recovery path for CBZs whose <Penciller> was
+        # already stripped by the pre-fix run). authors come from
+        # .aio_series.json above.
+        if existing_details.get("artist"):
+            comic_data["artists"] = [
+                s.strip()
+                for s in str(existing_details["artist"]).split(",")
+                if s.strip()
+            ]
 
         try:
             enrich_from_anilist(

--- a/sites/external_metadata.py
+++ b/sites/external_metadata.py
@@ -436,20 +436,28 @@ def _split_tags(
     return non_spoiler, spoiler
 
 
-def _union_genres(
-    site_genres: List[str], anilist_genres: List[str]
-) -> List[str]:
-    """Union site + AniList genres, case-insensitive dedupe, site order first.
+def _dedupe_genres(*genre_lists: List[str]) -> List[str]:
+    """Concatenate genre/tag-name lists with case-insensitive dedupe.
 
-    Site genres often have site-specific casing or wording (e.g.
-    "Action", "Sci-fi" vs AniList's "Action", "Sci-Fi"). The lower-case
-    dedupe keeps the first-seen casing, which is the site's — preserves
-    the user-recognizable display form when both sources agree.
+    Order: earlier lists win; first-seen casing is preserved, so the
+    leading list dictates the display form when two sources spell a genre
+    differently. Empty/blank entries are dropped.
+
+    Used by _apply_anilist_match to build the normalized visible genre
+    field = AniList genres (coarse buckets) followed by AniList high-rank
+    tag names (fine descriptors).
+
+    Renamed from _union_genres (2026-06-06): the merge is no longer
+    site ∪ AniList. On a confident match AniList is authoritative and the
+    site's own genre list is dropped entirely — it was the source of the
+    50+-tag taxonomy dumps (e.g. mangakatana leaking its whole nav genre
+    dropdown). See the REPLACE semantics documented in
+    _apply_anilist_match. grep callers: only _apply_anilist_match.
     """
     out: List[str] = []
     seen_lower = set()
-    for genre_list in (site_genres or [], anilist_genres or []):
-        for src in genre_list:
+    for genre_list in genre_lists:
+        for src in genre_list or []:
             if not src:
                 continue
             key = str(src).strip().lower()
@@ -471,8 +479,12 @@ def _apply_anilist_match(
     Field merge semantics (per plan-locked user decisions):
       - desc: REPLACE with AniList description (per user choice — max
         uniformity for filtering)
-      - genres: UNION (site first, AniList appended, case-insensitive
-        dedupe — preserves site display casing)
+      - genres: REPLACE with AniList genres + high-rank non-spoiler tag
+        names (case-insensitive dedupe via _dedupe_genres). The site's
+        genre list is dropped on a confident match — it's the source of
+        the 50+-tag taxonomy dumps. Spoilers are excluded from this
+        visible field. Falls back to the site genres only when AniList
+        contributed nothing (changed from UNION 2026-06-06 per user req).
       - authors / artists: FILL-MISSING (v1 doesn't fetch AniList
         staff{} connection so this is effectively a no-op today; the
         semantic is documented for future expansion)
@@ -496,10 +508,29 @@ def _apply_anilist_match(
     if cleaned_desc:
         comic_data["desc"] = cleaned_desc
 
-    comic_data["genres"] = _union_genres(
-        comic_data.get("genres") or [],
+    non_spoiler, spoiler = _split_tags(media.get("tags") or [], tag_min_rank)
+    comic_data["anilist_tags"] = non_spoiler
+    comic_data["anilist_spoiler_tags"] = spoiler
+
+    # REPLACE the visible genre list with AniList's curated set: AniList
+    # genres (coarse buckets) followed by the high-rank non-spoiler tag
+    # names (fine descriptors). The site's own genre list is dropped on a
+    # confident match — many sites (mangakatana especially) leak their
+    # entire genre taxonomy into this field, and the previous union-merge
+    # preserved that garbage. Spoiler tags are deliberately excluded so the
+    # default-visible genre field never leaks spoilers (they stay in
+    # anilist_spoiler_tags / <SpoilerTags>). Only fall back to the existing
+    # site genres if AniList contributed nothing at all (pathological:
+    # matched but zero genres AND zero tags above tag_min_rank) — never
+    # blank the field. Cross-file: flows to ComicInfo <Genre> (aio-dl.py
+    # build_comic_info_xml / build_per_chapter_comic_info_xml) and Komikku
+    # details.json `genre` (aio-dl.py, grep '"genre": list(comic_data').
+    normalized_genres = _dedupe_genres(
         media.get("genres") or [],
+        [t.name for t in non_spoiler],
     )
+    if normalized_genres:
+        comic_data["genres"] = normalized_genres
 
     if media.get("status"):
         comic_data["status"] = str(media["status"])
@@ -512,10 +543,6 @@ def _apply_anilist_match(
         comic_data["media_format"] = media_format
 
     comic_data["anilist_synonyms"] = list(media.get("synonyms") or [])
-
-    non_spoiler, spoiler = _split_tags(media.get("tags") or [], tag_min_rank)
-    comic_data["anilist_tags"] = non_spoiler
-    comic_data["anilist_spoiler_tags"] = spoiler
 
 
 # --- Public entry point ----------------------------------------------------

--- a/sites/external_metadata.py
+++ b/sites/external_metadata.py
@@ -72,6 +72,12 @@ ANILIST_TIMEOUT_S = 15
 
 ANILIST_MAX_RETRIES = 3
 
+# Cap on AniList search requests per series on the no-match path. The search
+# tries each source title (full + bracket-stripped variant); this bounds the
+# fan-out so a series that genuinely isn't on AniList can't trigger a request
+# storm. 4 = primary + cleaned-primary + one alt + its cleaned form.
+_MAX_SEARCH_QUERIES = 4
+
 # Drop candidates with these formats from the search-result pool. NOVEL
 # poisons comic enrichment (light novels share titles with their manga
 # adaptations and AniList lists them as separate Media entries). ONE_SHOT
@@ -305,6 +311,32 @@ def _strip_anilist_html(desc: Optional[str]) -> str:
 
 
 # --- Internal: matching ----------------------------------------------------
+
+# Bracket/tilde families that wrap subtitle noise AniList's search index
+# chokes on. Stripped (not split) so the core title survives; see
+# _clean_search_title.
+_TITLE_NOISE_RE = re.compile(r"~[^~]*~|\([^)]*\)|\[[^\]]*\]|[【「][^】」]*[】」]")
+
+
+def _clean_search_title(title: str) -> str:
+    """Return `title` with bracketed/tilde subtitle segments stripped.
+
+    e.g. "Shangri-La Frontier ~ Kusoge Hunter, Kamige ni Idoman to su~"
+    -> "Shangri-La Frontier". Used as a fallback AniList search query (and
+    scoring title) when the full stored title returns no candidates — some
+    sites bake a ~...~ or (...) subtitle into the title that defeats
+    AniList's search index. Deliberately does NOT split on ':' / ' - '
+    subtitle separators: that would surface a parent series for a spinoff
+    (e.g. "...Spoils Me Rotten: After the Rain") and risk a wrong match even
+    with full-title scoring. May return a string equal to the input (caller
+    dedupes) or "" if nothing survives. Cross-file: called only from
+    enrich_from_anilist's search path.
+    """
+    if not title:
+        return ""
+    s = _TITLE_NOISE_RE.sub(" ", str(title))
+    return re.sub(r"\s+", " ", s).strip()
+
 
 def _candidate_titles(media: Dict[str, Any]) -> List[str]:
     """All title variants a candidate exposes — used for fuzzy matching."""
@@ -595,25 +627,54 @@ def enrich_from_anilist(
         # search step also fails, comic_data ends up unchanged and the
         # caller logs accordingly.
 
-    # Search path.
+    # Search path. Build an ordered, deduped title list: each source title
+    # plus its bracket/tilde-stripped variant. Some sites bake a ~...~ or
+    # (...) subtitle into the title that defeats AniList's search index
+    # (e.g. "Shangri-La Frontier ~ Kusoge Hunter, ...~" returns nothing, but
+    # "Shangri-La Frontier" matches id 122063). The cleaned variant is used
+    # both as an extra search query AND for scoring — bracket content is
+    # genuine noise, so a candidate matching the cleaned form is a real match.
     source_titles: List[str] = []
+    seen_titles = set()
+    raw_titles: List[str] = []
     if comic_data.get("title"):
-        source_titles.append(str(comic_data["title"]))
+        raw_titles.append(str(comic_data["title"]))
     for alt in comic_data.get("alt_names") or []:
         if alt:
-            source_titles.append(str(alt))
+            raw_titles.append(str(alt))
+    for raw in raw_titles:
+        for variant in (raw, _clean_search_title(raw)):
+            v = variant.strip()
+            key = v.lower()
+            if v and key not in seen_titles:
+                seen_titles.add(key)
+                source_titles.append(v)
     if not source_titles:
         return comic_data
 
-    candidates = _search_candidates(source_titles[0])
-    if not candidates:
-        # Empty pool (network failure / 0 hits / API rate-limit exhausted).
-        # Set the best-score sentinel so the caller's log line is uniform
-        # across "no hits" and "hits but all below threshold" branches.
-        comic_data["_anilist_best_score"] = 0.0
-        return comic_data
+    # Query AniList with each title (full first, then cleaned/alt variants),
+    # accumulating candidates deduped by id; stop early once a candidate
+    # clears the match threshold. Bounded to _MAX_SEARCH_QUERIES requests so
+    # a series that genuinely isn't on AniList can't fan out into a storm.
+    # best_score stays 0.0 across the "no hits" and "hits but all below
+    # threshold" branches so the caller's log line is uniform.
+    pool: List[Dict[str, Any]] = []
+    seen_ids = set()
+    best: Optional[Dict[str, Any]] = None
+    score = 0.0
+    for query in source_titles[:_MAX_SEARCH_QUERIES]:
+        for cand in _search_candidates(query):
+            cid = cand.get("id")
+            if cid is not None and cid in seen_ids:
+                continue
+            if cid is not None:
+                seen_ids.add(cid)
+            pool.append(cand)
+        if pool:
+            best, score = _pick_best_candidate(source_titles, pool)
+            if best is not None:
+                break
 
-    best, score = _pick_best_candidate(source_titles, candidates)
     comic_data["_anilist_best_score"] = score
     if best is None:
         return comic_data

--- a/sites/mangakatana.py
+++ b/sites/mangakatana.py
@@ -135,7 +135,28 @@ class MangaKatanaSiteHandler(BaseSiteHandler):
         # MangaKatana does NOT expose a separate Artist field on its series
         # template (verified 2026-05-19 audit). `artists` stays empty by site
         # limitation; Komikku's details.json artist key reflects "no artist".
-        genres = [a.get_text(strip=True) for a in soup.select(".genres a") if a.get_text(strip=True)]
+        # Series genres live inside the .info meta table:
+        #   div.info > ul.meta.d-table > li.d-row-small > .value > div.genres > a
+        # MangaKatana ALSO ships a nav-header genre dropdown
+        # <ul class="sub-menu genres"> listing the ENTIRE genre taxonomy
+        # (~52 links). An unscoped ".genres a" matched BOTH and scraped the
+        # whole taxonomy as this series' genres — the bug behind the 50+-tag
+        # dumps in details.json/ComicInfo. Scope to .info; fall back to a
+        # nav-excluding scan if a future template drops the .info wrapper.
+        # Verified against the live "smoking-at-the-back" page 2026-06-06
+        # (grep "sub-menu genres" / "class=\"text_0\"").
+        genres = [
+            a.get_text(strip=True)
+            for a in soup.select(".info .genres a")
+            if a.get_text(strip=True)
+        ]
+        if not genres:
+            genres = [
+                a.get_text(strip=True)
+                for a in soup.select(".genres a")
+                if a.get_text(strip=True)
+                and not a.find_parent("ul", class_="sub-menu")
+            ]
 
         comic: Dict[str, object] = {
             "hid": slug,


### PR DESCRIPTION
## Summary

Follow-up to the merged AniList enrichment (#42). Fixes the **"50+ genre dump"** on downloaded series — e.g. mangakatana's *A Story About Smoking at the Back of the Supermarket* stored **52 genres**, the site's entire nav taxonomy — adds an in-place library-repair path, and hardens AniList matching.

Enrichment itself was working: AniList matched and wrote clean ranked tags. The garbage lived in the **genre** field, from two stacked bugs.

## Root causes

1. **Unscoped mangakatana selector** (`sites/mangakatana.py`). Genres were scraped with `.genres a`, which matched the nav-header genre dropdown (`<ul class="sub-menu genres">`, the full ~52-item taxonomy) in addition to the 4 real genres. Live: `.genres a` → 56; `.info .genres a` → 4.

2. **UNION genre merge** (`sites/external_metadata.py`). Genres were merged with union, which can never *drop* the site's list — so the dump survived enrichment.

## Changes

### 1. `sites/mangakatana.py` — scope the genre selector
`.genres a` → `.info .genres a`, with a nav-excluding fallback. Fixes non-enriched downloads too.

### 2. `sites/external_metadata.py` — REPLACE instead of UNION
On a confident match the genre field becomes **AniList genres + high-rank non-spoiler tags**; site garbage dropped; spoilers stay in `<SpoilerTags>`; falls back to site genres only if AniList contributes nothing. `_union_genres` → `_dedupe_genres`.

### 3. `aio-dl.py` — in-place library repair (no re-download)
- `--refresh-library-metadata [filter]` — re-pulls AniList by cached ID (falls back to title search) and rewrites `details.json` + `.aio_series.json` for every series under `--output-dir`; optional positional substring restricts to one series.
- `--refresh-rewrite-cbz` — additionally rewrites enrichment elements inside each CBZ's `ComicInfo.xml`, preserving all per-chapter fields and per-member ZIP compression.

### 4. `aio-dl.py` — preserve author/artist in CBZ rewrite *(addresses Codex review)*
`_rewrite_cbz_comicinfo` now parses and prefers each archive's existing `<Writer>`/`<Penciller>`; `_refresh_library_metadata` seeds `artists` from `details.json` as the fallback (and recovery path for already-rewritten CBZs).

### 5. `sites/external_metadata.py` — title-cleaning search fallback
Searches each title plus a bracket/tilde-stripped variant (`_clean_search_title`), so titles whose `~…~`/`(…)` subtitle defeats AniList's index still match (e.g. *Shangri-La Frontier ~…~* → id 122063). Does **not** split `:`/`-` subtitles, to avoid spinoff false matches. Bounded to `_MAX_SEARCH_QUERIES`.

## Verification

Ran the full repair over a real 106-series library: **99 enriched, 7 no-match (left untouched), 0 failed**.
- Genre dumps: **gone library-wide** (Smoking 52→12; Shangri-La 52→16 via the cleaning fallback).
- Artist `<Penciller>`: **45/45 intact**, including 28 recovered after the pre-fix CBZ rewrite stripped them.
- CBZ rewrite: per-chapter `<Number>`/`<Title>`/`<Year>`, images, and zip integrity preserved.
- Suite: handlers 302/41, clean compile, no torch import on `external_metadata` load.

## Test plan

- [ ] `--metadata-source anilist` download from mangakatana → `<Genre>`/`details.json` show the curated set, not the taxonomy dump
- [ ] `--refresh-library-metadata` on a pre-#42 library → series matched + rewritten in place
- [ ] `--refresh-rewrite-cbz` → Komga/Kavita pick up clean `<Genre>`; per-chapter + author/artist metadata intact
- [ ] Series with a `~…~`/`(…)` subtitle title → matched via the cleaned-title fallback
- [ ] Non-enriched mangakatana download (`--metadata-source none`) → 4 real genres, no nav dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
