### PR TITLE
AniList enrichment: reader-facing details.json, cover normalization, and robust title matching

### DIFF
--- a/aio-dl.py
+++ b/aio-dl.py
@@ -5149,6 +5149,69 @@ def _serialize_anilist_tag(t: Any) -> Dict[str, Any]:
     }
 
 
+def _build_aio_reader_extras(
+    comic_data: Dict[str, Any],
+    *,
+    source_site: Optional[str],
+    source_url: Optional[str],
+    language: Optional[str],
+) -> Dict[str, Any]:
+    """Reader-facing enrichment block merged into details.json as flat,
+    top-level keys. Returns a dict the caller `.update()`s onto the Komikku
+    payload AFTER the six canonical keys, so those stay first on disk.
+
+    WHY this exists: details.json is the only metadata file a *reader*
+    (Komikku, or the user's own reader) actually reads. .aio_series.json is
+    internal bookkeeping — the update-checker chapter list + the cached
+    anilist_id fast path (grep _load_cached_anilist_id) — and no reader ever
+    opens it. So everything a reader might surface has to live in
+    details.json. Komikku parses details.json with kotlinx
+    Json{ignoreUnknownKeys=true} (verified: `git show 1f17a20^:komikkuspec.md`
+    §6.1 — "extra keys are tolerated"), so these extra keys are silently
+    dropped by Komikku and read by the user's reader; no namespacing needed
+    for Komikku-safety.
+
+    Key names deliberately dodge Komikku's reserved set
+    (title/author/artist/description/genre/status) AND the TachiyomiSY keys
+    Komikku currently ignores but could one day wire up
+    (url/lang/tags/categories/alt_titles/thumbnail_url): hence
+    source_url/source_site (not bare url/site) and anilist_tags (not tags).
+    The anilist_*/country_of_origin/media_format names mirror
+    .aio_series.json's schema (grep 'series_meta =') so the two on-disk files
+    stay name-consistent for anything that reads both. Rich-tag dict shape ==
+    _serialize_anilist_tag == ComicInfo <TagsExtended> (name/category/rank +
+    the two spoiler flags), so a reader can render spoiler-aware chips off
+    any of the three artifacts identically.
+
+    Every key is emitted unconditionally (null / [] / "" when enrichment was
+    off or found no confident match) so the reader can rely on a stable
+    schema. comic_data's anilist_tags/anilist_spoiler_tags are AnilistTag
+    dataclass instances in both call sites (set by enrich_from_anilist →
+    _apply_anilist_match); _serialize_anilist_tag is getattr-based so that
+    holds. Cross-file callers: the two details.json writers — live-download
+    (grep 'details_payload.update') and --refresh-library-metadata (grep
+    'new_details.update').
+    """
+    return {
+        "anilist_id": comic_data.get("anilist_id"),
+        "mal_id": comic_data.get("mal_id"),
+        "country_of_origin": comic_data.get("country_of_origin"),
+        "media_format": comic_data.get("media_format"),
+        "anilist_synonyms": list(comic_data.get("anilist_synonyms") or []),
+        "anilist_tags": [
+            _serialize_anilist_tag(t)
+            for t in (comic_data.get("anilist_tags") or [])
+        ],
+        "anilist_spoiler_tags": [
+            _serialize_anilist_tag(t)
+            for t in (comic_data.get("anilist_spoiler_tags") or [])
+        ],
+        "source_site": source_site or "",
+        "source_url": source_url or "",
+        "language": language or "",
+    }
+
+
 def _rewrite_cbz_comicinfo(
     folder: str,
     comic_data: Dict[str, Any],
@@ -5283,6 +5346,43 @@ def _rewrite_cbz_comicinfo(
     return updated
 
 
+def _refresh_cover_jpg(
+    folder: str, url: str, fallback_url: Optional[str], scraper
+) -> bool:
+    """Re-download a series cover to <folder>/cover.jpg for
+    --refresh-library-metadata's always-normalize-covers path. Returns True
+    iff cover.jpg was (re)written.
+
+    dl_image sniffs the real image format and may produce cover_orig.<ext>;
+    we copy whatever it produced to the canonical Komikku name cover.jpg
+    (Komikku decodes by content, not extension — komikkuspec §5). Tries `url`
+    (the AniList cover) first, then `fallback_url` (the stashed site cover)
+    when the AniList CDN fetch returns None. On total failure the existing
+    cover.jpg is left untouched (never blanked). Download work happens in a
+    throwaway temp dir so a partial/aborted fetch can't litter the series
+    folder. dl_image is safe here: its watchdog/host-poison checks are no-ops
+    outside the chapter loop. grep caller: _refresh_library_metadata.
+    """
+    import tempfile
+
+    tmp_dir = tempfile.mkdtemp(prefix="aio_cover_")
+    try:
+        got = dl_image(url, tmp_dir, "cover_orig.jpg", scraper, cleanup=True)
+        if got is None and fallback_url and fallback_url != url:
+            got = dl_image(
+                fallback_url, tmp_dir, "cover_orig.jpg", scraper, cleanup=True
+            )
+        if got and os.path.exists(got):
+            shutil.copy2(got, os.path.join(folder, "cover.jpg"))
+            return True
+        return False
+    except Exception:
+        # Best-effort: a cover refresh must never abort the whole library run.
+        return False
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
 def _refresh_library_metadata(args) -> int:
     """--refresh-library-metadata mode. Returns a process exit code.
 
@@ -5297,8 +5397,10 @@ def _refresh_library_metadata(args) -> int:
          search for series predating enrichment. Honors --metadata-refresh
          (cache-bypass) and --metadata-tag-min-rank. Same merge as a live
          download, so genres get the REPLACE normalization.
-      3. On a confident match: rewrite details.json + .aio_series.json; with
-         --refresh-rewrite-cbz also rewrite each CBZ's ComicInfo.xml.
+      3. On a confident match: rewrite details.json + .aio_series.json,
+         repoint the cover URL to AniList's, and re-download cover.jpg from
+         AniList (normalize the on-disk cover); with --refresh-rewrite-cbz
+         also rewrite each CBZ's ComicInfo.xml.
       4. On no match / error: leave the series untouched.
 
     Cross-file: sites/external_metadata.enrich_from_anilist,
@@ -5345,10 +5447,25 @@ def _refresh_library_metadata(args) -> int:
     tag_min_rank = int(getattr(args, "metadata_tag_min_rank", 50) or 50)
     force_refresh = bool(getattr(args, "metadata_refresh", False))
     rewrite_cbz = bool(getattr(args, "refresh_rewrite_cbz", False))
+    # Cover normalization (user-chosen "always re-download" on refresh): one
+    # shared HTTP session reused for every matched series' cover.jpg fetch.
+    # cloudscraper when available (a site-cover fallback may sit behind
+    # Cloudflare); AniList's own CDN is plain and works with either.
+    cover_scraper = None
+    try:
+        if cloudscraper is not None and sys.version_info >= (3, 7):
+            cover_scraper = cloudscraper.create_scraper(
+                browser={"browser": "chrome", "platform": "darwin", "mobile": False}
+            )
+    except Exception:
+        cover_scraper = None
+    if cover_scraper is None:
+        cover_scraper = requests.Session()
     print(
         f"[*] Refreshing AniList metadata for {len(entries)} series in {root}"
         + (" (+CBZ ComicInfo rewrite)" if rewrite_cbz else "")
         + (" (cache-bypass)" if force_refresh else "")
+        + " (+cover.jpg re-download)"
     )
 
     matched: List[str] = []
@@ -5435,6 +5552,19 @@ def _refresh_library_metadata(args) -> int:
         )
         new_details["genre"] = list(comic_data.get("genres") or [])
         new_details["status"] = _komikku_status_to_digit(comic_data.get("status"))
+        # Reader-facing extension keys (flat top-level; Komikku ignores
+        # unknown keys). Mirrors the live-download writer (grep
+        # 'details_payload.update'). Provenance comes from the existing
+        # .aio_series.json (meta), authoritative on an in-place refresh;
+        # language falls back to any value the prior details.json carried.
+        new_details.update(
+            _build_aio_reader_extras(
+                comic_data,
+                source_site=meta.get("site"),
+                source_url=meta.get("url"),
+                language=meta.get("language") or existing_details.get("language"),
+            )
+        )
         try:
             with open(details_path, "w", encoding="utf-8") as f:
                 json.dump(new_details, f, ensure_ascii=False, indent=2)
@@ -5447,6 +5577,12 @@ def _refresh_library_metadata(args) -> int:
         meta["genres"] = list(comic_data.get("genres") or [])
         if comic_data.get("status"):
             meta["status"] = comic_data["status"]
+        # Repoint the cover URL to AniList's when enrichment supplied one so
+        # .aio_series.json + the UI thumbnail (library.js keys on
+        # seriesMeta.cover) normalize too. comic_data["cover"] is the AniList
+        # URL after enrich, or the unchanged site cover when AniList had none
+        # — safe to assign unconditionally.
+        meta["cover"] = comic_data.get("cover")
         meta["anilist_id"] = comic_data.get("anilist_id")
         meta["mal_id"] = comic_data.get("mal_id")
         meta["country_of_origin"] = comic_data.get("country_of_origin")
@@ -5470,6 +5606,22 @@ def _refresh_library_metadata(args) -> int:
             failed.append(title)
             continue
 
+        # Re-download cover.jpg from AniList (user chose always-normalize on
+        # refresh). Guarded on anilist_cover so we ONLY overwrite the on-disk
+        # cover when AniList actually supplied one — never clobber a custom
+        # cover.jpg with a re-fetched site cover in the rare matched-but-no-
+        # AniList-cover case. Falls back to the stashed site cover if the
+        # AniList CDN fetch fails. grep _refresh_cover_jpg.
+        cover_note = ""
+        if comic_data.get("anilist_cover"):
+            if _refresh_cover_jpg(
+                folder,
+                comic_data["cover"],
+                comic_data.get("site_cover"),
+                cover_scraper,
+            ):
+                cover_note = ", cover.jpg"
+
         cbz_note = ""
         if rewrite_cbz:
             n = _rewrite_cbz_comicinfo(
@@ -5485,7 +5637,7 @@ def _refresh_library_metadata(args) -> int:
             f"  [+] {title}: matched id={comic_data['anilist_id']} "
             f"({len(comic_data.get('anilist_tags', []))} tags, "
             f"{len(comic_data.get('genres', []))} genres) "
-            f"— details.json + .aio_series.json{cbz_note}"
+            f"— details.json + .aio_series.json{cover_note}{cbz_note}"
         )
 
     print(
@@ -7639,6 +7791,22 @@ def main():
             original_cover_path = dl_image(
                 cover_url, main_tmp_dir, "cover_orig.jpg", scraper, cleanup=not args.no_cleanup
             )
+            # AniList cover normalization (--metadata-source=anilist): the
+            # enrichment step (sites/external_metadata.py:_apply_anilist_match)
+            # overwrote comic_data["cover"] with the AniList cover and stashed
+            # the site's own cover under `site_cover`. If the AniList CDN fetch
+            # failed (dl_image → None), fall back to the site cover so an
+            # enriched run is never worse than an un-enriched one.
+            if original_cover_path is None:
+                site_cover = comic_data.get("site_cover")
+                if site_cover and site_cover != cover_url:
+                    log_verbose(
+                        "  AniList cover fetch failed; falling back to site cover"
+                    )
+                    original_cover_path = dl_image(
+                        site_cover, main_tmp_dir, "cover_orig.jpg", scraper,
+                        cleanup=not args.no_cleanup,
+                    )
             if args.format == "cbz" and original_cover_path:
                 current_book_content.append(
                     {"type": "image", "path": original_cover_path}
@@ -7676,12 +7844,30 @@ def main():
                 "genre": list(comic_data.get("genres", []) or []),
                 "status": _komikku_status_to_digit(comic_data.get("status")),
             }
+            # Reader-facing extension keys (flat, top-level). Komikku parses
+            # details.json with Json{ignoreUnknownKeys=true} (git show
+            # 1f17a20^:komikkuspec.md §6.1), so these are dropped by Komikku
+            # and read by the user's own reader. The AniList rich tags /
+            # ids / format / synonyms + source provenance only reach a reader
+            # via this file — .aio_series.json is never read by one. Field
+            # contract + name-collision rationale: _build_aio_reader_extras.
+            # Provenance values mirror the .aio_series.json writer below
+            # (grep '"site": handler.name').
+            details_payload.update(
+                _build_aio_reader_extras(
+                    comic_data,
+                    source_site=handler.name,
+                    source_url=args.comic_url,
+                    language=args.language,
+                )
+            )
             details_path = os.path.join(out_dir, "details.json")
             with open(details_path, "w", encoding="utf-8") as f:
                 json.dump(details_payload, f, ensure_ascii=False, indent=2)
             log_verbose(
                 f"  Komikku: wrote details.json (status={details_payload['status']}, "
-                f"{len(details_payload['genre'])} genre tags)"
+                f"{len(details_payload['genre'])} genre tags, "
+                f"{len(details_payload['anilist_tags'])} anilist tags)"
             )
         except OSError as exc:
             # Don't fail the whole run for a metadata-write error. The

--- a/sites/external_metadata.py
+++ b/sites/external_metadata.py
@@ -72,11 +72,14 @@ ANILIST_TIMEOUT_S = 15
 
 ANILIST_MAX_RETRIES = 3
 
-# Cap on AniList search requests per series on the no-match path. The search
-# tries each source title (full + bracket-stripped variant); this bounds the
-# fan-out so a series that genuinely isn't on AniList can't trigger a request
-# storm. 4 = primary + cleaned-primary + one alt + its cleaned form.
-_MAX_SEARCH_QUERIES = 4
+# Cap on AniList search requests per series on the no-match path. Each source
+# title now expands to up to four queries (full, bracket-cleaned, trailing
+# subtitle segment, shortened prefix — see enrich_from_anilist), so 6 leaves
+# room for the primary's variants plus an alt's. Early-stop means the common
+# case (full title matches on query 1) still costs a single request; this cap
+# only bounds the worst case so a series genuinely absent from AniList can't
+# trigger a request storm.
+_MAX_SEARCH_QUERIES = 6
 
 # Drop candidates with these formats from the search-result pool. NOVEL
 # poisons comic enrichment (light novels share titles with their manga
@@ -98,9 +101,12 @@ class AnilistTag:
     "Time Travel" is broadly spoilerish for any story). Either flag puts
     the tag into the spoiler bucket — the user's reader can decide
     granularity at display time using the per-tag attributes preserved
-    in the ComicInfo.xml <TagsExtended> block and .aio_series.json.
+    in the ComicInfo.xml <TagsExtended> block, the Komikku details.json
+    (flat `anilist_tags` / `anilist_spoiler_tags` keys), and
+    .aio_series.json.
 
-    Cross-file: serialized to dict in aio-dl.py's .aio_series.json writer
+    Cross-file: serialized to dict in aio-dl.py's details.json writer (grep
+    _build_aio_reader_extras) and .aio_series.json writer (grep _tag_to_dict),
     and to XML in aio-dl.py:_emit_tags_extended.
     """
     name: str
@@ -330,12 +336,55 @@ def _clean_search_title(title: str) -> str:
     (e.g. "...Spoils Me Rotten: After the Rain") and risk a wrong match even
     with full-title scoring. May return a string equal to the input (caller
     dedupes) or "" if nothing survives. Cross-file: called only from
-    enrich_from_anilist's search path.
+    enrich_from_anilist's search path. Subtitle-separator SPLITTING does
+    happen — but in _subtitle_segment, which is search-query-only (never a
+    scoring title), so the parent-match risk above doesn't apply to it.
     """
     if not title:
         return ""
     s = _TITLE_NOISE_RE.sub(" ", str(title))
     return re.sub(r"\s+", " ", s).strip()
+
+
+# Subtitle/volume separators: a ':' or a SPACED dash. Used to pull the trailing
+# distinctive segment out of titles AniList's search can't match whole — e.g.
+# "JoJo no Kimyou na Bouken: Part 4 - Diamond wa Kudakenai" (0 results) vs the
+# trailing "Diamond wa Kudakenai" (id 33006). Hyphens WITHOUT surrounding
+# spaces ("Shangri-La", "Boku-tachi") are deliberately NOT separators.
+_SUBTITLE_SPLIT_RE = re.compile(r":\s+|\s+[-–—]\s+")
+
+
+def _subtitle_segment(title: str) -> str:
+    """Trailing segment after the last subtitle separator — a SEARCH query only,
+    never a scoring title. "" when there's no separator or the trailing part is
+    a <2-word fragment (too generic to anchor a search). Because the match is
+    still gated by scoring against the FULL title in enrich_from_anilist,
+    pulling a parent/other series into the candidate pool here is harmless: it
+    fails the 75 threshold. grep caller: enrich_from_anilist.
+    """
+    parts = [p.strip() for p in _SUBTITLE_SPLIT_RE.split(str(title or "")) if p.strip()]
+    if len(parts) < 2:
+        return ""
+    seg = parts[-1]
+    return seg if len(seg.split()) >= 2 else ""
+
+
+def _shortened_prefix(title: str, words: int = 4) -> str:
+    """First `words` tokens of a LONG, separator-less title — a SEARCH query
+    only. "" when the title has a subtitle separator (use _subtitle_segment
+    instead) or is short enough (≤5 words) that the full-title query already
+    covers it. Rescues long romaji whose spelling drifts between the site and
+    AniList — e.g. AnoHana's "...Namae o Boku-tachi..." vs AniList's
+    "...Namae wo Bokutachi..." returns nothing whole, but "Ano Hi Mita Hana"
+    matches id 65733. grep caller: enrich_from_anilist.
+    """
+    s = str(title or "")
+    if _SUBTITLE_SPLIT_RE.search(s):
+        return ""
+    toks = s.split()
+    if len(toks) <= max(words, 5):
+        return ""
+    return " ".join(toks[:words])
 
 
 def _candidate_titles(media: Dict[str, Any]) -> List[str]:
@@ -355,7 +404,8 @@ def _candidate_titles(media: Dict[str, Any]) -> List[str]:
 def _score_candidate(
     source_titles: List[str], candidate: Dict[str, Any]
 ) -> float:
-    """Best (max) rapidfuzz WRatio across all (source x candidate) pairs.
+    """Best (max) rapidfuzz WRatio across all (source x candidate) pairs,
+    compared case/punctuation-insensitively via default_process.
 
     rapidfuzz is project-wide required for cross-site search; this lazy
     import keeps the failure mode consistent (clear ImportError naming
@@ -363,6 +413,7 @@ def _score_candidate(
     """
     try:
         from rapidfuzz import fuzz
+        from rapidfuzz.utils import default_process
     except ImportError as exc:
         raise ImportError(
             "rapidfuzz is required for --metadata-source enrichment. "
@@ -373,10 +424,17 @@ def _score_candidate(
     cand_titles = _candidate_titles(candidate)
     if not cand_titles:
         return 0.0
+    # processor=default_process lowercases, trims, and strips non-alphanumerics
+    # on both sides before scoring. Without it WRatio is brutally case-sensitive:
+    # "FULL METAL ALCHEMIST" vs the synonym "Full Metal Alchemist" scores 25 raw
+    # but 100 processed (verified against id 30025), while the unrelated romaji
+    # "Hagane no Renkinjutsushi" sits at 26 processed. So the 75 threshold still
+    # separates cleanly — processing rescues case/punctuation drift without
+    # inventing matches.
     best = 0.0
     for s in source_titles:
         for c in cand_titles:
-            score = float(fuzz.WRatio(s, c))
+            score = float(fuzz.WRatio(s, c, processor=default_process))
             if score > best:
                 best = score
     return best
@@ -528,6 +586,14 @@ def _apply_anilist_match(
         NOT_YET_RELEASED → falls through to "0"). No helper change
         needed.
       - anilist_tags / anilist_spoiler_tags: SET (AniList-only fields)
+      - cover: REPLACE with AniList coverImage (extraLarge → large) for
+        cross-library cover normalization — every enriched series ends up
+        with one cover source/quality/aspect. The site's own cover is
+        stashed under `site_cover` (aio-dl.py's cover-download path falls
+        back to it if the AniList CDN fetch fails) and the AniList URL is
+        also mirrored to `anilist_cover` (read by --refresh-library-metadata
+        to decide cover.jpg re-download). Only set when AniList actually
+        supplied a cover.
       - country_of_origin / media_format / anilist_id / mal_id /
         anilist_synonyms: SET
     """
@@ -573,6 +639,31 @@ def _apply_anilist_match(
     media_format = _derive_media_format(country)
     if media_format:
         comic_data["media_format"] = media_format
+
+    # Cover normalization: REPLACE the series cover with AniList's so the
+    # whole library shares one cover source/quality/aspect. extraLarge is
+    # AniList's highest-res variant; large is the smaller fallback. Stash the
+    # site's own cover under `site_cover` so aio-dl.py's cover-download block
+    # can fall back to it when the AniList CDN fetch fails (dl_image returns
+    # None, never raises). Cross-file: aio-dl.py cover-download block (grep
+    # 'site_cover'); the chosen cover flows to cover.jpg, the .aio_series.json
+    # `cover` field, and the UI thumbnail cache (library.js keys on
+    # seriesMeta.cover).
+    cover_block = media.get("coverImage") or {}
+    anilist_cover = cover_block.get("extraLarge") or cover_block.get("large")
+    if anilist_cover:
+        anilist_cover = str(anilist_cover)
+        existing_cover = comic_data.get("cover")
+        if existing_cover and existing_cover != anilist_cover:
+            comic_data["site_cover"] = existing_cover
+        comic_data["cover"] = anilist_cover
+        # Record the AniList cover URL explicitly (parallel to anilist_id).
+        # Not written to any sink today — cover.jpg + the `cover` field carry
+        # it — but --refresh-library-metadata reads it to decide whether to
+        # re-download cover.jpg, so it stays truthy ONLY when AniList actually
+        # supplied a cover (not merely when a site cover is present). grep
+        # anilist_cover in aio-dl.py.
+        comic_data["anilist_cover"] = anilist_cover
 
     comic_data["anilist_synonyms"] = list(media.get("synonyms") or [])
 
@@ -627,15 +718,41 @@ def enrich_from_anilist(
         # search step also fails, comic_data ends up unchanged and the
         # caller logs accordingly.
 
-    # Search path. Build an ordered, deduped title list: each source title
-    # plus its bracket/tilde-stripped variant. Some sites bake a ~...~ or
-    # (...) subtitle into the title that defeats AniList's search index
-    # (e.g. "Shangri-La Frontier ~ Kusoge Hunter, ...~" returns nothing, but
-    # "Shangri-La Frontier" matches id 122063). The cleaned variant is used
-    # both as an extra search query AND for scoring — bracket content is
-    # genuine noise, so a candidate matching the cleaned form is a real match.
-    source_titles: List[str] = []
-    seen_titles = set()
+    # Search path. Two deliberately decoupled lists:
+    #   scoring_titles — the identity set: each source title + its bracket/
+    #     tilde-cleaned variant. The match is ALWAYS gated by scoring against
+    #     these full forms (75 threshold), so nothing below can admit a wrong
+    #     series no matter how broad the search net gets.
+    #   search_queries — the broader net used only to FIND candidates: the
+    #     scoring titles plus two derived fallbacks per title — the trailing
+    #     subtitle segment (_subtitle_segment) and a shortened prefix
+    #     (_shortened_prefix). These rescue titles AniList returns nothing for
+    #     on the full string: subtitle-prefixed romaji ("...Gaiden: Toaru
+    #     Kagaku no Railgun" → id 37776), long romaji with spelling drift
+    #     (AnoHana → id 65733), and ~...~/(...)-suffixed titles (Shangri-La
+    #     Frontier → id 122063).
+    # Per-title order is full → cleaned → subtitle → shortened so precise forms
+    # are tried before loose fallbacks; early-stop means the common case (full
+    # title matches) never fires a fallback query.
+    scoring_titles: List[str] = []
+    search_queries: List[str] = []
+    seen_scoring = set()
+    seen_query = set()
+
+    def _add_scoring(v: str) -> None:
+        v = (v or "").strip()
+        k = v.lower()
+        if v and k not in seen_scoring:
+            seen_scoring.add(k)
+            scoring_titles.append(v)
+
+    def _add_query(v: str) -> None:
+        v = (v or "").strip()
+        k = v.lower()
+        if v and k not in seen_query:
+            seen_query.add(k)
+            search_queries.append(v)
+
     raw_titles: List[str] = []
     if comic_data.get("title"):
         raw_titles.append(str(comic_data["title"]))
@@ -643,18 +760,19 @@ def enrich_from_anilist(
         if alt:
             raw_titles.append(str(alt))
     for raw in raw_titles:
-        for variant in (raw, _clean_search_title(raw)):
-            v = variant.strip()
-            key = v.lower()
-            if v and key not in seen_titles:
-                seen_titles.add(key)
-                source_titles.append(v)
-    if not source_titles:
+        cleaned = _clean_search_title(raw)
+        _add_scoring(raw)
+        _add_scoring(cleaned)
+        _add_query(raw)
+        _add_query(cleaned)
+        _add_query(_subtitle_segment(cleaned or raw))
+        _add_query(_shortened_prefix(cleaned or raw))
+    if not scoring_titles:
         return comic_data
 
-    # Query AniList with each title (full first, then cleaned/alt variants),
-    # accumulating candidates deduped by id; stop early once a candidate
-    # clears the match threshold. Bounded to _MAX_SEARCH_QUERIES requests so
+    # Query AniList with each search query in priority order, accumulating
+    # candidates deduped by id; stop early once one clears the threshold when
+    # scored against scoring_titles. Bounded to _MAX_SEARCH_QUERIES requests so
     # a series that genuinely isn't on AniList can't fan out into a storm.
     # best_score stays 0.0 across the "no hits" and "hits but all below
     # threshold" branches so the caller's log line is uniform.
@@ -662,7 +780,7 @@ def enrich_from_anilist(
     seen_ids = set()
     best: Optional[Dict[str, Any]] = None
     score = 0.0
-    for query in source_titles[:_MAX_SEARCH_QUERIES]:
+    for query in search_queries[:_MAX_SEARCH_QUERIES]:
         for cand in _search_candidates(query):
             cid = cand.get("id")
             if cid is not None and cid in seen_ids:
@@ -671,7 +789,7 @@ def enrich_from_anilist(
                 seen_ids.add(cid)
             pool.append(cand)
         if pool:
-            best, score = _pick_best_candidate(source_titles, pool)
+            best, score = _pick_best_candidate(scoring_titles, pool)
             if best is not None:
                 break
 


### PR DESCRIPTION
## What & why

Three related improvements to `--metadata-source=anilist` so a reader (Komikku, or a custom one) sees **all** the enriched data and the library normalizes consistently. Builds directly on the genre-normalization + in-place library refresh from #47.

### 1. Reader-facing `details.json` extras
Komikku only reads `title/author/artist/description/genre/status` from `details.json`, and `.aio_series.json` is never opened by any reader — so the rich AniList data (per-tag `category`/`rank`/spoiler flags, ids, format, synonyms) previously lived only where no reader could surface it.

Both `details.json` writers (live download **and** `--refresh-library-metadata`) now append flat extension keys:
`anilist_id`, `mal_id`, `country_of_origin`, `media_format`, `anilist_synonyms`, `anilist_tags`, `anilist_spoiler_tags`, plus `source_site` / `source_url` / `language` provenance.

Komikku parses `details.json` with kotlinx `Json { ignoreUnknownKeys = true }`, so these are **silently ignored by Komikku** and read by a custom reader — no compatibility break. Key names dodge Komikku's reserved + TachiyomiSY-ignored set (`source_url` not `url`, `anilist_tags` not `tags`). The six canonical keys still come first. Shared via `_build_aio_reader_extras` so the two writers can't drift.

### 2. AniList cover normalization
On a confident match the series cover is replaced with AniList's `coverImage` (`extraLarge` → `large`) so the whole library shares one cover source / quality / aspect. It flows through to `cover.jpg`, the `.aio_series.json` cover field, and the UI thumbnail. The site cover is stashed (`site_cover`) as a **download-failure fallback**, so an enriched run is never worse than an un-enriched one. `--refresh-library-metadata` re-downloads `cover.jpg` and repoints the cover URL for matched series.

### 3. Robust title matching
- **Case/punctuation-insensitive scoring** via rapidfuzz `default_process`: `"FULL METAL ALCHEMIST"` vs the synonym `"Full Metal Alchemist"` went **25 → 100**, while the unrelated romaji stays at 26 — so the 75 threshold still separates cleanly.
- **Subtitle-segment + shortened-prefix fallback search queries**, while **scoring still uses the full title** so the broader net can't admit a wrong match. Rescues subtitle-prefixed romaji (`"…Gaiden: Toaru Kagaku no Railgun"` → id 37776) and long romaji with spelling drift (AnoHana → id 65733) that AniList's search returns nothing for on the full string.

## Verification
- End-to-end against a 111-series library: matches went from **105/111 → 110/111** (the lone holdout has no AniList manga entry at all).
- Regression-checked: normal titles still match (Berserk/Solo Leveling → 100); non-existent titles still correctly return no match.
- Verification suite green: 302 handlers registered, both CLIs parse, no `torch` import on bare `search_orchestrator` load, no conflict markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
