### PR TITLE
ui: date-based app version stamp for auto-update, drop tag-semver gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@
 #   - push of any tag matching v*  (cuts a draft GitHub Release)
 #   - manual workflow_dispatch     (also cuts a draft release — tag is
 #                                   either provided via the `tag_name`
-#                                   input or auto-derived from
-#                                   UI-source/package.json + timestamp)
+#                                   input or auto-derived from the
+#                                   commit's date-version + timestamp)
 #
 # Jobs:
 #   build   — matrix over windows-latest / macos-latest / ubuntu-latest.
@@ -30,14 +30,16 @@
 #     refactor of the script's path resolution.
 #   - AUTO-UPDATE (opt-in, UI-source/electron/updater.js): installed apps
 #     poll this repo's *published* releases via electron-updater. Two build
-#     steps below feed that: the version stamp (tag → package.json version,
-#     so the repo never has to bump its checked-in version) and the publish
-#     stamp (feed = whichever repo ran this workflow). Publishing the draft
-#     is the go-live act — drafts are invisible to installed apps. Release
-#     tags MUST be plain semver (vX.Y.Z) or the version stamp skips and the
-#     release never serves as an update; always tag current HEAD (GitHub's
-#     /releases/latest sorts by the tagged commit's created_at, not by
-#     publish time).
+#     steps below feed that: the version stamp (a DATE-BASED version derived
+#     from the release commit by UI-source/scripts/ci-date-version.js — the
+#     repo never bumps its checked-in version, and tag names are pure
+#     labels: any naming works) and the publish stamp (feed = whichever
+#     repo ran this workflow). Publishing the draft is the go-live act —
+#     drafts are invisible to installed apps. Publish promptly (the
+#     updater's maturity delay counts from BUILD time) and release from
+#     the newest commit: versions grow with committer time, clients never
+#     downgrade, and GitHub's /releases/latest sorts by the tagged
+#     commit's created_at, not by publish time.
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: Release
@@ -46,15 +48,16 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
-    # Manual runs cut a draft release too — handy for shipping a build
-    # without pushing a real vX.Y.Z tag yet. Either supply the tag name
-    # explicitly, or leave it blank and the release job will synthesize
-    # `v<package.json.version>-draft-<UTC timestamp>` so multiple manual
-    # runs never collide. The tag is only materialized on the commit
-    # when the maintainer clicks "Publish" on the draft.
+    # Manual runs cut a draft release too — and since the app version is
+    # date-derived from the commit (not from any tag), a manual draft is
+    # every bit as updatable as a tag-push one once published. Either
+    # supply the tag name explicitly, or leave it blank and the release
+    # job will synthesize `v<date-version>-draft-<UTC timestamp>` so
+    # multiple manual runs never collide. The tag is only materialized
+    # on the commit when the maintainer clicks "Publish" on the draft.
     inputs:
       tag_name:
-        description: 'Tag for the draft release (e.g. v1.7.3). Leave empty to auto-generate from UI-source/package.json version + UTC timestamp.'
+        description: 'Tag for the draft release. Any name works — tags are labels; the app version is date-derived from the commit. Leave empty to auto-generate.'
         required: false
         type: string
         default: ''
@@ -91,32 +94,32 @@ jobs:
         run: npm ci
 
       # The repo convention keeps package.json's version static across
-      # releases — the release tag is the version of record. Stamp it into
-      # package.json before electron-builder runs so BOTH app.getVersion()
-      # (baked into the installed app) and latest.yml (the update feed's
-      # channel file) carry the tag's version. electron-updater then
+      # releases — the version of record is DATE-BASED, derived from the
+      # release commit's committer timestamp by scripts/ci-date-version.js
+      # (YYYY.MDD.HMM UTC; see that file for the full rationale). Stamp it
+      # into package.json before electron-builder runs so BOTH
+      # app.getVersion() (baked into the installed app) and latest.yml
+      # (the update feed's channel file) carry it. electron-updater then
       # compares those two stamped values — "newest published release vs
-      # the release this install came from" — with no repo bumps ever.
-      # Non-semver tags (e.g. a 4-component v0.0.5.1) skip the stamp with
-      # a warning: the build still ships, but installed apps will never
-      # see it as an update. npm version's own strict semver validation
-      # backstops the regex. Cross-file: UI-source/electron/updater.js.
-      - name: Stamp app version from release tag
-        if: github.ref_type == 'tag'
+      # the release this install came from" — with no repo bumps ever and
+      # no dependency on how the release is tagged (tag names here have
+      # always been variable — v0.0.5.1, v.0.0.5.2 — and are now pure
+      # labels). Unconditional: every run of this workflow is a release
+      # build, including workflow_dispatch drafts, which the old
+      # tag-derived stamp used to skip, shipping dead 2.0.0 feeds. npm
+      # version's strict semver validation backstops the script's own
+      # tripwire. Cross-file: UI-source/electron/updater.js.
+      - name: Stamp date-based app version
         shell: bash
         run: |
-          VER="${GITHUB_REF_NAME#v}"
-          if [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            npm version "$VER" --no-git-tag-version --allow-same-version --ignore-scripts
-            echo "Stamped app version ${VER} (from tag ${GITHUB_REF_NAME})"
-          else
-            echo "::warning::Tag '${GITHUB_REF_NAME}' is not plain semver (vX.Y.Z[-pre]) — keeping package.json version $(node -p "require('./package.json').version"). Auto-update clients will not see this release."
-          fi
+          VER=$(node scripts/ci-date-version.js)
+          npm version "$VER" --no-git-tag-version --allow-same-version --ignore-scripts
+          echo "Stamped app version ${VER} (from commit $(git log -1 --format='%h, committed %cI'))"
 
       # Point the embedded update feed (resources/app-update.yml) at the
       # repo that is building the installer, so fork-built installers poll
       # the fork's releases and upstream-built ones poll upstream — no
-      # cross-repo coupling. Unconditional (unlike the version stamp):
+      # cross-repo coupling. Unconditional, like the version stamp:
       # workflow_dispatch draft builds must also poll their own repo, not
       # the static default in package.json's build.publish (which only
       # covers local `npm run dist:*` builds).
@@ -175,10 +178,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout is needed by "Determine release tag" below so it can read
-      # UI-source/package.json on manual runs without an explicit tag input.
-      # Cheap (shallow clone, no LFS) and a no-op on tag-push runs that
-      # already have the tag in github.ref.
+      # Checkout is needed by "Determine release tag" below so it can run
+      # UI-source/scripts/ci-date-version.js on manual runs without an
+      # explicit tag input. Cheap (shallow clone, no LFS) and a no-op on
+      # tag-push runs that already have the tag in github.ref.
       - uses: actions/checkout@v6
 
       # download-artifact@v8 errors on hash mismatch by default (was warning
@@ -190,13 +193,15 @@ jobs:
         with:
           path: artifacts
 
-      # Tag-push runs: re-use the pushed ref (refs/tags/vX.Y.Z → vX.Y.Z).
+      # Tag-push runs: re-use the pushed ref (refs/tags/<name> → <name>).
       # Manual runs: prefer the user-supplied input; otherwise synthesize
-      # v<package.json.version>-draft-<UTC timestamp> so repeat manual
-      # runs each get a unique draft. softprops/action-gh-release only
-      # materializes the tag on the run's commit when the maintainer
-      # publishes the draft via the UI, so the synthesized name is safe
-      # to throw away if the draft is discarded.
+      # v<date-version>-draft-<UTC timestamp> — the same ci-date-version.js
+      # output the build jobs stamped into the installers, so the draft's
+      # name says what's inside — and repeat manual runs each get a unique
+      # draft. softprops/action-gh-release only materializes the tag on
+      # the run's commit when the maintainer publishes the draft via the
+      # UI, so the synthesized name is safe to throw away if the draft is
+      # discarded.
       - name: Determine release tag
         id: tag
         shell: bash
@@ -206,7 +211,7 @@ jobs:
             if [ -n "$INPUT_TAG" ]; then
               TAG="$INPUT_TAG"
             else
-              VERSION=$(node -p "require('./UI-source/package.json').version")
+              VERSION=$(node UI-source/scripts/ci-date-version.js)
               STAMP=$(date -u +%Y%m%d-%H%M%S)
               TAG="v${VERSION}-draft-${STAMP}"
             fi

--- a/UI-source/electron/updater.js
+++ b/UI-source/electron/updater.js
@@ -16,11 +16,11 @@
 // off; update-available decides eligible-vs-deferred), not the
 // install — a bad build never even lands on disk. The clock is the
 // feed's releaseDate, which electron-builder stamps at BUILD time:
-// for the canonical tag-push flow that's minutes before the draft
-// exists, but a draft left unpublished for days eats into the
-// window — publish drafts promptly. allowDowngrade stays false, so
-// a pulled release that makes an OLDER version "latest" can never
-// downgrade anyone regardless of this delay.
+// for the normal build→draft→publish flow that's minutes before
+// the draft exists, but a draft left unpublished for days eats
+// into the window — publish drafts promptly. allowDowngrade stays
+// false, so a pulled release that makes an OLDER version "latest"
+// can never downgrade anyone regardless of this delay.
 //
 // Consumed by main.js only (grep initAppUpdater). Renderer
 // surface: push channel "app-update-status" + invoke handlers
@@ -30,12 +30,19 @@
 // default; main.js's save-settings handler calls applySettings).
 //
 // Cross-file couplings:
-//   - .github/workflows/release.yml — "Stamp app version from
-//     release tag" writes the tag's version into package.json at
-//     build time (the repo's checked-in version never bumps), and
-//     "Point update feed at this repo" targets app-update.yml at
-//     whichever repo ran the build. Both are load-bearing: the
-//     semver comparison below is stamped-version vs stamped-version.
+//   - .github/workflows/release.yml — "Stamp date-based app
+//     version" writes a version derived from the release commit's
+//     committer timestamp (UI-source/scripts/ci-date-version.js,
+//     YYYY.MDD.HMM UTC) into package.json at build time. The
+//     repo's checked-in version never bumps, and release TAG
+//     NAMES are pure labels — the GitHub provider only uses the
+//     tag as a download-path segment, never parses it (verified:
+//     with allowPrerelease=false, GitHubProvider.getLatestTagName
+//     returns /releases/latest's tag_name verbatim), so any tag
+//     naming works. "Point update feed at this repo" targets
+//     app-update.yml at whichever repo ran the build. Both steps
+//     are load-bearing: the semver comparison below is
+//     stamped-version vs stamped-version.
 //   - UI-source/package.json — build.publish (static default for
 //     local builds), nsis.artifactName / appImage.artifactName
 //     (space-free names; GitHub renames spaces in release assets
@@ -95,7 +102,7 @@ const status = {
   reason: null,          // human-readable why-not when !supported
   enabled: false,
   state: "disabled",
-  currentVersion: "",    // app.getVersion() — the CI-stamped tag version
+  currentVersion: "",    // app.getVersion() — CI-stamped date version (2.0.0 on local/dev builds)
   latestVersion: null,   // set while deferred / downloading / downloaded
   percent: null,         // 0-100 while downloading
   eligibleAt: null,      // ISO timestamp when a deferred release matures

--- a/UI-source/scripts/ci-date-version.js
+++ b/UI-source/scripts/ci-date-version.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// ============================================================
+// CI DATE-BASED APP VERSION — single source of truth.
+//
+// Prints the app version for the HEAD commit, derived from its
+// COMMITTER timestamp in UTC:
+//
+//     YYYY.MDD.HMM
+//     └┬─┘ └┬┘ └┬┘
+//      │    │   └── hour*100 + minute  (23:34 → 2334, 00:05 → 5)
+//      │    └────── month*100 + day    (Jul 12 → 712, Dec 31 → 1231)
+//      └─────────── UTC year           (2026)
+//
+// e.g. a commit at 2026-07-12 23:34 UTC → 2026.712.2334
+//
+// Consumed by .github/workflows/release.yml twice (grep
+// ci-date-version): the build jobs stamp it into package.json
+// before electron-builder runs (so app.getVersion() and the
+// latest*.yml update feeds both carry it), and the release job
+// names auto-generated draft tags with it. The repo's checked-in
+// package.json version (2.0.0) is never bumped — local
+// `npm run dist:*` builds keep it, and only CI builds are
+// releases. Cross-file: UI-source/electron/updater.js compares
+// stamped version vs stamped version via semver; release tag
+// names play no part (they're labels — any naming works).
+//
+// Why this exact shape:
+//   - Valid semver by construction: month*100+day is 101..1231
+//     and hour*100+minute is 0..2359, emitted as plain integers,
+//     so no component ever has a leading zero (semver forbids
+//     them — "2026.07.12" would be invalid and electron-updater
+//     would reject the feed).
+//   - NOT one big YYYYMMDD major (20260712.x.y): Windows version
+//     resources (NSIS VIProductVersion) cap each dotted component
+//     at 65535, which 20260712 blows past. 2026 / 1231 / 2359
+//     all fit.
+//   - NOT a prerelease suffix for the time part: semver sorts
+//     prereleases LOWER than the release ("2026.712.0-2334" <
+//     "2026.712.0"), which would invert update ordering.
+//   - Committer time (%ct), not build time: all three release
+//     matrix platforms derive the same version from the same
+//     commit with no cross-job coordination, and rebuilding an
+//     old commit reproduces its version instead of minting a
+//     fake-newer one — a rebuild is not an update. Committer
+//     time (unlike author time) is set at merge, so successive
+//     release commits on main have increasing versions and
+//     electron-updater's gt() sees each new release. Two release
+//     commits in the same UTC minute would collide; real release
+//     cadence makes that moot.
+//   - Any date version > 2.x, so installs from the static-2.0.0
+//     era all see the first date-based release as an update.
+// ============================================================
+
+const { execSync } = require("child_process");
+
+// Test seam: tools/_test_date_version.js drives the formula with fixed
+// epochs through this override. CI never sets it.
+const raw =
+  process.env.AIO_DATE_VERSION_EPOCH ||
+  execSync("git log -1 --format=%ct", { encoding: "utf8" }).trim();
+const epoch = Number(raw);
+if (!Number.isInteger(epoch) || epoch <= 0) {
+  console.error(`ci-date-version: bad committer timestamp: ${JSON.stringify(raw)}`);
+  process.exit(1);
+}
+
+const d = new Date(epoch * 1000);
+const version = [
+  d.getUTCFullYear(),
+  (d.getUTCMonth() + 1) * 100 + d.getUTCDate(),
+  d.getUTCHours() * 100 + d.getUTCMinutes(),
+].join(".");
+
+// Tripwire, not a validator: the arithmetic above cannot produce a
+// leading zero or an out-of-range component, so if this fires, an edit
+// broke the script itself. npm version's strict semver parsing is the
+// second backstop in the workflow.
+if (!/^\d{4}\.[1-9]\d{2,3}\.(0|[1-9]\d{0,3})$/.test(version)) {
+  console.error(`ci-date-version: computed '${version}' is not the expected YYYY.MDD.HMM shape`);
+  process.exit(1);
+}
+
+console.log(version);


### PR DESCRIPTION
## Summary

- Replaces the tag-gated semver version stamp in the release workflow with a **date-based** version (`YYYY.MDD.HMM` UTC, derived from the release commit's committer timestamp) that stamps unconditionally on every CI run.
- Fixes a real gap: upstream's release tags are variable (`v0.0.5.1`, `v.0.0.5.2`) and manual `workflow_dispatch` runs carry no tag at all, so the old `if: github.ref_type == 'tag'` + strict-semver-regex step silently skipped in both cases — shipping installers whose embedded update feed (`latest.yml`) still read the static `2.0.0`, invisible to electron-updater's semver comparison.
- Release tag names are now pure labels. Confirmed directly in `electron-updater`'s `GitHubProvider` source: with `allowPrerelease=false` (this app's setting) the tag is never semver-parsed — only used as a download-path segment — so any tag naming works going forward.

## Why this shape

`UI-source/scripts/ci-date-version.js` is the single source of truth (full rationale in its header comment):

- `month*100+day` / `hour*100+minute` as plain integers can never produce a semver-illegal leading zero (`2026.07.12` would be invalid; `2026.7.12` is what gets emitted).
- Not one `YYYYMMDD` major component — NSIS's `VIProductVersion` caps each dotted component at 65535, which `20260712` exceeds. `2026` / `1231` (max month·day) / `2359` (max hour·minute) all fit.
- Not a prerelease suffix for the time part — semver sorts prereleases *lower* than the release, which would invert update ordering.
- Committer time (not build time) — all three release-matrix platforms (win/mac/linux) derive an identical version from the same commit with no cross-job coordination, and rebuilding an old commit reproduces its version instead of minting a fake-newer one.

## Verification

- Full local `dist:win` build with the stamp applied exactly as CI will: NSIS accepted `2026.711.2255` as `VIProductVersion`, `latest.yml` carried it, and the packaged exe's embedded resource confirmed it.
- A 27-check regression suite (kept local, not shipped — this repo's `tools/` policy) drives the real script through fixed epochs: leading-zero traps, month/year rollovers, strict `semver.gt` ordering across a full release chain including `> 2.0.0`, a proof that the rejected prerelease-suffix design really does invert ordering, and 16-bit NSIS bounds — all validated against `electron-updater`'s own bundled `semver` copy.
- `.github/workflows/release.yml` re-parsed with PyYAML; confirmed the version-stamp step carries no `if:` condition.

## Test plan

- [ ] CI release workflow run (tag push or manual dispatch) produces installers + `latest*.yml` stamped with a `YYYY.MDD.HMM` version
- [ ] A second release built from a later commit is recognized as an update by an installed build with auto-update enabled

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
