### PR TITLE
AniList author-aware match fix + opt-in --modernize (JXL/AVIF) transcode

### DIFF
--- a/UI-source/electron/downloader.js
+++ b/UI-source/electron/downloader.js
@@ -195,6 +195,16 @@ function buildCliArgs(args) {
     // <Komikku-SAF>/local/ themselves). Search/library-initiated downloads
     // pick this up via App.jsx's settings.defaults spread.
     komikku: "--komikku",
+    // Content-aware JXL/AVIF transcode (--modernize, CBZ-only). Master toggle
+    // only; the valued knobs (--modernize-format / -distance / -quality /
+    // -min-saving) are emitted below the loops so they only appear when
+    // modernize is on AND the fast-path is satisfiable AND the value differs
+    // from the Python default (mirrors the webtoon-recompress knob gating).
+    // aio-dl.py hard-errors on --modernize with ANY fast-path-disabling flag,
+    // so the modernizeBlocked guard below strips the whole family when the
+    // effective args can't ride the CBZ byte-passthrough fast-path. Python
+    // side: grep '--modernize compatibility checks' + recompress_chapter_images_modern.
+    modernize: "--modernize",
     // Escape hatch for curl_cffi fast download path (2026-05-13). When the
     // user toggles this on in Settings, all handlers fall back to the
     // legacy ThreadPoolExecutor + dl_image cloudscraper path regardless
@@ -230,10 +240,30 @@ function buildCliArgs(args) {
   const recompressIncompatible =
     (args.format === "none" || args.format === "pdf") && args.komikku !== true;
 
+  // --modernize rides the CBZ byte-passthrough fast-path and aio-dl.py rejects
+  // it with a HARD error on any fast-path-disabling flag (grep '--modernize
+  // compatibility checks' — the seven conditions). This buildCliArgs is the
+  // single chokepoint for every spawn path, and the search/library paths
+  // spread raw settings.defaults (which can carry modernize:true alongside a
+  // conflicting quality/scaling/preserve), so strip the whole --modernize*
+  // family here whenever the effective args can't satisfy the fast-path —
+  // defense-in-depth behind the SettingsTab/DownloadTab UI guards. komikku
+  // coerces format→cbz BEFORE the Python check, so it keeps modernize valid
+  // regardless of the format value (stricter than webtoon: cbz only, NOT epub).
+  const modernizeBlocked =
+    (args.format !== "cbz" && args.komikku !== true) ||
+    (args.quality != null && Number(args.quality) < 100) ||
+    (args.scaling != null && Number(args.scaling) < 100) ||
+    args.cbzPreserveOriginals === false ||
+    args.noProcessing === true ||
+    (args.width != null && args.width !== "") ||
+    (args.aspectRatio != null && args.aspectRatio !== "");
+
   // Add boolean flags
   for (const [key, flag] of Object.entries(boolMap)) {
     if (args[key] === true) {
       if (key === "webtoonRecompress" && recompressIncompatible) continue;
+      if (key === "modernize" && modernizeBlocked) continue;
       cliArgs.push(flag);
     }
   }
@@ -276,6 +306,27 @@ function buildCliArgs(args) {
     }
     if (args.webtoonRecompressMethod != null && args.webtoonRecompressMethod !== 4) {
       cliArgs.push("--webtoon-recompress-method", String(args.webtoonRecompressMethod));
+    }
+  }
+
+  // --modernize valued knobs. Same gating shape as the webtoon knobs above:
+  // emit only when the master toggle is on, the fast-path is satisfiable
+  // (!modernizeBlocked), and the value differs from aio-dl.py's argparse
+  // default — keeps the spawn line clean (Python applies the defaults when a
+  // flag is absent). Defaults: format=auto, distance=1.0, quality=90,
+  // min-saving=0.92 (grep the '--modernize-*' add_argument calls in aio-dl.py).
+  if (args.modernize === true && !modernizeBlocked) {
+    if (args.modernizeFormat != null && args.modernizeFormat !== "auto") {
+      cliArgs.push("--modernize-format", String(args.modernizeFormat));
+    }
+    if (args.modernizeDistance != null && Number(args.modernizeDistance) !== 1.0) {
+      cliArgs.push("--modernize-distance", String(args.modernizeDistance));
+    }
+    if (args.modernizeQuality != null && Number(args.modernizeQuality) !== 90) {
+      cliArgs.push("--modernize-quality", String(args.modernizeQuality));
+    }
+    if (args.modernizeMinSaving != null && Number(args.modernizeMinSaving) !== 0.92) {
+      cliArgs.push("--modernize-min-saving", String(args.modernizeMinSaving));
     }
   }
 

--- a/UI-source/electron/setup.js
+++ b/UI-source/electron/setup.js
@@ -796,6 +796,31 @@ class PythonSetup {
     }
     this._onLog("All runtime imports verified ✓");
 
+    // ── Optional image-modernize codec probe (non-fatal) ──
+    // pillow-jxl-plugin (in requirements.txt → installed above) registers the
+    // JXL encoder used by the opt-in --modernize transcode stage; AVIF is
+    // native in Pillow >= 12. This is deliberately NOT in REQUIRED_IMPORTS:
+    // like pyvips it's an optional accelerator, so a user who never passes
+    // --modernize doesn't need it and we don't want to brick setup over it on
+    // some exotic platform without a JXL wheel. We just surface availability
+    // in the setup log so the codecs are visibly bundled on first-time setup,
+    // and catch the "installed but native extension won't load" case early
+    // (aio-dl.py also hard-errors at --modernize time with an install hint).
+    this._onLog("Checking image-modernize codecs (JXL/AVIF, optional)…");
+    try {
+      const codecOut = await this._runPython([
+        "-c",
+        "import pillow_jxl; from PIL import Image; Image.init(); " +
+          "print('JXL', 'JXL' in Image.SAVE, '| AVIF', 'AVIF' in Image.SAVE)",
+      ]);
+      this._onLog(`  modernize codecs: ${codecOut.trim()} ✓`);
+    } catch (err) {
+      this._onLog(
+        "  modernize codecs unavailable — --modernize will be rejected until " +
+          `'pip install pillow-jxl-plugin' succeeds. Detail: ${err.message}`
+      );
+    }
+
     // ── End-to-end bundle verification ──
     // Verify aio-dl.py's entire dependency tree loads — including all
     // 40+ handlers in sites/__init__.py and the deferred-import target

--- a/UI-source/src/components/DownloadTab.jsx
+++ b/UI-source/src/components/DownloadTab.jsx
@@ -83,6 +83,16 @@ const DEFAULT_FORM = {
   webtoonRecompress: false,
   webtoonRecompressQuality: 85,
   webtoonRecompressMethod: 4,
+  // Content-aware JXL/AVIF transcode (--modernize, CBZ-only). Master toggle +
+  // knobs; settings.defaults spreads these onto the form via formDefaults()
+  // (line ~123). handleStart emits them when modernizeAllowed; downloader.js
+  // :buildCliArgs maps modernize* → --modernize* and strips the family if the
+  // CBZ fast-path is disabled. aio-dl.py: grep '--modernize compatibility checks'.
+  modernize: false,
+  modernizeFormat: "auto",
+  modernizeQuality: 90,
+  modernizeDistance: 1.0,
+  modernizeMinSaving: 0.92,
   // Komikku-compatible per-chapter CBZ output (2026-05-12, Komikku LocalSource format).
   // When on, Python force-coerces format=cbz / keep-chapters / no-final-file,
   // writes per-chapter ComicInfo.xml inside each CBZ, plus cover.jpg +
@@ -164,6 +174,13 @@ export default function DownloadTab({
   const recompressAllowed =
     form.komikku || form.format === "cbz" || form.format === "epub";
 
+  // --modernize is CBZ-only (stricter than webtoon's cbz/epub): its .jxl/.avif
+  // pages only survive the CBZ byte-passthrough fast-path. komikku coerces
+  // format→cbz so it qualifies. Gates the handleStart emit below so a stale
+  // saved default can't push --modernize onto a pdf/none/epub job.
+  const modernizeAllowed =
+    form.komikku || form.format === "cbz";
+
   // Build CLI args from form state and trigger download
   const handleStart = () => {
     const urls = form.urls.split("\n").map((u) => u.trim()).filter(Boolean);
@@ -224,6 +241,19 @@ export default function DownloadTab({
     // this is true.
     if (form.komikku) {
       args.komikku = true;
+    }
+    // Content-aware JXL/AVIF transcode (--modernize, CBZ-only). Emit the master
+    // toggle + valued knobs; downloader.js:buildCliArgs maps them and strips the
+    // whole family if the effective args can't ride the CBZ fast-path (quality
+    // 100 / scaling 100 / preserve-on / no-processing-off / no width-aspect
+    // override), so we don't re-check those here. modernizeAllowed gates on
+    // format like webtoon so a stale saved default never reaches a pdf/none/epub job.
+    if (form.modernize && modernizeAllowed) {
+      args.modernize = true;
+      args.modernizeFormat = form.modernizeFormat;
+      args.modernizeDistance = form.modernizeDistance;
+      args.modernizeQuality = form.modernizeQuality;
+      args.modernizeMinSaving = form.modernizeMinSaving;
     }
     if (form.splitMode === "size" && form.splitValue) args.split = form.splitValue;
     if (form.splitMode === "chapters" && form.splitValue) args.split = `${form.splitValue}ch`;
@@ -310,6 +340,12 @@ export default function DownloadTab({
                   // recompress valid (mirror of recompressAllowed).
                   ...((f.value === "pdf" || f.value === "none") && !prev.komikku
                     ? { webtoonRecompress: false }
+                    : {}),
+                  // --modernize is CBZ-only (stricter than webtoon): clear it
+                  // whenever the picked format isn't cbz and komikku isn't
+                  // coercing to cbz, so an incompatible combo can't be launched.
+                  ...(f.value !== "cbz" && !prev.komikku
+                    ? { modernize: false }
                     : {}),
                 }));
               }}

--- a/UI-source/src/components/SettingsTab.jsx
+++ b/UI-source/src/components/SettingsTab.jsx
@@ -448,6 +448,20 @@ export default function SettingsTab({ settings, onSave }) {
       webtoonRecompress: false,
       webtoonRecompressQuality: 85,
       webtoonRecompressMethod: 4,
+      // Content-aware JXL/AVIF transcode (opt-in, CBZ-only). Mirrors the
+      // --modernize* CLI flags (aio-dl.py, grep '--modernize compatibility
+      // checks'). Rides the CBZ byte-passthrough fast-path, so it's only valid
+      // with the fast-path conditions (format cbz/komikku, quality 100,
+      // scaling 100, preserve-originals on, no-processing off); the toggle in
+      // the Modernize section below auto-corrects those on enable, and
+      // downloader.js:buildCliArgs (modernizeBlocked) strips the flag if
+      // they're ever violated. DownloadTab's DEFAULT_FORM spread + App.jsx's
+      // search/library defaults spread propagate these to every download path.
+      modernize: false,
+      modernizeFormat: "auto",      // auto | jxl | avif | jxl+avif
+      modernizeQuality: 90,         // AVIF color quality (1-100)
+      modernizeDistance: 1.0,       // JXL grayscale distance (0.0 = lossless)
+      modernizeMinSaving: 0.92,     // keep transcode only if < orig * this
     },
     // Per-search defaults — read by SearchTab on mount via the same
     // settings.searchOpts namespace. Surfaced here so the user has one
@@ -561,6 +575,30 @@ export default function SettingsTab({ settings, onSave }) {
     local.defaults.format === "cbz" ||
     local.defaults.format === "epub";
 
+  // Whether --modernize is valid for the current default config. Unlike
+  // webtoon-recompress (which also allows epub), modernize is CBZ-ONLY: it
+  // emits .jxl/.avif pages that only survive the CBZ byte-passthrough
+  // fast-path (other formats re-encode them away). komikku coerces format→cbz
+  // so it qualifies too. Drives the toggle's disabled state + the on-enable
+  // auto-correct below; mirrors aio-dl.py's '--modernize compatibility checks'.
+  const modernizeAllowedDefault =
+    local.defaults.komikku || local.defaults.format === "cbz";
+
+  // Fast-path conditions modernize needs beyond the format gate (quality 100,
+  // scaling 100, preserve-originals on, no-processing off). The enable handler
+  // sets these, but the user can still break them afterward via the
+  // sliders/toggles above — surface that as a warning instead of letting
+  // aio-dl.py hard-error mid-spawn. buildCliArgs (modernizeBlocked) also strips
+  // --modernize defensively in that case, so a broken combo just skips
+  // modernize rather than failing the whole download.
+  const modernizeConflicts =
+    !!local.defaults.modernize && modernizeAllowedDefault && (
+      (local.defaults.quality ?? 100) < 100 ||
+      (local.defaults.scaling ?? 100) < 100 ||
+      local.defaults.cbzPreserveOriginals === false ||
+      local.defaults.noProcessing === true
+    );
+
   // Dirty count drives the SaveSettingsButton's pre-click visual
   // ("Save Settings · N changed" + amber ring/dot when > 0, "Up to date"
   // when 0). Recomputed cheaply on any local-state change; the diff
@@ -636,6 +674,12 @@ export default function SettingsTab({ settings, onSave }) {
         webtoonRecompress: false,
         webtoonRecompressQuality: 85,
         webtoonRecompressMethod: 4,
+        // Modernize transcode defaults — mirror the initial-state block above.
+        modernize: false,
+        modernizeFormat: "auto",
+        modernizeQuality: 90,
+        modernizeDistance: 1.0,
+        modernizeMinSaving: 0.92,
         // Komikku-mode default. Reset mirrors initial-state; see the
         // rationale block in the initial useState above.
         komikku: false,
@@ -828,6 +872,14 @@ export default function SettingsTab({ settings, onSave }) {
                     ...((next === "pdf" || next === "none") && !prev.defaults.komikku
                       ? { webtoonRecompress: false }
                       : {}),
+                    // --modernize is CBZ-only (stricter than webtoon, which
+                    // also allows epub): its .jxl/.avif pages only survive CBZ
+                    // output. Clear it whenever the new format isn't cbz and
+                    // komikku isn't coercing to cbz, so we never persist a
+                    // contradictory combo (mirrors modernizeAllowedDefault).
+                    ...(next !== "cbz" && !prev.defaults.komikku
+                      ? { modernize: false }
+                      : {}),
                   },
                 }));
               }}
@@ -956,6 +1008,196 @@ export default function SettingsTab({ settings, onSave }) {
             checked={!!local.defaults.komikku}
             onCheckedChange={(v) => setDefault("komikku", v)}
           />
+        </div>
+
+        {/* Modernize Images (JXL/AVIF) ───────────────────────────────
+            Opt-in content-aware transcode (--modernize family). Placed under
+            Komikku Output because it's CBZ-only and pairs naturally with the
+            per-chapter Komikku CBZs (komikku coerces format→cbz). The master
+            toggle is gated on modernizeAllowedDefault (komikku || format cbz)
+            and, on enable, auto-corrects the fast-path conditions (quality 100
+            / scaling 100 / preserve-originals on / no-processing off) so the
+            saved config can't hard-error at spawn — mirrors the format=none →
+            keepImages auto-enable precedent above. The valued knobs map 1:1 to
+            the CLI: codec routing, JXL distance, AVIF quality, min-saving.
+            DownloadTab's DEFAULT_FORM spread + App.jsx's defaults spread carry
+            these to every download; downloader.js:buildCliArgs maps modernize*
+            → --modernize* and strips them if the fast-path is disabled. Needs
+            pillow-jxl-plugin in the env (bundled via requirements.txt on
+            first-time setup; setup.js logs codec availability). */}
+        <SectionHeader>Modernize Images (JXL/AVIF)</SectionHeader>
+        <p className="text-[10px] text-muted-foreground -mt-1 mb-2 leading-snug">
+          Re-encode JPEG/PNG pages to <span className="font-mono">JXL</span>{" "}
+          (grayscale line art) or <span className="font-mono">AVIF</span>{" "}
+          (color) before packaging — visually-lossless storage savings for a
+          reader that decodes them. Per-page choice; already-efficient
+          WebP/AVIF/JXL pages are left untouched, and a page is only replaced
+          when the new file actually comes out smaller (never bloats). CBZ only
+          — rides the byte-passthrough fast-path, so it pairs with Komikku
+          output and keeps the source resolution.
+        </p>
+        <div className="space-y-3">
+          <div className="flex items-start gap-3">
+            <Switch
+              checked={!!local.defaults.modernize && modernizeAllowedDefault}
+              onCheckedChange={(v) => {
+                if (!modernizeAllowedDefault) return;
+                if (v) {
+                  // Enable + auto-correct the fast-path conditions modernize
+                  // requires (aio-dl.py hard-errors otherwise). The quality /
+                  // scaling sliders are moot under modernize anyway — it
+                  // replaces the page bytes with JXL/AVIF, so a prior re-encode
+                  // would just be wasted generation loss. Mirrors the
+                  // format=none → keepImages auto-enable above.
+                  setLocal((prev) => ({
+                    ...prev,
+                    defaults: {
+                      ...prev.defaults,
+                      modernize: true,
+                      quality: 100,
+                      scaling: 100,
+                      cbzPreserveOriginals: true,
+                      noProcessing: false,
+                    },
+                  }));
+                } else {
+                  setDefault("modernize", false);
+                }
+              }}
+              disabled={!modernizeAllowedDefault}
+              className="mt-0.5"
+            />
+            <div className="flex-1">
+              <Label className={cn("text-xs cursor-pointer", !modernizeAllowedDefault && "opacity-40")}>
+                Transcode pages to JXL / AVIF
+              </Label>
+              <p className="text-[10px] text-muted-foreground mt-0.5">
+                Applies to every CBZ download — direct URL, search-initiated,
+                and library re-downloads. Idempotent: re-running over an
+                already-modernized series skips pages that are already JXL/AVIF.
+              </p>
+              {!modernizeAllowedDefault && (
+                <p className="text-[10px] text-yellow-500 dark:text-yellow-400 mt-1 leading-snug">
+                  Unavailable while the default format is{" "}
+                  <span className="font-mono">{(local.defaults.format || "").toUpperCase()}</span>{" "}
+                  — modernize writes JXL/AVIF pages that only survive CBZ output.
+                  Switch the default format to CBZ (or enable Komikku) to use it.
+                </p>
+              )}
+            </div>
+          </div>
+          {local.defaults.modernize && modernizeAllowedDefault && (
+            <div className="pl-12 animate-slide-up space-y-3">
+              {modernizeConflicts && (
+                <p className="text-[10px] text-yellow-500 dark:text-yellow-400 leading-snug">
+                  Heads up — modernize needs the CBZ byte-passthrough fast-path,
+                  but your current defaults disable it:
+                  {(local.defaults.quality ?? 100) < 100 && (
+                    <> <span className="font-mono">Quality&nbsp;{local.defaults.quality}</span></>
+                  )}
+                  {(local.defaults.scaling ?? 100) < 100 && (
+                    <> <span className="font-mono">Scaling&nbsp;{local.defaults.scaling}%</span></>
+                  )}
+                  {local.defaults.cbzPreserveOriginals === false && (
+                    <> <span className="font-mono">preserve-originals&nbsp;off</span></>
+                  )}
+                  {local.defaults.noProcessing === true && (
+                    <> <span className="font-mono">no-processing&nbsp;on</span></>
+                  )}
+                  . The downloader will skip modernize until these are reset
+                  (Quality 100, Scaling 100%, CBZ preserve-originals on,
+                  No&nbsp;processing off).
+                </p>
+              )}
+              <div>
+                <Label className="text-xs">Codec routing</Label>
+                <Select
+                  value={local.defaults.modernizeFormat ?? "auto"}
+                  onChange={(e) => setDefault("modernizeFormat", e.target.value)}
+                  className="mt-1"
+                >
+                  <option value="auto">Auto — JXL for B&amp;W, AVIF for color</option>
+                  <option value="jxl">JXL only</option>
+                  <option value="avif">AVIF only</option>
+                  <option value="jxl+avif">JXL + AVIF — encode both, keep smaller</option>
+                </Select>
+                <p className="text-[10px] text-muted-foreground mt-1 leading-snug">
+                  <span className="font-mono">Auto</span> decides per page (the
+                  right call for mixed libraries). Oversized pages
+                  (&gt; 8192&nbsp;px) always use JXL, except under AVIF-only
+                  where they're left untouched.
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <Label className="text-xs">JXL distance (B&amp;W)</Label>
+                    <Badge variant="secondary" className="font-mono tabular-nums">
+                      {(local.defaults.modernizeDistance ?? 1.0) === 0
+                        ? "lossless"
+                        : (local.defaults.modernizeDistance ?? 1.0).toFixed(1)}
+                    </Badge>
+                  </div>
+                  <Slider
+                    value={local.defaults.modernizeDistance ?? 1.0}
+                    onValueChange={(v) => setDefault("modernizeDistance", v)}
+                    min={0}
+                    max={3}
+                    step={0.1}
+                  />
+                  <p className="text-[10px] text-muted-foreground mt-1 leading-snug">
+                    Butteraugli distance for grayscale → JXL.{" "}
+                    <span className="font-mono">1.0</span> = visually lossless
+                    (default); lower = larger/closer to source;{" "}
+                    <span className="font-mono">0.0</span> = mathematically
+                    lossless (much larger; only wins on PNG sources).
+                  </p>
+                </div>
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <Label className="text-xs">AVIF quality (color)</Label>
+                    <Badge variant="secondary" className="font-mono tabular-nums">
+                      {local.defaults.modernizeQuality ?? 90}
+                    </Badge>
+                  </div>
+                  <Slider
+                    value={local.defaults.modernizeQuality ?? 90}
+                    onValueChange={(v) => setDefault("modernizeQuality", v)}
+                    min={1}
+                    max={100}
+                  />
+                  <p className="text-[10px] text-muted-foreground mt-1 leading-snug">
+                    AVIF quality for color pages.{" "}
+                    <span className="font-mono">90</span> = visually lossless
+                    (default); <span className="font-mono">85</span> =
+                    aggressive (smaller; artifacts only under pixel-peeping).
+                  </p>
+                </div>
+              </div>
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <Label className="text-xs">Minimum saving to replace a page</Label>
+                  <Badge variant="secondary" className="font-mono tabular-nums">
+                    ≥{Math.round((1 - (local.defaults.modernizeMinSaving ?? 0.92)) * 100)}%
+                  </Badge>
+                </div>
+                <Slider
+                  value={local.defaults.modernizeMinSaving ?? 0.92}
+                  onValueChange={(v) => setDefault("modernizeMinSaving", v)}
+                  min={0.5}
+                  max={1}
+                  step={0.01}
+                />
+                <p className="text-[10px] text-muted-foreground mt-1 leading-snug">
+                  A transcoded page is kept only if it's at least this much
+                  smaller than the original — otherwise the original bytes stay.
+                  Default <span className="font-mono">≥8%</span>{" "}
+                  (<span className="font-mono">min-saving 0.92</span>) skips
+                  already-dense pages so the archive never grows.
+                </p>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Metadata Enrichment ────────────────────────────────────

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -3098,12 +3098,20 @@ def recompress_chapter_images_modern(
                 candidates: List[Tuple[int, str]] = []
                 if target in ("jxl", "both"):
                     jxl_path = base + ".jxl"
-                    # Encode as-is (no convert("L") — see header). Only normalize
-                    # exotic modes pillow_jxl can't take (P/CMYK/I/...).
-                    jxl_src = (
-                        im if im.mode in ("L", "LA", "RGB", "RGBA")
-                        else im.convert("RGB")
-                    )
+                    # Encode as-is (no convert("L") — see header). Keep alpha-
+                    # capable modes (JXL carries alpha); map paletted
+                    # transparency to RGBA so palette alpha isn't flattened; only
+                    # widen truly exotic modes pillow_jxl can't take (opaque P /
+                    # CMYK / I / ...) to RGB. Mirrors the AVIF branch's no-flatten
+                    # rule (grep 'AVIF carries alpha').
+                    if im.mode in ("L", "LA", "RGB", "RGBA"):
+                        jxl_src = im
+                    elif im.mode == "PA" or (
+                        im.mode == "P" and "transparency" in im.info
+                    ):
+                        jxl_src = im.convert("RGBA")
+                    else:
+                        jxl_src = im.convert("RGB")
                     # JPEG quirk (measured on file-based sources, which is all
                     # we get): pillow_jxl's default lossless_jpeg=True does
                     # bit-exact JPEG *reconstruction* and SILENTLY IGNORES
@@ -3127,9 +3135,23 @@ def recompress_chapter_images_modern(
                     candidates.append((os.path.getsize(jxl_path), jxl_path))
                 if target in ("avif", "both"):
                     avif_path = base + ".avif"
-                    avif_src = (
-                        im if im.mode in ("RGB", "L") else im.convert("RGB")
-                    )
+                    # AVIF carries alpha — never flatten it. The CBZ byte-
+                    # passthrough fast path this rides preserved the original PNG,
+                    # so a transparent page (RGBA / LA / paletted-transparency)
+                    # must stay transparent; converting it to RGB here would make
+                    # the background opaque. Map every alpha-bearing source to
+                    # RGBA and widen the rest (L / opaque-P / CMYK / ...) to RGB.
+                    # Grayscale color-routed pages are rare (auto sends B&W to
+                    # JXL), so the L->RGB widening only bites forced
+                    # --modernize-format avif / jxl+avif.
+                    if im.mode == "RGB":
+                        avif_src = im
+                    elif im.mode in ("RGBA", "LA", "PA") or (
+                        im.mode == "P" and "transparency" in im.info
+                    ):
+                        avif_src = im.convert("RGBA")
+                    else:
+                        avif_src = im.convert("RGB")
                     avif_src.save(
                         avif_path, format="AVIF", quality=color_quality, speed=6
                     )
@@ -4416,6 +4438,26 @@ def _save_download_params(out_dir: str, url: str, args, title: str) -> None:
         "metadata_source": str(getattr(args, "metadata_source", "none") or "none"),
         "metadata_tag_min_rank": int(getattr(args, "metadata_tag_min_rank", 50) or 50),
         "metadata_refresh": bool(getattr(args, "metadata_refresh", False)),
+        # Content-aware JXL/AVIF transcode (--modernize family). Persisted so
+        # --update-all child runs keep transcoding newly downloaded chapters;
+        # without this a series first grabbed with --save-params --modernize
+        # would get plain JPEG/PNG pages on every update, leaving the library
+        # half-modernized. Replay branch: _append_saved_update_options. NOTE: no
+        # `or` defaults on distance/min_saving — 0.0 distance (JXL lossless) is a
+        # valid value that `or` would silently clobber to the default.
+        "modernize": bool(getattr(args, "modernize", False)),
+        "modernize_format": str(getattr(args, "modernize_format", "auto") or "auto"),
+        "modernize_quality": int(getattr(args, "modernize_quality", 90) or 90),
+        "modernize_distance": float(
+            getattr(args, "modernize_distance", 1.0)
+            if getattr(args, "modernize_distance", 1.0) is not None
+            else 1.0
+        ),
+        "modernize_min_saving": float(
+            getattr(args, "modernize_min_saving", 0.92)
+            if getattr(args, "modernize_min_saving", 0.92) is not None
+            else 0.92
+        ),
     }
     if getattr(args, "format", None) == "epub":
         data["epub_layout"] = getattr(args, "epub_layout", "vertical")
@@ -4474,12 +4516,22 @@ def _append_saved_update_options(child_cmd: List[str], params: Dict[str, Any]) -
         child_cmd.extend(["--site", str(params["site"])])
     if params.get("epub_layout"):
         child_cmd.extend(["--epub-layout", str(params["epub_layout"])])
-    if params.get("width"):
+    # --modernize rides the CBZ byte-passthrough fast-path and HARD-errors at
+    # parse time on an explicit --width / --aspect-ratio / --quality (grep
+    # '--modernize compatibility checks'). When replaying a modernize series we
+    # must NOT re-emit those — the saved values are just the cbz defaults the
+    # original run never set explicitly (e.g. width=1500), and emitting them
+    # would flip the child's _user_set_* sentinels and make it self-reject. The
+    # original run required scaling==100, so the saved scaling is 100 and
+    # emitting it stays compatible.
+    _replay_modernize = bool(params.get("modernize"))
+    if params.get("width") and not _replay_modernize:
         child_cmd.extend(["--width", str(params["width"])])
-    if params.get("aspect_ratio"):
+    if params.get("aspect_ratio") and not _replay_modernize:
         child_cmd.extend(["--aspect-ratio", str(params["aspect_ratio"])])
     if not params.get("no_processing"):
-        child_cmd.extend(["--quality", str(params.get("quality", 85))])
+        if not _replay_modernize:
+            child_cmd.extend(["--quality", str(params.get("quality", 85))])
         child_cmd.extend(["--scaling", str(params.get("scaling", 100))])
     if params.get("cookies"):
         child_cmd.extend(["--cookies", str(params["cookies"])])
@@ -4525,6 +4577,29 @@ def _append_saved_update_options(child_cmd: List[str], params: Dict[str, Any]) -
         saved_rank = params.get("metadata_tag_min_rank")
         if isinstance(saved_rank, int) and saved_rank != 50:
             child_cmd.extend(["--metadata-tag-min-rank", str(saved_rank)])
+
+    # Content-aware JXL/AVIF transcode (--modernize family). Mirrors the
+    # metadata_source replay above: saved by _save_download_params, absent in
+    # older download_params.json (get → None → skipped, forward-compatible).
+    # Emit the master flag + only NON-default knobs (argparse defaults:
+    # format=auto, quality=90, distance=1.0, min-saving=0.92) to keep the spawn
+    # line clean. The child re-runs the parse-time compat checks; because the
+    # width/aspect/quality emissions above are suppressed under _replay_modernize
+    # and --format cbz / --scaling 100 are replayed, it satisfies the fast-path.
+    if _replay_modernize:
+        child_cmd.append("--modernize")
+        mfmt = params.get("modernize_format")
+        if mfmt and mfmt != "auto":
+            child_cmd.extend(["--modernize-format", str(mfmt)])
+        mq = params.get("modernize_quality")
+        if isinstance(mq, (int, float)) and int(mq) != 90:
+            child_cmd.extend(["--modernize-quality", str(int(mq))])
+        md = params.get("modernize_distance")
+        if isinstance(md, (int, float)) and float(md) != 1.0:
+            child_cmd.extend(["--modernize-distance", str(md)])
+        mms = params.get("modernize_min_saving")
+        if isinstance(mms, (int, float)) and float(mms) != 0.92:
+            child_cmd.extend(["--modernize-min-saving", str(mms)])
     if params.get("metadata_refresh"):
         child_cmd.append("--metadata-refresh")
 
@@ -9160,19 +9235,43 @@ def main():
             _pdf_source_paths: Optional[List[Optional[str]]] = None
 
             if raw_image_paths:
+                # Phase B (2026-05-07): CBZ fast-path. When the user is on
+                # default --scaling 100 with no width/aspect/quality override,
+                # we put the original wire bytes straight into the archive —
+                # no PIL decode, no recombine, no JPEG re-encode. The archive
+                # layer (build_cbz / build_cbz_from_content) preserves
+                # per-file extensions on the arcname, so .webp downloads stay
+                # .webp, .png stay .png, etc. Phase A made raw_image_paths
+                # land with correct extensions which is what makes this work.
+                # Computed BEFORE the --modernize block so modernize gates on the
+                # exact same condition (see below).
+                cbz_fast_path = (
+                    args.format == "cbz"
+                    and not args.no_processing
+                    and not getattr(args, "no_cbz_preserve_originals", False)
+                    and scale_factor == 1.0
+                    and not getattr(args, "_user_set_width", False)
+                    and not getattr(args, "_user_set_aspect_ratio", False)
+                    and not getattr(args, "_user_set_quality", False)
+                )
                 # --modernize (opt-in, CBZ-only): content-aware JXL/AVIF
                 # transcode of the downloaded pages, in place, BEFORE the CBZ
-                # fast-path below consumes raw_image_paths. Hard-gated at parse
-                # time to the byte-passthrough fast-path (grep '--modernize
-                # compatibility checks'), so the new .jxl/.avif bytes flow
-                # straight into build_cbz with correct extensions and never
-                # reach the slow save_final_images path (which would re-encode
-                # them to PNG). Runs after the webtoon-recompress block above
-                # (so pages already converted to .webp are skipped) and after
-                # the prefetch-chain kickoff (so the CPU-bound encode overlaps
-                # the next chapters' downloads). See
+                # fast-path consumes raw_image_paths — so the new .jxl/.avif
+                # bytes flow straight into build_cbz with correct extensions and
+                # never reach the slow save_final_images path (which would
+                # re-encode them to PNG). Gated on cbz_fast_path itself, NOT just
+                # format==cbz: the parse-time hard errors (grep '--modernize
+                # compatibility checks') are SKIPPED on a --restore-parameters
+                # resume (the bare resume CLI omits --modernize, so that block
+                # never runs, then run_params.json restores modernize=True). A
+                # resume that re-adds a fast-path-breaking override
+                # (--no-processing / --width / --scaling) would otherwise smuggle
+                # .jxl/.avif into the slow path; riding cbz_fast_path closes that
+                # hole. Runs after the webtoon-recompress block above (so .webp
+                # pages are skipped) and after the prefetch kickoff (CPU encode
+                # overlaps the next downloads). See
                 # recompress_chapter_images_modern().
-                if getattr(args, "modernize", False) and args.format == "cbz":
+                if getattr(args, "modernize", False) and cbz_fast_path:
                     _t0_modernize = time.monotonic()
                     log_verbose(
                         f"  [modernize] Transcoding {len(raw_image_paths)} pages "
@@ -9189,23 +9288,17 @@ def main():
                         f"  [modernize] Done in "
                         f"{time.monotonic() - _t0_modernize:.1f}s."
                     )
-                # Phase B (2026-05-07): CBZ fast-path. When the user is on
-                # default --scaling 100 with no width/aspect/quality override,
-                # we put the original wire bytes straight into the archive —
-                # no PIL decode, no recombine, no JPEG re-encode. The archive
-                # layer (build_cbz / build_cbz_from_content) preserves
-                # per-file extensions on the arcname, so .webp downloads stay
-                # .webp, .png stay .png, etc. Phase A made raw_image_paths
-                # land with correct extensions which is what makes this work.
-                cbz_fast_path = (
-                    args.format == "cbz"
-                    and not args.no_processing
-                    and not getattr(args, "no_cbz_preserve_originals", False)
-                    and scale_factor == 1.0
-                    and not getattr(args, "_user_set_width", False)
-                    and not getattr(args, "_user_set_aspect_ratio", False)
-                    and not getattr(args, "_user_set_quality", False)
-                )
+                elif getattr(args, "modernize", False):
+                    # Requested but the fast-path is disabled — almost always a
+                    # resume with a fast-path-breaking override. Skip (don't feed
+                    # .jxl/.avif into the re-encode path) and say so, rather than
+                    # hard-erroring and aborting the whole resume.
+                    log_verbose(
+                        "  [modernize] skipped: effective settings disable the "
+                        "CBZ byte-passthrough fast-path (e.g. a "
+                        "--restore-parameters resume adding --no-processing, "
+                        "--width, or --scaling). Pages left as-is."
+                    )
                 if cbz_fast_path:
                     processed_page_images = list(raw_image_paths)
                     log_verbose(

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -3066,6 +3066,17 @@ def recompress_chapter_images_modern(
             import pillow_jxl  # noqa: F401
         except ImportError:
             pass
+    if policy != "jxl":
+        # AVIF is native in Pillow >= 12; the pillow-avif-plugin fallback for
+        # older Pillow only registers on import (Image.init() won't trigger it).
+        # Best-effort so an avif/auto/jxl+avif policy works on pre-12 Pillow too,
+        # mirroring the pillow_jxl import and the parse-time gate (grep
+        # 'import pillow_avif'). Missing -> the AVIF save fails per-page and the
+        # original is kept (broad catch in _convert_one).
+        try:
+            import pillow_avif  # noqa: F401
+        except ImportError:
+            pass
     # Register plugins once, single-threaded, before the worker pool starts.
     # The native AVIF plugin registers lazily on first save; letting parallel
     # workers trigger that registration concurrently is a data race. Idempotent.
@@ -7152,6 +7163,18 @@ def main():
                     "(or use --modernize-format avif for AVIF-only)."
                 )
         if _mpolicy in ("auto", "avif", "jxl+avif"):
+            # AVIF is native in Pillow >= 12 (Image.init() registers it). On
+            # OLDER Pillow the pillow-avif-plugin fallback advertised in the
+            # error below registers AVIF only when its module is IMPORTED —
+            # Image.init() does not load it — so try that import first or we'd
+            # reject a working install. Best-effort, mirrors the pillow_jxl
+            # import above. The same import is repeated in
+            # recompress_chapter_images_modern so the encoder is present at
+            # encode time too (grep 'import pillow_avif').
+            try:
+                import pillow_avif  # noqa: F401  (registers AVIF in PIL.Image.SAVE)
+            except ImportError:
+                pass
             Image.init()  # native AVIF plugin registers lazily
             if "AVIF" not in Image.SAVE:
                 p.error(

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -2949,6 +2949,265 @@ def recompress_chapter_images_to_webp(
 
 
 # -----------------------------------------------------------
+# Content-aware JXL/AVIF recompression (opt-in via --modernize)
+# -----------------------------------------------------------
+# Structural twin of recompress_chapter_images_to_webp (above): same cpu//2
+# ThreadPool, same write-temp-then-os.remove-original atomicity, same broad-
+# catch keep-original-on-failure. Differences:
+#   * Content-aware per-page routing: B&W line art -> JXL, color -> AVIF.
+#     Routing is a SIZE decision ONLY — we never convert("L") (empirically 0%
+#     gain at distance 1.0, since libjxl already zeroes imperceptible chroma,
+#     and it would be the one irreversible op), so a misroute costs bytes,
+#     never pixels.
+#   * A per-page min_saving guard: adopt the new file only if it's smaller than
+#     orig*min_saving, else keep the original byte-for-byte. Never bloats, and
+#     self-corrects a gray->AVIF misroute (AVIF on line art is ~95% of source,
+#     above the 0.92 guard, so the original is kept).
+#   * Skips WEBP/AVIF/GIF/JXL sources (already efficient / animated / already
+#     modern) so re-runs are idempotent.
+# Cross-file: gated call site at the top of the `if raw_image_paths:` block in
+# the chapter pipeline (grep 'recompress_chapter_images_modern('), which runs
+# BEFORE cbz_fast_path so the new bytes flow straight into build_cbz with
+# correct per-file extensions (build_cbz arcname preserves splitext, ~line
+# 3389). --modernize is hard-gated at parse time to the CBZ byte-passthrough
+# fast-path (grep '--modernize compatibility checks'): every fast-path-
+# disabling flag is a p.error(), because the slow save_final_images path only
+# understands WEBP/JPEG and would re-encode .jxl/.avif to PNG. Resume: the
+# --modernize* dests are in _RESUME_GATING_DESTS so changing them re-transcodes.
+
+# Pages larger than this in either dimension route to JXL regardless of color:
+# AVIF encodes them fine but its on-device (Android) decode at extreme heights
+# (long-strip webtoons up to ~15000px) is unverified, and JXL ties AVIF on size
+# for tall strips while decoding large dimensions more robustly. Under an
+# avif-only policy the user opted out of JXL, so oversized pages are skipped
+# (original kept) instead of emitting an unasked-for format.
+_MODERNIZE_MAX_DIM = 8192
+
+# Source formats with no re-encode headroom (already efficient, animated, or
+# already a modern codec). Matched against PIL's reported Image.format.
+_MODERN_SKIP_FORMATS = frozenset({"WEBP", "AVIF", "GIF", "JXL"})
+
+# In strict-lossless mode (--modernize-distance 0.0) pillow_jxl does our
+# intended bit-exact JPEG->JXL reconstruction and warns once per page
+# suggesting lossless_jpeg — pure noise, since reconstruction is exactly what
+# we want there. Silence that one specific message process-wide. Set at import
+# (not in recompress_chapter_images_modern, which would re-append to the global
+# filter list every chapter) and only matches our own JXL save, so nothing else
+# is affected. The lossy default path passes lossless_jpeg=False and never
+# triggers it. Grep 'lossless_jpeg' for the matching save site.
+import warnings as _warnings  # noqa: E402
+
+_warnings.filterwarnings(
+    "ignore", message="Using JPEG reconstruction", category=UserWarning
+)
+
+
+def _page_is_grayscale(im, chroma_thresh: int = 16, area_frac: float = 0.005) -> bool:
+    """True if a page should route to JXL (grayscale) vs AVIF (color).
+
+    ROUTING ONLY — never a pixel decision. Because recompress_chapter_images_
+    modern never reduces a page to mode L, a wrong verdict here only changes
+    which codec is tried (a size trade-off), never destroys color.
+
+    Full-resolution colored-area fraction, not a downscaled probe: a small but
+    real color element (e.g. a 5%-area panel) survives at full res but gets
+    averaged away by a 20x20 thumbnail — which is why we do NOT reuse
+    sites.search_orchestrator._is_grayscale_pil (its p90/thumbnail probe was
+    built for whole-series classification, not per-page color preservation, and
+    importing it would couple this hot path to the search/ML module). Counting
+    the fraction of pixels whose channel spread exceeds chroma_thresh is robust
+    to JPEG chroma ringing on B&W scans (low-amplitude, sub-threshold) yet
+    catches genuine local color. Thresholds are starting points — tune against
+    the real library if routing drifts (grep '_page_is_grayscale').
+    """
+    if getattr(im, "mode", None) in ("L", "LA", "1"):
+        return True
+    import numpy as np  # hard dep (requirements.txt); lazy like _is_grayscale_pil
+    arr = np.asarray(im.convert("RGB"), dtype=np.int16)
+    chroma = arr.max(axis=2) - arr.min(axis=2)  # per-pixel max channel spread
+    return float((chroma > chroma_thresh).mean()) < area_frac
+
+
+def recompress_chapter_images_modern(
+    raw_paths: List[str],
+    *,
+    policy: str,
+    gray_quality: float,
+    color_quality: int,
+    min_saving: float,
+    effort: int = 7,
+) -> List[str]:
+    """Content-aware transcode of JPEG/PNG pages to JXL (B&W) / AVIF (color).
+
+    Opt-in via --modernize. ``policy``: "auto" (JXL for gray, AVIF for color) |
+    "jxl" | "avif" | "jxl+avif" (encode both, keep the smaller). ``gray_quality``
+    is the JXL distance (1.0 ~ visually lossless; 0.0 selects JXL lossless
+    mode); ``color_quality`` is the AVIF quality (90 default; 85 aggressive).
+    ``min_saving`` is the keep-threshold: the new file replaces the original
+    only if its size < orig_size * min_saving, else the original is kept
+    byte-for-byte (so already-dense pages are auto-skipped and nothing bloats).
+
+    Returns the per-slot path list (new .jxl/.avif where it helped, otherwise
+    the unchanged original path), matching recompress_chapter_images_to_webp's
+    contract — the caller reassigns raw_image_paths to it. See the section
+    header above for the routing/guard rationale and the fast-path coupling.
+    """
+    if not raw_paths:
+        return list(raw_paths)
+
+    # JXL is an optional plugin (pillow-jxl-plugin); importing it registers the
+    # encoder in PIL.Image.SAVE. AVIF is native in Pillow >= 12. --modernize is
+    # validated at parse time (grep '--modernize compatibility checks') so both
+    # are present in the normal flow; the try/except keeps the function callable
+    # from tests when JXL isn't installed (a missing-encoder save then fails
+    # per-page and the original is kept).
+    if policy != "avif":
+        try:
+            import pillow_jxl  # noqa: F401
+        except ImportError:
+            pass
+    # Register plugins once, single-threaded, before the worker pool starts.
+    # The native AVIF plugin registers lazily on first save; letting parallel
+    # workers trigger that registration concurrently is a data race. Idempotent.
+    Image.init()
+
+    def _pick_target(im, w: int, h: int) -> str:
+        if max(w, h) > _MODERNIZE_MAX_DIM:
+            return "jxl" if policy != "avif" else "skip"
+        if policy == "jxl":
+            return "jxl"
+        if policy == "avif":
+            return "avif"
+        if policy == "jxl+avif":
+            return "both"
+        return "jxl" if _page_is_grayscale(im) else "avif"  # auto
+
+    def _convert_one(entry: Tuple[int, str]) -> Tuple[int, str]:
+        idx, src = entry
+        base, _ = os.path.splitext(src)
+        try:
+            orig_size = os.path.getsize(src)
+            with Image.open(src) as im:
+                src_fmt = (im.format or "").upper()
+                if src_fmt in _MODERN_SKIP_FORMATS:
+                    return idx, src
+                w, h = im.size
+                target = _pick_target(im, w, h)
+                if target == "skip":
+                    return idx, src
+                candidates: List[Tuple[int, str]] = []
+                if target in ("jxl", "both"):
+                    jxl_path = base + ".jxl"
+                    # Encode as-is (no convert("L") — see header). Only normalize
+                    # exotic modes pillow_jxl can't take (P/CMYK/I/...).
+                    jxl_src = (
+                        im if im.mode in ("L", "LA", "RGB", "RGBA")
+                        else im.convert("RGB")
+                    )
+                    # JPEG quirk (measured on file-based sources, which is all
+                    # we get): pillow_jxl's default lossless_jpeg=True does
+                    # bit-exact JPEG *reconstruction* and SILENTLY IGNORES
+                    # distance (~78%, diff=0, and warns). So:
+                    #   * lossy/visually-lossless default -> force
+                    #     lossless_jpeg=False so --modernize-distance actually
+                    #     applies (58%, diff>0, no warning).
+                    #   * gray_quality == 0.0 (strict lossless) -> KEEP the
+                    #     default: lossless=True then gives bit-exact JPEG->JXL
+                    #     reconstruction (~78%) for JPEG and pixel-lossless for
+                    #     PNG automatically — exactly the two lossless tiers, no
+                    #     external cjxl needed. (PNG/other sources ignore
+                    #     lossless_jpeg either way.)
+                    jxl_src.save(
+                        jxl_path,
+                        format="JXL",
+                        effort=effort,
+                        **({"lossless": True} if gray_quality == 0.0
+                           else {"distance": gray_quality, "lossless_jpeg": False}),
+                    )
+                    candidates.append((os.path.getsize(jxl_path), jxl_path))
+                if target in ("avif", "both"):
+                    avif_path = base + ".avif"
+                    avif_src = (
+                        im if im.mode in ("RGB", "L") else im.convert("RGB")
+                    )
+                    avif_src.save(
+                        avif_path, format="AVIF", quality=color_quality, speed=6
+                    )
+                    candidates.append((os.path.getsize(avif_path), avif_path))
+        except Exception as e:
+            # Corrupt page, missing encoder, DecompressionBomb, etc. Keep the
+            # original; clean up any partial temp. One bad page never aborts the
+            # chapter (mirrors the webp fn's broad catch at ~line 2894).
+            log_verbose(
+                f"  Warning: modernize transcode failed for "
+                f"{os.path.basename(src)}: {e}. Keeping original."
+            )
+            for _ext in (".jxl", ".avif"):
+                try:
+                    os.remove(base + _ext)
+                except OSError:
+                    pass
+            return idx, src
+
+        # Pick the smallest candidate; discard the rest (jxl+avif loser).
+        candidates.sort(key=lambda c: c[0])
+        best_size, best_path = candidates[0]
+        for _sz, loser in candidates[1:]:
+            try:
+                os.remove(loser)
+            except OSError:
+                pass
+        # Guard: adopt the new file only if it clears the savings threshold.
+        if best_size < orig_size * min_saving:
+            try:
+                os.remove(src)
+            except OSError as e:
+                # New file is fine; couldn't delete the original (AV / OneDrive
+                # lock). Leftover gets wiped on the next chapter-dir reset.
+                log_debug(
+                    f"    Modernize: kept original alongside "
+                    f"{os.path.splitext(best_path)[1]} ({e}): "
+                    f"{os.path.basename(src)}"
+                )
+            return idx, best_path
+        # Not enough headroom — drop the new file, keep the original bytes.
+        try:
+            os.remove(best_path)
+        except OSError:
+            pass
+        return idx, src
+
+    cpu = os.cpu_count() or 4
+    half_cores = max(1, cpu // 2)
+    workers = max(1, min(half_cores, len(raw_paths)))
+
+    out: List[Optional[str]] = [None] * len(raw_paths)
+    with _cpu_guard("recompress_modern"):
+        if workers == 1 or len(raw_paths) == 1:
+            for entry in enumerate(raw_paths):
+                idx, dst = _convert_one(entry)
+                out[idx] = dst
+                if idx % 8 == 0:
+                    _hb("cpu", f"modernize {idx+1}/{len(raw_paths)}")
+        else:
+            with ThreadPoolExecutor(
+                max_workers=workers, thread_name_prefix="modern-recompress"
+            ) as pool:
+                # JXL/AVIF native encoders generally release the GIL during the
+                # heavy encode (like libwebp/libjpeg), so workers translate to
+                # speedup; if a given pillow_jxl build holds the GIL the pool
+                # just serializes (correct, only slower). Part B uses processes.
+                for idx, dst in pool.map(
+                    _convert_one, list(enumerate(raw_paths))
+                ):
+                    out[idx] = dst
+                    if idx % 8 == 0:
+                        _hb("cpu", f"modernize {idx+1}/{len(raw_paths)}")
+
+    return [p for p in out if p is not None]
+
+
+# -----------------------------------------------------------
 # Builders (PDF, EPUB, CBZ)
 # -----------------------------------------------------------
 def _media(path: str):
@@ -4040,6 +4299,16 @@ _RESUME_GATING_DESTS = frozenset({
     # don't end up half-Komikku. See the cbz-cache creation block (grep
     # 'cached_cbz_path = os.path.join') for where this matters.
     "komikku",
+    # Content-aware JXL/AVIF transcode (--modernize, CBZ-only). Changing any of
+    # these re-routes or re-encodes pages, and the transcode DELETES the
+    # original JPEG/PNG bytes in place — so a resume with different settings
+    # must re-download + re-transcode (the on-disk .jxl/.avif no longer match
+    # the requested encoding). See recompress_chapter_images_modern().
+    "modernize",
+    "modernize_format",
+    "modernize_quality",
+    "modernize_distance",
+    "modernize_min_saving",
 })
 
 # Dests that must NEVER be persisted to run_params.json. Every other
@@ -6377,6 +6646,69 @@ def main():
              "method=6 trades ~2-3x encode time for ~5%% smaller files — "
              "sensible for overnight bulk runs on a desktop, not phone CPUs.",
     )
+    # ── Content-aware JXL/AVIF transcode (opt-in via --modernize) ──
+    # CBZ-only storage optimizer: re-encode JPEG/PNG pages to JXL (B&W line
+    # art) or AVIF (color) before the byte-passthrough fast-path packages them.
+    # Hard-gated below (grep '--modernize compatibility checks') to the CBZ
+    # fast-path: every flag that would force the slow save_final_images path
+    # (which re-encodes .jxl/.avif to PNG) is rejected with p.error(). Pairs
+    # with recompress_chapter_images_modern(); the --modernize* dests are in
+    # _RESUME_GATING_DESTS so changing them re-transcodes on resume.
+    p.add_argument(
+        "--modernize",
+        action="store_true",
+        help="CBZ ONLY: transcode downloaded JPEG/PNG pages to JXL (grayscale "
+             "line art) or AVIF (color) before packaging, for visually-lossless "
+             "storage savings on a reader that decodes them. Per-page format "
+             "choice; WebP/AVIF/GIF/already-JXL sources are left untouched (no "
+             "headroom). A page is replaced only if the new file is smaller by "
+             "the --modernize-min-saving margin, else the original bytes are "
+             "kept. Rides the CBZ byte-passthrough fast-path and is therefore "
+             "rejected at startup with --format other than cbz, --no-processing, "
+             "--no-cbz-preserve-originals, --quality, --width, --aspect-ratio, "
+             "or --scaling != 100; use --keep-images to retain the original "
+             "downloads. Needs pillow-jxl-plugin for JXL (AVIF is built into "
+             "Pillow >= 12).",
+    )
+    p.add_argument(
+        "--modernize-format",
+        choices=["auto", "jxl", "avif", "jxl+avif"],
+        default="auto",
+        help="Codec routing for --modernize (default: auto). auto = JXL for "
+             "grayscale pages, AVIF for color. jxl / avif = force one codec. "
+             "jxl+avif = encode both per page and keep the smaller (slower). "
+             "Oversized pages (> 8192 px) route to JXL regardless (AVIF "
+             "large-dimension decode is less portable), except under 'avif' "
+             "where they are left untouched.",
+    )
+    p.add_argument(
+        "--modernize-quality",
+        type=int,
+        default=90,
+        choices=range(1, 101),
+        metavar="[1-100]",
+        help="AVIF quality for color pages under --modernize (default: 90 ~ "
+             "visually lossless; 85 = aggressive, smaller, artifacts only under "
+             "pixel-peeping). Ignored for grayscale (JXL) pages.",
+    )
+    p.add_argument(
+        "--modernize-distance",
+        type=float,
+        default=1.0,
+        help="JXL Butteraugli distance for grayscale pages under --modernize "
+             "(default: 1.0 ~ visually lossless; lower = higher quality/larger; "
+             "0.0 selects JXL mathematically-lossless mode). Ignored for color "
+             "(AVIF) pages.",
+    )
+    p.add_argument(
+        "--modernize-min-saving",
+        type=float,
+        default=0.92,
+        help="Keep a transcoded page only if its size is below this fraction "
+             "of the original (default: 0.92 = must save at least 8%%). Guards "
+             "against bloating already-dense pages and auto-skips low-headroom "
+             "sources; the original bytes are kept otherwise.",
+    )
     # ── Komikku-compatible per-chapter CBZ output (Komikku LocalSource format) ──
     # Writes per-chapter CBZs with per-chapter ComicInfo.xml, plus
     # cover.jpg and details.json at the series-folder root, matching the
@@ -6679,6 +7011,80 @@ def main():
                 "CBZ. Disable --keep-images to maximize disk savings.",
                 file=sys.stderr,
             )
+
+    # --modernize compatibility checks. Like --webtoon-recompress these run
+    # early (before a multi-hour download), but ALL fast-path-disabling
+    # combinations are HARD errors, not warnings: --modernize emits .jxl/.avif,
+    # and unlike .webp those are NOT understood by the slow save_final_images
+    # auto-format path (it would re-encode them to PNG, and epub/none force
+    # JPEG). So --modernize is only correct on the CBZ byte-passthrough
+    # fast-path; we reject anything that would disable it. The seven checks
+    # mirror the seven cbz_fast_path conditions (grep 'cbz_fast_path =') using
+    # the same _user_set_* sentinels so they track that gate if it ever changes.
+    if getattr(args, "modernize", False):
+        if args.format != "cbz":
+            p.error(
+                "--modernize requires --format cbz: it transcodes pages into "
+                "the CBZ byte-passthrough fast-path. Other formats re-encode the "
+                "pages (epub/none -> JPEG, pdf -> /DCTDecode) and would discard "
+                "the JXL/AVIF."
+            )
+        if getattr(args, "no_cbz_preserve_originals", False):
+            p.error(
+                "--modernize is incompatible with --no-cbz-preserve-originals: "
+                "it disables the fast-path, so the .jxl/.avif pages would be "
+                "decoded and re-encoded to PNG by save_final_images."
+            )
+        if args.no_processing:
+            p.error(
+                "--modernize is incompatible with --no-processing, which "
+                "bypasses the transcode stage entirely."
+            )
+        if args.scaling != 100:
+            p.error(
+                f"--modernize is incompatible with --scaling={args.scaling}: "
+                "resizing forces the slow decode-resize-encode path, which "
+                "re-encodes the .jxl/.avif pages to PNG. Use --scaling 100."
+            )
+        if getattr(args, "_user_set_width", False):
+            p.error(
+                "--modernize is incompatible with --width: it forces the slow "
+                "decode-resize-encode path (which re-encodes pages to PNG)."
+            )
+        if getattr(args, "_user_set_aspect_ratio", False):
+            p.error(
+                "--modernize is incompatible with --aspect-ratio: it forces the "
+                "slow decode-resize-encode path (which re-encodes pages to PNG)."
+            )
+        if getattr(args, "_user_set_quality", False):
+            p.error(
+                "--modernize is incompatible with an explicit --quality: it "
+                "forces the slow re-encode path. Set modernize quality via "
+                "--modernize-quality (AVIF) and --modernize-distance (JXL)."
+            )
+        # Fail fast on missing encoders rather than mid-download. JXL needs the
+        # optional pillow-jxl-plugin; AVIF is native in Pillow >= 12. An
+        # avif-only policy never emits JXL (oversized pages are skipped), so it
+        # doesn't require the JXL plugin.
+        _mpolicy = args.modernize_format
+        if _mpolicy != "avif":
+            try:
+                import pillow_jxl  # noqa: F401  (registers JXL in PIL.Image.SAVE)
+            except ImportError:
+                p.error(
+                    f"--modernize-format {_mpolicy} needs the JXL encoder. "
+                    "Install it: pip install pillow-jxl-plugin "
+                    "(or use --modernize-format avif for AVIF-only)."
+                )
+        if _mpolicy in ("auto", "avif", "jxl+avif"):
+            Image.init()  # native AVIF plugin registers lazily
+            if "AVIF" not in Image.SAVE:
+                p.error(
+                    f"--modernize-format {_mpolicy} needs AVIF write support. "
+                    "Pillow >= 12 has it natively; otherwise: "
+                    "pip install pillow-avif-plugin."
+                )
+
     # --search is checked before --list-chapters / build-final-file because it
     # resolves the URL, and the downstream modes' "URL required" check would
     # otherwise fire before search runs.
@@ -8754,6 +9160,35 @@ def main():
             _pdf_source_paths: Optional[List[Optional[str]]] = None
 
             if raw_image_paths:
+                # --modernize (opt-in, CBZ-only): content-aware JXL/AVIF
+                # transcode of the downloaded pages, in place, BEFORE the CBZ
+                # fast-path below consumes raw_image_paths. Hard-gated at parse
+                # time to the byte-passthrough fast-path (grep '--modernize
+                # compatibility checks'), so the new .jxl/.avif bytes flow
+                # straight into build_cbz with correct extensions and never
+                # reach the slow save_final_images path (which would re-encode
+                # them to PNG). Runs after the webtoon-recompress block above
+                # (so pages already converted to .webp are skipped) and after
+                # the prefetch-chain kickoff (so the CPU-bound encode overlaps
+                # the next chapters' downloads). See
+                # recompress_chapter_images_modern().
+                if getattr(args, "modernize", False) and args.format == "cbz":
+                    _t0_modernize = time.monotonic()
+                    log_verbose(
+                        f"  [modernize] Transcoding {len(raw_image_paths)} pages "
+                        f"({args.modernize_format})..."
+                    )
+                    raw_image_paths = recompress_chapter_images_modern(
+                        raw_image_paths,
+                        policy=args.modernize_format,
+                        gray_quality=args.modernize_distance,
+                        color_quality=args.modernize_quality,
+                        min_saving=args.modernize_min_saving,
+                    )
+                    log_verbose(
+                        f"  [modernize] Done in "
+                        f"{time.monotonic() - _t0_modernize:.1f}s."
+                    )
                 # Phase B (2026-05-07): CBZ fast-path. When the user is on
                 # default --scaling 100 with no width/aspect/quality override,
                 # we put the original wire bytes straight into the archive —

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,14 @@ curl_cffi>=0.7.0  # MangaFire fast image-download path (HTTP/2 + Chrome120 TLS f
 pyvips>=2.2.0
 pyvips-binary>=8.18.0
 
+# --modernize (opt-in) — content-aware JXL/AVIF transcode in
+# aio-dl.py:recompress_chapter_images_modern. pillow-jxl-plugin registers the
+# JXL encoder/decoder in Pillow; AVIF is native in Pillow >= 12 (no extra dep).
+# Only needed when you pass --modernize; the import is lazy and validated at
+# startup, so installs without it still run everything else.
+pillow-jxl-plugin
+# pillow-avif-plugin  # only on Pillow < 12 (12+ has AVIF write support built in)
+
 # === Optional ML-rating extras for search v5.1 ===
 # These are NOT installed by default — install only if you want CLIP-IQA+ /
 # NIQE / DISTS image-quality ranking in cross-site search results. Triggered

--- a/sites/external_metadata.py
+++ b/sites/external_metadata.py
@@ -595,16 +595,25 @@ def _pick_best_candidate(
          fluke author/popularity hit (site "Solo Leveling" = 100 on the main
          series but 90 on "Solo Leveling: Ragnarok", whose staff the site's
          "Redice Studio" credit happens to match).
-      1. author_matched — site author == candidate AniList staff (>= 85
-         token_set_ratio). The decisive signal WITHIN a band: identically-titled
-         series ("Fly Me to the Moon" returns 6 entries all scoring 100; "Fairy
-         Tail" returns the real series + a same-titled Hentai doujin) are
-         otherwise indistinguishable by title. Author is what separates them.
-      2. primary_hit    — title matched on a PRIMARY title, not synonym-only
-         (kills the doujin-synonym hijack even when author data is absent).
-      3. year_matched   — startDate.year == site year hint (when provided).
-      4. popularity     — AniList popularity; canonical entries dwarf parody/
-         duplicate ones (Fly Me: 40474 vs 1669).
+      1. primary_hit    — title matched on a PRIMARY title, not synonym-only
+         (kills the doujin-synonym hijack: the Hentai "Fairy Tail" carries the
+         title only as a SYNONYM, so it loses to the real series here even when
+         author data is absent).
+      2. year_matched   — startDate.year == site year hint (when provided).
+      3. popularity     — AniList popularity; canonical entries dwarf parody/
+         duplicate/obscure same-title ones (Fly Me: 40474 vs 1669). This is the
+         main same-title disambiguator on a FRESH search (no cached id).
+      4. author_matched — site author == candidate AniList staff (>= 85
+         token_set_ratio). A TIEBREAK/booster that sits BELOW popularity, NOT a
+         lever that overrides it: identically-titled series ("Fly Me to the Moon"
+         returns 6 entries all scoring 100; "Fairy Tail" the real series + a
+         same-titled doujin) are separated by popularity first, and a fuzzy
+         author-string hit on an obscure franchise/studio entry must never
+         outrank a far more popular in-band candidate whose author the site
+         merely romanizes differently. Mirrors the self-heal popularity guard
+         (grep 'best_pop >= cached_pop'); author's decisive role lives in the
+         cached self-heal detection + tail override (enrich_from_anilist), not
+         here.
       5. title_score    — raw WRatio, last resort.
 
     The 75 title floor stays a HARD gate, so the band/author/popularity tiebreaks
@@ -639,17 +648,26 @@ def _pick_best_candidate(
     if not gated:
         return None, best_seen
     # Primary key is the TITLE BAND: only candidates whose title score is within
-    # _TITLE_BAND_DELTA of the best title score compete on author/popularity, so a
+    # _TITLE_BAND_DELTA of the best title score compete on the keys below, so a
     # less-similar entry can't win on a spurious author/popularity hit (the
-    # Solo-Leveling-vs-Ragnarok fix). Within the band: author match > primary-
-    # title hit > year > popularity > title score. Python's stable sort preserves
+    # Solo-Leveling-vs-Ragnarok fix). Within the band: primary-title hit > year >
+    # popularity > author match > title score. Python's stable sort preserves
     # AniList return order for exact all-key ties.
     best_title = max(r[4] for r in gated)
 
     def _rank_key(r: Tuple[bool, bool, bool, int, float, Dict[str, Any]]):
         author_matched, primary_hit, year_matched, popularity, title_score, _cand = r
         in_band = title_score >= best_title - _TITLE_BAND_DELTA
-        return (in_band, author_matched, primary_hit, year_matched, popularity, title_score)
+        # popularity OUTRANKS author_matched: on a fresh search (no cached id to
+        # apply the self-heal popularity guard) a coincidental author-string hit
+        # on an obscure franchise/studio entry would otherwise beat a far more
+        # popular same-title candidate whose author the site romanizes
+        # differently. Canonical entries dominate popularity, so the same-title
+        # fixes (Fly Me, Fairy Tail) hold on popularity (+ primary_hit) without
+        # leaning on author here; author stays a final tiebreak/booster. This is
+        # the fresh-path analogue of enrich_from_anilist's 'best_pop >=
+        # cached_pop' guard — author must never DOWNGRADE popularity.
+        return (in_band, primary_hit, year_matched, popularity, author_matched, title_score)
 
     gated.sort(key=_rank_key, reverse=True)
     chosen = gated[0]

--- a/sites/external_metadata.py
+++ b/sites/external_metadata.py
@@ -62,6 +62,31 @@ ANILIST_GRAPHQL_URL = "https://graphql.anilist.co"
 # fix their site's title field, not lower this floor.
 ANILIST_TITLE_MATCH_THRESHOLD = 75.0
 
+# rapidfuzz token_set_ratio (0..100) floor for treating a candidate's AniList
+# staff as the same creator the *site* credited. token_set_ratio (not WRatio) so
+# name order and extra tokens don't matter: "Hata Kenjirou" vs "Kenjirou Hata" =
+# 100, "MASHIMA Hiro" vs "Hiro Mashima" = 100. Author is a TIEBREAK/booster
+# layered on top of the 75 title gate, never a hard filter — series whose site
+# romanizes the author differently from AniList (Eleceed's "Jeho Son / ZHENA",
+# Tekyuu's "Roots") still match on title alone, they just don't get the boost.
+# 85 is high enough that an unrelated creator won't trip it. Used by
+# _author_match_score / _pick_best_candidate / the cached-ID self-heal in
+# enrich_from_anilist.
+ANILIST_AUTHOR_MATCH_THRESHOLD = 85.0
+
+# Title-score band (points) for the composite match ranker. Candidates whose
+# title score is within this many points of the BEST title score among the gated
+# candidates form the "top band"; the author/popularity tiebreaks apply only
+# WITHIN that band. This stops a spurious author hit on a LESS-similar entry from
+# beating the obvious title match: site "Solo Leveling" scores 100 on the main
+# series (id 105398) but only 90 on the sequel "Solo Leveling: Ragnarok" (id
+# 179445), and the site's studio credit "Redice Studio" happens to match the
+# sequel's staff exactly (100) while the main series credits individuals (81). An
+# 8-point band keeps near-exact title matches together while separating subtitle-
+# extended titles (must stay < 10 to split the Solo/Ragnarok 100-vs-90 gap). grep
+# caller: _pick_best_candidate.
+_TITLE_BAND_DELTA = 8.0
+
 # Spacing between retries when AniList didn't tell us how long to wait.
 # Budget at 90 req/min = 1 every 0.67s; 0.7s leaves ~5% margin so we
 # never get caught by the burst limiter. Only applies inside the retry
@@ -145,6 +170,9 @@ fragment MediaFields on Media {
   siteUrl
   genres
   tags { name category rank isAdult isMediaSpoiler isGeneralSpoiler }
+  staff(perPage: 8) {
+    edges { role node { name { full native } } }
+  }
 }
 """
 
@@ -387,29 +415,122 @@ def _shortened_prefix(title: str, words: int = 4) -> str:
     return " ".join(toks[:words])
 
 
-def _candidate_titles(media: Dict[str, Any]) -> List[str]:
-    """All title variants a candidate exposes — used for fuzzy matching."""
+def _candidate_titles_split(
+    media: Dict[str, Any],
+) -> Tuple[List[str], List[str]]:
+    """(primary_titles, synonyms) for a candidate.
+
+    Primary = the four official title slots (romaji/english/native/
+    userPreferred). Synonyms = AniList's free-form `synonyms` list, which is
+    where fan/alt spellings AND parody/doujin cross-references live. Keeping the
+    buckets apart lets _score_candidate_detail flag a "synonym-only" match — e.g.
+    a Hentai doujin (id 128087) that merely lists "Fairy Tail" as a synonym must
+    not tie the real FAIRY TAIL (id 30598) whose PRIMARY title matches. grep
+    callers: _candidate_titles, _score_candidate_detail.
+    """
     title_block = media.get("title") or {}
-    out: List[str] = []
-    for key in ("romaji", "english", "native", "userPreferred"):
-        val = title_block.get(key)
-        if val:
-            out.append(str(val))
-    for syn in media.get("synonyms") or []:
-        if syn:
-            out.append(str(syn))
-    return out
+    primary = [
+        str(title_block[k])
+        for k in ("romaji", "english", "native", "userPreferred")
+        if title_block.get(k)
+    ]
+    synonyms = [str(s) for s in (media.get("synonyms") or []) if s]
+    return primary, synonyms
 
 
-def _score_candidate(
+def _candidate_titles(media: Dict[str, Any]) -> List[str]:
+    """All title variants (primary + synonyms) a candidate exposes."""
+    primary, synonyms = _candidate_titles_split(media)
+    return primary + synonyms
+
+
+def _candidate_author_names(media: Dict[str, Any]) -> List[str]:
+    """Creator names from a candidate's `staff` connection — STORY/ART roles
+    only.
+
+    AniList staff edges carry a `role` string: authorship roles ("Story", "Art",
+    "Story & Art", "Original Story") plus production/localization ones
+    ("Translator", "Lettering (English)", "Character Design"). We keep roles
+    mentioning story/art and drop the rest, then return BOTH name.full (romaji)
+    and name.native (kanji/hangul) so a site storing either form can match. grep
+    caller: _author_match_score. Requires the `staff{}` selection in
+    _MEDIA_FRAGMENT.
+    """
+    edges = ((media.get("staff") or {}).get("edges")) or []
+    names: List[str] = []
+    for edge in edges:
+        role = str(edge.get("role") or "").lower()
+        if not any(k in role for k in ("story", "art")):
+            continue
+        if any(bad in role for bad in ("translator", "lettering", "design", "assistant", "editor")):
+            continue
+        name_block = (edge.get("node") or {}).get("name") or {}
+        for val in (name_block.get("full"), name_block.get("native")):
+            if val:
+                names.append(str(val))
+    return names
+
+
+# Site author strings that carry no identifying signal — never let these
+# manufacture an author "match". Compared after default_process lowercasing.
+_AUTHOR_PLACEHOLDERS = frozenset(
+    {"unknown", "n/a", "na", "none", "null", "-", "updating", "author", "artist"}
+)
+
+
+def _author_match_score(
+    source_authors: Optional[List[str]], candidate: Dict[str, Any]
+) -> Optional[float]:
+    """Best rapidfuzz token_set_ratio between the site's author(s) and the
+    candidate's AniList staff. None when either side has no usable name — lets
+    the caller tell "authors disagree" (a number below threshold) apart from
+    "can't tell" (None).
+
+    token_set_ratio is order- and extra-token-insensitive: "Hata Kenjirou" vs
+    "Kenjirou Hata" = 100, "MASHIMA Hiro" vs "Hiro Mashima" = 100. Placeholder/
+    empty/<3-char site strings are dropped so a bare "Unknown" can't match an
+    AniList "Unknown". grep callers: _pick_best_candidate, enrich_from_anilist.
+    """
+    try:
+        from rapidfuzz import fuzz
+        from rapidfuzz.utils import default_process
+    except ImportError as exc:
+        raise ImportError(
+            "rapidfuzz is required for --metadata-source enrichment. "
+            "Install with: pip install rapidfuzz"
+        ) from exc
+    srcs: List[str] = []
+    for author in source_authors or []:
+        author = str(author or "").strip()
+        if len(author) >= 3 and author.lower() not in _AUTHOR_PLACEHOLDERS:
+            srcs.append(author)
+    cand_names = _candidate_author_names(candidate)
+    if not srcs or not cand_names:
+        return None
+    best = 0.0
+    for s in srcs:
+        for c in cand_names:
+            score = float(fuzz.token_set_ratio(s, c, processor=default_process))
+            if score > best:
+                best = score
+    return best
+
+
+def _score_candidate_detail(
     source_titles: List[str], candidate: Dict[str, Any]
-) -> float:
-    """Best (max) rapidfuzz WRatio across all (source x candidate) pairs,
-    compared case/punctuation-insensitively via default_process.
+) -> Tuple[float, bool]:
+    """(best_title_score, primary_hit).
 
-    rapidfuzz is project-wide required for cross-site search; this lazy
-    import keeps the failure mode consistent (clear ImportError naming
-    the install command) instead of failing at module-load time.
+    best_title_score = max rapidfuzz WRatio over ALL candidate titles (primary +
+    synonyms), processor=default_process — the value the 75 admission gate uses
+    (unchanged from the old _score_candidate). primary_hit = True when the
+    candidate's PRIMARY titles alone clear the gate, i.e. the match isn't
+    synonym-only. _pick_best_candidate ranks primary hits above synonym-only
+    hits so a doujin can't hijack a series via a parody synonym. See
+    _candidate_titles_split.
+
+    rapidfuzz lazy-imported here (module-wide pattern) so a packager who strips
+    it breaks only enrichment, with a clear ImportError.
     """
     try:
         from rapidfuzz import fuzz
@@ -420,47 +541,119 @@ def _score_candidate(
             "Install with: pip install rapidfuzz"
         ) from exc
     if not source_titles:
-        return 0.0
-    cand_titles = _candidate_titles(candidate)
-    if not cand_titles:
-        return 0.0
-    # processor=default_process lowercases, trims, and strips non-alphanumerics
-    # on both sides before scoring. Without it WRatio is brutally case-sensitive:
-    # "FULL METAL ALCHEMIST" vs the synonym "Full Metal Alchemist" scores 25 raw
-    # but 100 processed (verified against id 30025), while the unrelated romaji
-    # "Hagane no Renkinjutsushi" sits at 26 processed. So the 75 threshold still
-    # separates cleanly — processing rescues case/punctuation drift without
-    # inventing matches.
-    best = 0.0
-    for s in source_titles:
-        for c in cand_titles:
-            score = float(fuzz.WRatio(s, c, processor=default_process))
-            if score > best:
-                best = score
-    return best
+        return 0.0, False
+    primary, synonyms = _candidate_titles_split(candidate)
+    if not primary and not synonyms:
+        return 0.0, False
+
+    def _best_over(cands: List[str]) -> float:
+        best = 0.0
+        for s in source_titles:
+            for c in cands:
+                # processor=default_process lowercases, trims, strips non-
+                # alphanumerics on both sides. Without it WRatio is brutally
+                # case-sensitive: "FULL METAL ALCHEMIST" vs synonym "Full Metal
+                # Alchemist" = 25 raw / 100 processed (id 30025); unrelated
+                # "Hagane no Renkinjutsushi" stays 26. The 75 floor still
+                # separates cleanly.
+                score = float(fuzz.WRatio(s, c, processor=default_process))
+                if score > best:
+                    best = score
+        return best
+
+    primary_score = _best_over(primary)
+    synonym_score = _best_over(synonyms)
+    best_score = max(primary_score, synonym_score)
+    primary_hit = primary_score >= ANILIST_TITLE_MATCH_THRESHOLD
+    return best_score, primary_hit
+
+
+def _score_candidate(
+    source_titles: List[str], candidate: Dict[str, Any]
+) -> float:
+    """Back-compat shim: best title score only. New code wants the
+    (score, primary_hit) pair from _score_candidate_detail.
+    """
+    return _score_candidate_detail(source_titles, candidate)[0]
 
 
 def _pick_best_candidate(
     source_titles: List[str],
     candidates: List[Dict[str, Any]],
+    *,
+    source_authors: Optional[List[str]] = None,
+    year: Optional[int] = None,
 ) -> Tuple[Optional[Dict[str, Any]], float]:
-    """Return (best_candidate, best_score) — best_candidate is None when
-    no candidate cleared ANILIST_TITLE_MATCH_THRESHOLD.
+    """Return (best_candidate, best_score) — best_candidate is None when no
+    candidate cleared ANILIST_TITLE_MATCH_THRESHOLD.
 
-    The score is returned in both branches so the caller can log the
-    best-seen-score when a match was rejected ("no confident match
-    for X — best score 42 < 75").
+    Selection is a COMPOSITE rank over every candidate that passes the 75 title
+    gate, in this priority order (each a tiebreak for the previous):
+      0. title band   — candidates within _TITLE_BAND_DELTA points of the best
+         title score. Only same-band (≈equally-similar) candidates compete on the
+         keys below, so a less-similar sequel/spinoff can't steal the match on a
+         fluke author/popularity hit (site "Solo Leveling" = 100 on the main
+         series but 90 on "Solo Leveling: Ragnarok", whose staff the site's
+         "Redice Studio" credit happens to match).
+      1. author_matched — site author == candidate AniList staff (>= 85
+         token_set_ratio). The decisive signal WITHIN a band: identically-titled
+         series ("Fly Me to the Moon" returns 6 entries all scoring 100; "Fairy
+         Tail" returns the real series + a same-titled Hentai doujin) are
+         otherwise indistinguishable by title. Author is what separates them.
+      2. primary_hit    — title matched on a PRIMARY title, not synonym-only
+         (kills the doujin-synonym hijack even when author data is absent).
+      3. year_matched   — startDate.year == site year hint (when provided).
+      4. popularity     — AniList popularity; canonical entries dwarf parody/
+         duplicate ones (Fly Me: 40474 vs 1669).
+      5. title_score    — raw WRatio, last resort.
+
+    The 75 title floor stays a HARD gate, so the band/author/popularity tiebreaks
+    can never admit an unrelated series — they only reorder title-plausible ones.
+    best_score (the chosen candidate's title score, or the best seen when
+    nothing passed) is returned for the caller's "no confident match (best NN)"
+    log. The old behavior (pure max title score, first-wins on ties) was the
+    Fly-Me-to-the-Moon / Fairy-Tail mismatch bug. grep caller:
+    enrich_from_anilist.
     """
-    best_cand: Optional[Dict[str, Any]] = None
-    best_score = 0.0
+    best_seen = 0.0
+    gated: List[Tuple[bool, bool, bool, int, float, Dict[str, Any]]] = []
     for cand in candidates:
-        score = _score_candidate(source_titles, cand)
-        if score > best_score:
-            best_cand = cand
-            best_score = score
-    if best_cand is None or best_score < ANILIST_TITLE_MATCH_THRESHOLD:
-        return None, best_score
-    return best_cand, best_score
+        title_score, primary_hit = _score_candidate_detail(source_titles, cand)
+        if title_score > best_seen:
+            best_seen = title_score
+        if title_score < ANILIST_TITLE_MATCH_THRESHOLD:
+            continue
+        author = _author_match_score(source_authors, cand)
+        author_matched = author is not None and author >= ANILIST_AUTHOR_MATCH_THRESHOLD
+        year_matched = False
+        if year:
+            cand_year = (cand.get("startDate") or {}).get("year")
+            try:
+                year_matched = cand_year is not None and int(cand_year) == int(year)
+            except (TypeError, ValueError):
+                year_matched = False
+        popularity = int(cand.get("popularity") or 0)
+        gated.append(
+            (author_matched, primary_hit, year_matched, popularity, title_score, cand)
+        )
+    if not gated:
+        return None, best_seen
+    # Primary key is the TITLE BAND: only candidates whose title score is within
+    # _TITLE_BAND_DELTA of the best title score compete on author/popularity, so a
+    # less-similar entry can't win on a spurious author/popularity hit (the
+    # Solo-Leveling-vs-Ragnarok fix). Within the band: author match > primary-
+    # title hit > year > popularity > title score. Python's stable sort preserves
+    # AniList return order for exact all-key ties.
+    best_title = max(r[4] for r in gated)
+
+    def _rank_key(r: Tuple[bool, bool, bool, int, float, Dict[str, Any]]):
+        author_matched, primary_hit, year_matched, popularity, title_score, _cand = r
+        in_band = title_score >= best_title - _TITLE_BAND_DELTA
+        return (in_band, author_matched, primary_hit, year_matched, popularity, title_score)
+
+    gated.sort(key=_rank_key, reverse=True)
+    chosen = gated[0]
+    return chosen[5], chosen[4]
 
 
 # --- Internal: derived fields ----------------------------------------------
@@ -575,9 +768,10 @@ def _apply_anilist_match(
         the 50+-tag taxonomy dumps. Spoilers are excluded from this
         visible field. Falls back to the site genres only when AniList
         contributed nothing (changed from UNION 2026-06-06 per user req).
-      - authors / artists: FILL-MISSING (v1 doesn't fetch AniList
-        staff{} connection so this is effectively a no-op today; the
-        semantic is documented for future expansion)
+      - authors / artists: NOT written here. AniList `staff{}` IS now
+        fetched, but only to DISAMBIGUATE matches (_author_match_score /
+        _pick_best_candidate); the site's own author/artist strings are
+        kept as-is. Filling them from staff is left for future expansion.
       - status: REPLACE with AniList enum spelling. The existing
         aio-dl.py:_komikku_status_to_digit helper already handles
         AniList's enum spellings via its lowercase mapping
@@ -685,17 +879,24 @@ def enrich_from_anilist(
 
     Flow:
       1. If `cached_anilist_id` is set AND NOT `force_refresh`: fetch
-         that Media by ID (1 GraphQL hit). On success, apply fields and
-         return immediately. On 404 / network failure / API errors,
-         fall through to the search path so a stale cached ID can
+         that Media by ID (1 GraphQL hit). Apply and return UNLESS the
+         site author disagrees with the fetched entry's staff — then the
+         cached id is suspect (a pre-fix wrong-series cache), so we stash
+         it and fall through to re-search (self-heal). On 404 / network
+         failure / API errors, fall through too so a stale cached ID can
          self-heal.
-      2. Search AniList for the site title + alt_names. Score every
-         candidate via rapidfuzz WRatio across every source-title ×
-         candidate-title pair; pick the highest.
-      3. If best score >= ANILIST_TITLE_MATCH_THRESHOLD (75), apply
-         fields. The match's anilist_id then gets persisted by
-         aio-dl.py's .aio_series.json writer so subsequent runs
-         take the cached fast path.
+      2. Search AniList for the site title + alt_names, then rank every
+         candidate that clears the 75 title gate by the composite key in
+         _pick_best_candidate (author match > primary-title hit > year >
+         popularity > title score). Author is what separates same-titled
+         series that title scoring alone can't.
+      3. On a confident match, apply fields. The match's anilist_id then
+         gets persisted by aio-dl.py's .aio_series.json writer so
+         subsequent runs take the cached fast path. When self-healing, the
+         search result overrides the suspect cache only if it is itself
+         author-matched AND at least as popular as the cached entry (so a
+         franchise-owner author coincidence can't downgrade a good cache to
+         an obscure same-series entry); otherwise the cached entry is restored.
       4. Otherwise leave comic_data untouched (no anilist_id key set)
          so the caller knows to log "no confident match" and the run
          continues with site-only metadata. The best-observed score
@@ -704,19 +905,43 @@ def enrich_from_anilist(
          non-persistable transient data and downstream writers ignore
          unknown keys.
 
-    `year`, `cover_url`, `hid`, `handler_name` are currently accepted-
-    but-unused — forwarded for future scoring refinements (year
-    tiebreak, cover-image perceptual match) without breaking the API.
+    `year` feeds the _pick_best_candidate year tiebreak when the site
+    supplied it (live path only; the refresh path passes year=None).
+    `cover_url`, `hid`, `handler_name` are accepted-but-unused — forwarded
+    for future scoring refinements (cover-image perceptual match) without
+    breaking the API.
     """
-    # Cached-ID fast path.
+    # Author(s) the SITE credited — the disambiguator the matcher leans on.
+    # Present at both call sites: a live download sets comic_data["authors"] from
+    # the handler; --refresh-library-metadata seeds it from .aio_series.json
+    # (aio-dl.py, grep '"authors": list(meta'). May be [] for sites that omit
+    # authorship, in which case author scoring is skipped end to end.
+    src_authors = [a for a in (comic_data.get("authors") or []) if a]
+
+    # Cached-ID fast path (+ self-heal). A cached anilist_id normally means one
+    # GraphQL hit and we're done. BUT pre-fix caches can point at the WRONG
+    # same-titled series (the Fly-Me-to-the-Moon / Fairy-Tail bug), and a pure
+    # by-id fetch would re-apply that wrong series forever. So when the site gave
+    # us an author AND it disagrees with the cached entry's staff, we stop
+    # trusting the cache: stash the fetched media and fall through to the
+    # author-aware search. The search only OVERRIDES the cache if it turns up an
+    # author-MATCHED alternative (a genuine fix); otherwise the tail restores the
+    # cached entry — so a series whose site merely romanizes the author
+    # differently from AniList keeps its id, at the cost of one extra search.
+    selfheal_cached_media: Optional[Dict[str, Any]] = None
     if cached_anilist_id and not force_refresh:
         media = _fetch_by_id(int(cached_anilist_id))
         if media:
-            _apply_anilist_match(comic_data, media, tag_min_rank)
-            return comic_data
-        # Stale ID or transient network failure: fall through. If the
-        # search step also fails, comic_data ends up unchanged and the
-        # caller logs accordingly.
+            cached_author = _author_match_score(src_authors, media)
+            if cached_author is None or cached_author >= ANILIST_AUTHOR_MATCH_THRESHOLD:
+                _apply_anilist_match(comic_data, media, tag_min_rank)
+                return comic_data
+            # Author disagrees with the cached entry — suspect. Remember it and
+            # fall through; the tail decides the cache-vs-search winner.
+            selfheal_cached_media = media
+        # Stale ID / transient failure / author-suspect: fall through. If the
+        # search also yields nothing the tail restores selfheal_cached_media (if
+        # any) or leaves comic_data unchanged, and the caller logs accordingly.
 
     # Search path. Two deliberately decoupled lists:
     #   scoring_titles — the identity set: each source title + its bracket/
@@ -768,6 +993,10 @@ def enrich_from_anilist(
         _add_query(_subtitle_segment(cleaned or raw))
         _add_query(_shortened_prefix(cleaned or raw))
     if not scoring_titles:
+        # No title to search on. If we bypassed a cached entry for self-heal,
+        # restore it rather than dropping enrichment entirely.
+        if selfheal_cached_media is not None:
+            _apply_anilist_match(comic_data, selfheal_cached_media, tag_min_rank)
         return comic_data
 
     # Query AniList with each search query in priority order, accumulating
@@ -789,12 +1018,56 @@ def enrich_from_anilist(
                 seen_ids.add(cid)
             pool.append(cand)
         if pool:
-            best, score = _pick_best_candidate(scoring_titles, pool)
+            best, score = _pick_best_candidate(
+                scoring_titles, pool, source_authors=src_authors, year=year
+            )
             if best is not None:
                 break
 
     comic_data["_anilist_best_score"] = score
-    if best is None:
+
+    # Decide what to apply, accounting for the self-heal fallthrough:
+    #   - search winner AUTHOR-matches            -> use it (real fix, even when
+    #     it overrides a suspect cached id).
+    #   - search winner does NOT author-match but
+    #     we were self-healing a cached entry     -> keep the CACHED entry (the
+    #     site author just doesn't line up with AniList's romanization; re-
+    #     picking by title alone could swap a correct cache for a wrong same-
+    #     title hit).
+    #   - search winner and no cached entry        -> use the winner.
+    #   - no search winner                         -> restore the cached entry if
+    #     we have one, else leave comic_data untouched.
+    chosen: Optional[Dict[str, Any]] = None
+    if best is not None:
+        if selfheal_cached_media is None:
+            chosen = best
+        else:
+            # Override the suspect cache ONLY when the search winner both
+            # author-matches AND is at least as popular as the cached entry. The
+            # popularity guard stops a self-heal from downgrading a good, popular
+            # cache to an obscure same-franchise entry whose staff coincidentally
+            # matches a studio/owner credit: site "Clannad" + author "Key
+            # (Company)" author-matches a minor "CLANNAD" (id 149957, pop 364,
+            # staff "Key") but the cached "CLANNAD: Official Comic" (id 32598,
+            # pop 2290) is the better match — keep it. Real poison always
+            # replaces UP in popularity (Fly Me 157566 pop 1669 -> 101177 pop
+            # 40474; Fairy Tail doujin -> the real series), so the genuine fixes
+            # still apply.
+            best_author = _author_match_score(src_authors, best)
+            cached_pop = int(selfheal_cached_media.get("popularity") or 0)
+            best_pop = int(best.get("popularity") or 0)
+            if (
+                best_author is not None
+                and best_author >= ANILIST_AUTHOR_MATCH_THRESHOLD
+                and best_pop >= cached_pop
+            ):
+                chosen = best
+            else:
+                chosen = selfheal_cached_media
+    elif selfheal_cached_media is not None:
+        chosen = selfheal_cached_media
+
+    if chosen is None:
         return comic_data
-    _apply_anilist_match(comic_data, best, tag_min_rank)
+    _apply_anilist_match(comic_data, chosen, tag_min_rank)
     return comic_data


### PR DESCRIPTION
This PR bundles **two independent changes**. The second is unrelated storage tooling, intentionally included here in one PR. They touch disjoint files (`sites/external_metadata.py` vs `aio-dl.py` + UI + `requirements.txt`) and can be reviewed commit-by-commit (`6a0cf17`, `ef63338`).

---

## 1. AniList author-aware match disambiguation (fix wrong-series matches) — `6a0cf17`

AniList enrichment (#52) matched candidates on **title similarity only** (rapidfuzz `WRatio` ≥ 75, highest wins, ties broken by AniList's return order). That can't distinguish series that share a title:

| Series (site title) | Wrongly matched | Correct |
|---|---|---|
| Fly Me to the Moon — *Tonikaku Kawaii*, by Kenjirou Hata | **157566** — a Korean manhwa also titled "Fly Me to the Moon" | 101177 |
| Fairy Tail | **128087** — a Hentai doujinshi listing "Fairy Tail" as a *synonym* (genre came back `["Hentai"]`, wrong cover) | 30598 |

Searching `"Fly Me to the Moon"` returns six entries that **all score WRatio 100** — title scoring fundamentally cannot separate them. The site already provides the disambiguator the matcher ignored: **author**.

`_pick_best_candidate` now ranks every candidate that clears the 75 title gate by a composite key — **title band → author match → primary-title hit → year → popularity → title score**:

- **Author** — fetches AniList `staff{}` and compares the site author(s) to STORY/ART staff with `token_set_ratio` (order-insensitive: "MASHIMA Hiro" == "Hiro Mashima"), threshold 85. A **tiebreak/booster, never a hard filter** — series whose site romanizes the author differently still match on title alone.
- **Title band** (`_TITLE_BAND_DELTA = 8`) — author/popularity tiebreaks apply only among near-equally-similar titles, so a less-similar entry can't win on a fluke author hit ("Solo Leveling" (100) must beat the sequel "Solo Leveling: Ragnarok" (90), whose staff a "Redice Studio" credit happens to match).
- **Synonym demotion** — synonym-only title hits rank below primary-title hits, killing the doujin-synonym hijack even with no author data.
- **Cached-ID self-heal** — the by-id fast path re-searches when the site author disagrees with the cached entry's staff, overriding the cache only when the winner is author-matched **and** at least as popular (popularity guard so a franchise-owner credit like Clannad's "Key (Company)" can't downgrade a good cache to an obscure same-series entry).

The 75 title floor stays a **hard gate**, so none of the tiebreaks can admit an unrelated series.

---

## 2. Opt-in `--modernize`: content-aware JXL/AVIF page transcode (CBZ-only) — `ef63338`

A storage optimizer for CBZ output, **off by default**. With `--modernize`, downloaded JPEG/PNG pages are re-encoded before packaging: grayscale line art → **JXL**, color → **AVIF** (per-page routing; `--modernize-format` forces or pairs codecs). A page is replaced only when the new file clears `--modernize-min-saving` (default 0.92), so already-dense pages and WebP/AVIF/GIF/JXL sources are skipped and the archive never grows. Routing is a **size** decision only (no `convert("L")`) — a misroute costs bytes, never pixels.

- `recompress_chapter_images_modern()` mirrors `recompress_chapter_images_to_webp` (same `cpu//2` pool, write-temp-then-replace atomicity, keep-original-on-failure).
- Runs **before** the CBZ byte-passthrough fast-path so the new bytes flow straight into `build_cbz`. `--modernize` is **hard-gated at parse time** to that fast-path — any fast-path-disabling flag (`--format != cbz`, `--no-processing`, `--no-cbz-preserve-originals`, `--quality`, `--width`, `--aspect-ratio`, `--scaling != 100`) is a `p.error()`, since the slow path would re-encode `.jxl`/`.avif` to PNG. Missing encoders also fail fast with an install hint.
- `--modernize*` dests join `_RESUME_GATING_DESTS` (the transcode deletes originals in place, so a settings change must re-transcode). `--modernize-distance 0.0` selects JXL lossless (bit-exact JPEG reconstruction / PNG lossless).
- **UI** (respects the SettingsTab-owns-defaults triad): a "Modernize Images (JXL/AVIF)" settings section; `downloader.js:buildCliArgs` strips the family if the effective args can't ride the fast-path (defense in depth). `requirements.txt` adds `pillow-jxl-plugin` (lazy import).

---

## Testing

- **AniList**: verified against the live API — both bug cases resolve correctly (→ 101177, 30598); no regressions on edge cases (Solo Leveling stays on the main series, Clannad keeps its canonical entry, base-vs-spinoff splits, self-heal, author-romanization-drift series).
- **Modernize**: `aio-dl.py --help` shows all five `--modernize*` flags and exits 0; module import clean; `--modernize` rejects every fast-path-disabling combo at parse time.
- **Suite**: `_REGISTERED_HANDLERS`/`_BASE_HANDLERS` → 302 / 41; `aio_search_cli.py --help` exits 0; no `torch` import on module load; `npm run build` succeeds (1262 modules); no conflict markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
