### PR TITLE
search: don't penalize slow sites' image-quality score (atsumaru 0.10 fix) + serial resume queue

### DIFF
--- a/UI-source/src/App.jsx
+++ b/UI-source/src/App.jsx
@@ -202,7 +202,15 @@ export default function App() {
               settings={dl.settings}
               onSaveSettings={dl.saveSettings}
               resumable={dl.resumable}
-              onResumeDownload={dl.resumeDownload}
+              onResumeDownload={async (item) => {
+                // Resume now routes through the serial queue; jump to the Queue
+                // tab so the user sees it land (running or queued). Skip the jump
+                // on a dedupe no-op / missing-API result.
+                const r = await dl.resumeDownload(item);
+                if (r && r.status !== "duplicate" && r.status !== "noop") {
+                  setActiveTab("queue");
+                }
+              }}
               searchSiteHealth={dl.searchSiteHealth}
               onManageSources={() => {
                 setSettingsCategory("search");
@@ -229,6 +237,7 @@ export default function App() {
               currentDownloadId={dl.currentDownloadId}
               onCancel={dl.cancelDownload}
               onRemoveFromQueue={dl.removeFromQueue}
+              onStartQueuedNow={dl.startQueuedNow}
               onClearCompleted={dl.clearCompleted}
             />
           )}
@@ -253,7 +262,14 @@ export default function App() {
         {/* Resume bar — pinned at the bottom, visible when unfinished downloads exist */}
         <ResumeBar
           resumable={dl.resumable}
-          onResume={dl.resumeDownload}
+          onResume={async (item) => {
+            // Serial-queue the resume (bug fix) and surface it: jump to the Queue
+            // tab on accept. Skip on a dedupe no-op / missing-API result.
+            const r = await dl.resumeDownload(item);
+            if (r && r.status !== "duplicate" && r.status !== "noop") {
+              setActiveTab("queue");
+            }
+          }}
           onDelete={dl.deleteTemp}
           onRefresh={dl.refreshResumable}
         />

--- a/UI-source/src/components/QueueTab.jsx
+++ b/UI-source/src/components/QueueTab.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Card, Badge } from "@/components/ui/primitives";
-import { X, Trash2, Clock, Loader2 } from "lucide-react";
+import { X, Trash2, Clock, Loader2, RotateCw, Zap } from "lucide-react";
 import { cn, formatDuration } from "@/lib/utils";
 
 function ProgressBar({ value, max, indeterminate, className }) {
@@ -40,6 +40,7 @@ export default function QueueTab({
   currentDownloadId,
   onCancel,
   onRemoveFromQueue,
+  onStartQueuedNow,
   onClearCompleted,
 }) {
   const running = [];
@@ -140,23 +141,56 @@ export default function QueueTab({
           <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
             Queued ({(queue || []).length})
           </h3>
-          {(queue || []).map((item, index) => (
-            <Card key={index} className="p-3 mb-2 opacity-70">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2 min-w-0">
-                  <Clock className="w-4 h-4 text-muted-foreground shrink-0" />
-                  <span className="text-sm truncate">{item.displayUrl || item.url}</span>
+          {(queue || []).map((item) => {
+            // Resume jobs (type:"resume") and fresh downloads share the queue;
+            // distinguish them at a glance with icon + a "Resume" badge.
+            const isResume = item.type === "resume";
+            const TypeIcon = isResume ? RotateCw : Clock;
+            return (
+              <Card key={item.id} className="p-3 mb-2 border-dashed animate-slide-up">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <TypeIcon className="w-4 h-4 text-muted-foreground shrink-0" />
+                    <span className="text-sm truncate text-muted-foreground">
+                      {item.displayUrl || item.url}
+                    </span>
+                  </div>
+                  {/* Right cluster: promote-to-parallel ("start alongside") + remove */}
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 text-xs gap-1 transition-all active:scale-[0.97]"
+                      onClick={() => onStartQueuedNow?.(item.id)}
+                      title="Start now, in parallel with the current download"
+                    >
+                      <Zap className="w-3 h-3" />
+                      Start alongside
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={() => onRemoveFromQueue(item.id)}
+                      title="Remove from queue"
+                    >
+                      <X className="w-4 h-4" />
+                    </Button>
+                  </div>
                 </div>
-                <Button variant="ghost" size="icon" onClick={() => onRemoveFromQueue(index)}>
-                  <X className="w-4 h-4" />
-                </Button>
-              </div>
-              <div className="flex gap-1.5 mt-1.5 ml-6 flex-wrap">
-                {item.args?.format && <Badge variant="secondary">{item.args.format.toUpperCase()}</Badge>}
-                {item.args?.quality && <Badge variant="secondary">Q{item.args.quality}</Badge>}
-              </div>
-            </Card>
-          ))}
+                <div className="flex gap-1.5 mt-1.5 ml-6 flex-wrap">
+                  {isResume && <Badge variant="default">Resume</Badge>}
+                  {isResume && item.cachedChapters > 0 && (
+                    <Badge variant="secondary">{item.cachedChapters} ch cached</Badge>
+                  )}
+                  {isResume
+                    ? item.format && <Badge variant="secondary">{item.format.toUpperCase()}</Badge>
+                    : item.args?.format && <Badge variant="secondary">{item.args.format.toUpperCase()}</Badge>}
+                  {item.args?.quality && <Badge variant="secondary">Q{item.args.quality}</Badge>}
+                </div>
+              </Card>
+            );
+          })}
         </div>
       )}
 

--- a/UI-source/src/components/ResumeBar.jsx
+++ b/UI-source/src/components/ResumeBar.jsx
@@ -86,6 +86,10 @@ export default function ResumeBar({ resumable, onResume, onDelete, onRefresh }) 
       tmpDir: item.tmpDir,
       format,
       epubLayout: format === "epub" ? getEpubLayout(item) : undefined,
+      // Threaded so a queued resume card shows a name + cached-chapter count.
+      // (useDownloader falls back to params?.title, but callers don't pass params.)
+      title: item.params?.title || item.title,
+      cachedChapters: item.cachedChapters,
     });
 
     // Clean up state for this item

--- a/UI-source/src/components/SearchSourceCard.jsx
+++ b/UI-source/src/components/SearchSourceCard.jsx
@@ -12,7 +12,7 @@
 
 import React, { useEffect, useState } from "react";
 import { Button, Badge } from "@/components/ui/primitives";
-import { Download, Image as ImageIcon, AlertTriangle } from "lucide-react";
+import { Download, Image as ImageIcon, AlertTriangle, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Map a 0..1 quality score to one of 4 visual tiers. Returns Tailwind
@@ -281,7 +281,8 @@ export default function SearchSourceCard({
             (m?.decode_quality != null ? ` · decode=${m.decode_quality.toFixed(2)}` : "") +
             (m?.outlier ? ` · outlier=${m.outlier}` : "") +
             (m?.samples_attempted != null
-              ? ` · ${m.samples_succeeded ?? 0}/${m.samples_attempted} samples`
+              ? ` · ${m.samples_succeeded ?? 0}/${m.samples_attempted} samples` +
+                ((m?.samples_timed_out ?? 0) > 0 ? ` (${m.samples_timed_out} timed out)` : "")
               : "") +
             (source.dmca_likely ? " · DMCA-flagged" : "")
           }
@@ -297,6 +298,28 @@ export default function SearchSourceCard({
             user can spot a degenerate score at a glance without hovering for
             the tooltip. yellow-500 is the existing warning palette. */}
         <div className="flex items-center justify-end gap-1">
+          {/* Partial-probe hint (2026-07-14): some breadth-sample chapters timed
+              out, so the score was measured on fewer chapters than usual. Muted
+              Clock — distinct from the red basis triangle (rating not from
+              chapter pages) and the yellow outlier triangle (measured-but-
+              suspect); the score itself is FAIR, this just flags it's partial.
+              Keyed on samples_timed_out (covers budget-miss AND per-fetch
+              timeout); older JSON lacks the field → ?? 0 → no icon. Wrapped in a
+              title span because lucide SVGs don't surface native tooltips
+              reliably (see the site-name icons above). Data:
+              sites/base.py:_probe_chapter_aggregate metadata
+              samples_timed_out / samples_measured. */}
+          {(m?.samples_timed_out ?? 0) > 0 && (
+            <span
+              className="shrink-0 inline-flex items-center"
+              title={`Partial probe — ${m.samples_succeeded ?? 0}/${m.samples_attempted} sample chapters measured; ${m.samples_timed_out} timed out (site is slow to probe). Score reflects the chapters we could fetch.`}
+            >
+              <Clock
+                className="w-3 h-3 text-muted-foreground"
+                aria-label={`partial probe: ${m.samples_timed_out} of ${m.samples_attempted} sample chapters timed out`}
+              />
+            </span>
+          )}
           {m?.outlier && (
             <AlertTriangle
               className="w-3 h-3 text-yellow-500 shrink-0"

--- a/UI-source/src/components/SearchTab.jsx
+++ b/UI-source/src/components/SearchTab.jsx
@@ -481,6 +481,9 @@ export default function SearchTab({
                   tmpDir: matchedResumable.tmpDir,
                   format: matchedResumable.format,
                   epubLayout: matchedResumable.params?.epubLayout,
+                  // Name + cached count for the queued resume card.
+                  title: matchedResumable.title || matchedResumable.params?.title,
+                  cachedChapters: matchedResumable.cachedChapters,
                 });
               }}
             >

--- a/UI-source/src/hooks/useDownloader.js
+++ b/UI-source/src/hooks/useDownloader.js
@@ -4,15 +4,18 @@
 // This connects to the Electron main process via window.electronAPI
 // (exposed by preload.js) and manages:
 //   - Active downloads and their progress
-//   - A queue system (one download at a time, auto-advances)
+//   - A queue system: auto-advances ONE at a time (currentDownloadId = the
+//     serial "anchor"), but a queued item can be launched in PARALLEL with the
+//     anchor via startQueuedNow ("start alongside")
 //   - Log lines from each download (flat array)
 //   - Resumable downloads found on disk (tmp_* folders)
 //   - App settings
 //
 // STATE SHAPES (what each component expects):
-//   activeDownloads: { [downloadId]: { url, args, status, progress, logs } }
+//   activeDownloads: { [downloadId]: { url, args, status, progress, logs, tmpDir? } }
 //   logs: [ { downloadId, line, level, timestamp }, ... ]
-//   queue: [ { url, args, queuedAt }, ... ]
+//   queue: [ { id, type:"download"|"resume", url, displayUrl, queuedAt,
+//             args? (download) | tmpDir?/format?/epubLayout?/title?/cachedChapters? (resume) }, ... ]
 //   resumable: [ { hid, tmpDir, params, cachedChapters }, ... ]
 //   settings: { pythonCmd, scriptPath, workingDir, defaults, verboseAlways }
 // ============================================================
@@ -30,6 +33,50 @@ import { formatDuration } from "@/lib/utils";
 // window.electronAPI won't exist. We return mock data so the UI
 // still renders without crashing.
 const hasAPI = () => typeof window !== "undefined" && !!window.electronAPI;
+
+// ── Queue-item spawn/adopt helpers ──
+// Module-level (NOT useCallback) on purpose: they read only their `item` arg +
+// window.electronAPI + Date.now, so the useCallback closures below can reference
+// them WITHOUT dep-array churn. A queue item is either a fresh download
+// ({type:"download", url, displayUrl, args}) or a resume job
+// ({type:"resume", url, tmpDir, format, epubLayout, title}). Both drain through
+// the SAME path (_startNextInQueue / startQueuedNow) via these two helpers, so
+// resume and download queue and replay identically.
+
+// Spawn a queue item via the right IPC. Returns main's { downloadId }. The
+// resume branch mirrors resumeDownload's original payload; the download branch
+// mirrors queueDownload's. grep _spawnQueueItem for the call sites.
+async function _spawnQueueItem(item) {
+  if (item.type === "resume") {
+    return window.electronAPI.resumeDownload({
+      url: item.url,
+      tmpDir: item.tmpDir,
+      format: item.format,          // optional format override from the resume UI
+      epubLayout: item.epubLayout,  // optional epub layout when format is epub
+    });
+  }
+  return window.electronAPI.startDownload({ url: item.url, args: item.args });
+}
+
+// Build the activeDownloads entry for a just-spawned queue item. `tmpDir` is
+// carried onto the active entry ONLY so resumeDownload's dedupe can spot an
+// in-flight resume for the same folder (grep dupActive in resumeDownload).
+function _activeEntryForQueueItem(item) {
+  return {
+    url: item.url,
+    displayUrl: item.displayUrl,
+    args: item.args,          // undefined for resume items — harmless
+    tmpDir: item.tmpDir,      // undefined for download items — harmless
+    status: "running",
+    progress:
+      item.type === "resume"
+        ? { phase: "resuming", title: item.title || "" }
+        : { phase: "starting" },
+    logs: [],
+    queuedAt: item.queuedAt,
+    startedAt: Date.now(),
+  };
+}
 
 export function useDownloader() {
   // ── State ──
@@ -122,6 +169,12 @@ export function useDownloader() {
   // Refs so callbacks always see the latest state without re-subscribing
   const queueRef = useRef(queue);
   queueRef.current = queue;
+  // Monotonic id source for queue items — the React key AND the stable handle
+  // removeFromQueue / startQueuedNow operate on (indices shift under the auto-
+  // drain, so id, not index). A counter (not Date.now) so rapid enqueues never
+  // collide. Refs are exempt from exhaustive-deps, so the useCallback closures
+  // below mint ids inline via `q${++queueIdRef.current}`.
+  const queueIdRef = useRef(0);
   const currentIdRef = useRef(currentDownloadId);
   currentIdRef.current = currentDownloadId;
   // activeDownloadsRef gives the IPC complete-handler synchronous read access
@@ -402,10 +455,9 @@ export function useDownloader() {
     if (!hasAPI()) return;
     startingRef.current = true;
     try {
-      const { downloadId } = await window.electronAPI.startDownload({
-        url: next.url,
-        args: next.args,
-      });
+      // _spawnQueueItem branches resume vs download — the head item becomes the
+      // new serial "anchor" regardless of type.
+      const { downloadId } = await _spawnQueueItem(next);
 
       // UIR-1: only dequeue AFTER a successful spawn, so a throw leaves the
       // item in place to be retried (the startingRef guard above prevents a
@@ -418,15 +470,7 @@ export function useDownloader() {
 
       setActiveDownloads((prev) => ({
         ...prev,
-        [downloadId]: {
-          url: next.url,
-          args: next.args,
-          status: "running",
-          progress: { phase: "starting" },
-          logs: [],
-          queuedAt: next.queuedAt,
-          startedAt: Date.now(),
-        },
+        [downloadId]: _activeEntryForQueueItem(next),
       }));
 
       setCurrentDownloadId(downloadId);
@@ -567,8 +611,13 @@ export function useDownloader() {
         }
       }
 
-      // Otherwise add to queue
-      setQueue((prev) => [...prev, { url, displayUrl, args: finalArgs, queuedAt: Date.now() }]);
+      // Otherwise add to queue. type:"download" discriminates from resume jobs
+      // (which _spawnQueueItem replays via the resume IPC); id is the React key
+      // + the handle removeFromQueue / startQueuedNow operate on.
+      setQueue((prev) => [
+        ...prev,
+        { id: `q${++queueIdRef.current}`, type: "download", url, displayUrl, args: finalArgs, queuedAt: Date.now() },
+      ]);
     },
     []
   );
@@ -592,33 +641,70 @@ export function useDownloader() {
   }, [_startNextInQueue]);
 
   // ── Public: resume from a tmp folder ──
-  // item: { url, tmpDir, format?, epubLayout?, params? }
+  // item: { url, tmpDir, format?, epubLayout?, title?, cachedChapters?, params? }
+  //
+  // Mirrors queueDownload's serialization: resume now routes through the SAME
+  // single-anchor gate instead of spawning immediately (the pre-2026-07-15 bug
+  // — clicking Resume on N series spawned N concurrent processes, each clobbering
+  // currentDownloadId). Returns { status } so App.jsx can react (jump to Queue):
+  //   "started"   — nothing was running; spawned now as the serial anchor
+  //   "queued"    — a download was running; parked in the queue
+  //   "duplicate" — a resume for this tmpDir is already queued/running (dedupe)
+  //   "noop"      — no API / no url
   const resumeDownload = useCallback(async (item) => {
-    if (!hasAPI() || !item.url) return;
+    if (!hasAPI() || !item.url) return { status: "noop" };
 
-    try {
-      const { downloadId } = await window.electronAPI.resumeDownload({
-        url: item.url,
-        tmpDir: item.tmpDir,
-        format: item.format,         // optional format override from dropdown
-        epubLayout: item.epubLayout,  // optional epub layout when format is epub
-      });
+    const title = item.title || item.params?.title || "";
+    const resumeItem = {
+      id: `q${++queueIdRef.current}`,
+      type: "resume",
+      url: item.url,
+      tmpDir: item.tmpDir,
+      format: item.format,          // optional format override from the resume UI
+      epubLayout: item.epubLayout,  // optional epub layout when format is epub
+      title,
+      cachedChapters: item.cachedChapters,
+      displayUrl: title || item.url,
+      queuedAt: Date.now(),
+    };
 
-      setActiveDownloads((prev) => ({
-        ...prev,
-        [downloadId]: {
-          url: item.url,
-          status: "running",
-          progress: { phase: "resuming", title: item.params?.title || "" },
-          logs: [],
-          startedAt: Date.now(),
-        },
-      }));
-
-      setCurrentDownloadId(downloadId);
-    } catch (err) {
-      console.error("Failed to resume download:", err);
+    // Dedupe by tmpDir: two processes writing one tmp_ folder corrupts the
+    // resume state — a real risk now that "start alongside" can run resumes in
+    // PARALLEL. Bail if the same folder is already queued or actively running.
+    // Guarded on a truthy tmpDir so undefined can't collide with other
+    // tmpDir-less entries (resumable items always carry tmpDir — it's the scan key).
+    if (item.tmpDir) {
+      const dupInQueue = queueRef.current.some(
+        (q) => q.type === "resume" && q.tmpDir === item.tmpDir
+      );
+      const dupActive = Object.values(activeDownloadsRef.current).some(
+        (d) => d.status === "running" && d.tmpDir === item.tmpDir
+      );
+      if (dupInQueue || dupActive) return { status: "duplicate" };
     }
+
+    // Same gate as queueDownload (grep currentIdRef.current in this file): run
+    // now only if the serial slot is free AND no spawn is mid-flight; else queue.
+    if (!currentIdRef.current && !startingRef.current) {
+      startingRef.current = true;
+      try {
+        const { downloadId } = await _spawnQueueItem(resumeItem);
+        setActiveDownloads((prev) => ({
+          ...prev,
+          [downloadId]: _activeEntryForQueueItem(resumeItem),
+        }));
+        setCurrentDownloadId(downloadId);
+        return { status: "started" };
+      } catch (err) {
+        console.error("Failed to resume download:", err);
+        // Fall through to enqueue so the user's intent is preserved.
+      } finally {
+        startingRef.current = false;
+      }
+    }
+
+    setQueue((prev) => [...prev, resumeItem]);
+    return { status: "queued" };
   }, []);
 
   // ── Public: delete a tmp folder ──
@@ -629,9 +715,49 @@ export function useDownloader() {
     if (Array.isArray(r)) setResumable(r);
   }, []);
 
+  // ── Public: start a queued item NOW, in parallel with the current download ──
+  // ("start alongside", the QueueTab ⚡ button). The promoted item is spawned as
+  // a NON-anchor extra: it does NOT take over currentDownloadId, so the auto-
+  // queue keeps draining off the existing anchor and this extra's completion is
+  // a no-op for queue advancement (completion handler / cancelDownload only
+  // advance when currentIdRef.current === downloadId). EXCEPTION: if nothing is
+  // running it becomes the anchor (becomesPrimary) so the chain still advances.
+  // Concurrency model: ~/.claude/plans/there-s-a-weird-bug-intended-purring-lecun.md
+  const startQueuedNow = useCallback(async (id) => {
+    const item = queueRef.current.find((q) => q.id === id);
+    if (!item || !hasAPI()) return;
+
+    const becomesPrimary = !currentIdRef.current && !startingRef.current;
+
+    // Remove optimistically so the card (and its button) vanish before a second
+    // click can double-spawn. Restored below if the spawn throws.
+    setQueue((prev) => prev.filter((q) => q.id !== id));
+
+    // Only claim the serial-slot mutex when this launch is the anchor; parallel
+    // extras are independent and must NOT block each other on one startingRef.
+    if (becomesPrimary) startingRef.current = true;
+    try {
+      const { downloadId } = await _spawnQueueItem(item);
+      setActiveDownloads((prev) => ({
+        ...prev,
+        [downloadId]: _activeEntryForQueueItem(item),
+      }));
+      if (becomesPrimary) setCurrentDownloadId(downloadId);
+    } catch (err) {
+      console.error("Failed to start queued item now:", err);
+      // Restore the item so the user's intent isn't silently lost.
+      setQueue((prev) => [item, ...prev]);
+      if (becomesPrimary) setTimeout(() => _startNextInQueue(), 1000);
+    } finally {
+      if (becomesPrimary) startingRef.current = false;
+    }
+  }, [_startNextInQueue]);
+
   // ── Public: remove a queued (not yet started) download ──
-  const removeFromQueue = useCallback((index) => {
-    setQueue((prev) => prev.filter((_, i) => i !== index));
+  // By id, not index: startQueuedNow / removeFromQueue race against the auto-
+  // drain and each other, and indices shift under them — id is stable.
+  const removeFromQueue = useCallback((id) => {
+    setQueue((prev) => prev.filter((q) => q.id !== id));
   }, []);
 
   // ── Public: clear completed/failed/cancelled from the active list ──
@@ -824,6 +950,7 @@ export function useDownloader() {
     resumeDownload,
     deleteTemp,
     removeFromQueue,
+    startQueuedNow,
     clearCompleted,
     clearLogs,
     saveSettings,

--- a/sites/atsumaru.py
+++ b/sites/atsumaru.py
@@ -13,6 +13,20 @@ class AtsumaruSiteHandler(BaseSiteHandler):
     _BASE_URL = "https://atsu.moe"
     _SEARCH_URL = "/collections/manga/documents/search"
 
+    # Probe atsumaru's 8 breadth-sample chapters in ONE wave, not 2. Each sample
+    # is a full-res color WebP CDN download (atsu.moe is WebP-native), so at the
+    # base width of 4 the 8-chapter image-quality probe needs 2 waves and
+    # routinely blew PROBE_SOURCE_BUDGET_S, timing out half the samples and
+    # (pre-v5.2) scoring them 0.0 → a ~0.8 source read as ~0.10. atsu.moe is a
+    # plain JSON API + CDN and real downloads already run ~8-wide image workers,
+    # so 8 concurrent probe fetches is within its normal load. Combined with the
+    # v5.2 timeout-exclusion in base._probe_chapter_aggregate this keeps the
+    # probe measuring real quality; it does NOT (and is not meant to) drop the
+    # probe under the 30s slow_probe threshold — atsumaru stays honestly flagged
+    # "slow" in the search-health system (user decision). Grep
+    # PROBE_BREADTH_CONCURRENCY.
+    PROBE_BREADTH_CONCURRENCY = 8
+
     def __init__(self) -> None:
         super().__init__()
         self._api_headers = {

--- a/sites/base.py
+++ b/sites/base.py
@@ -4,6 +4,7 @@ import datetime as dt
 import os
 import queue
 import re
+import socket
 import statistics
 import threading
 import time
@@ -40,6 +41,23 @@ try:
 except Exception:  # ImportError or any sub-dep failure
     _CurlCffiAsyncSession = None  # type: ignore[assignment]
     _CURL_CFFI_AVAILABLE = False
+
+# Exceptions from a probe fetch that mean "we couldn't MEASURE this page in time"
+# (slowness), NOT "the page/CDN is definitively broken". The image-quality probe
+# (_probe_chapter_aggregate) EXCLUDES these from the quality aggregate instead of
+# scoring them 0.0, so a merely-slow-to-probe site (e.g. atsumaru: WebP-native,
+# fast to download but slow to breadth-probe 8 full-res color chapters) isn't
+# mislabeled as broken. requests.exceptions.Timeout already covers BOTH
+# ConnectTimeout and ReadTimeout. Base requests.exceptions.ConnectionError
+# (refused / reset / DNS) is DELIBERATELY NOT here — that's a genuine
+# reachability failure and must stay a scored 0.0 (it's what keeps rizzcomic's
+# connection-poison detection working). Grep _PROBE_TIMEOUT_EXCEPTIONS:
+# _fetch_probe_item_bytes_ex + _probe_one_pick.
+try:
+    import requests as _requests
+    _PROBE_TIMEOUT_EXCEPTIONS = (_requests.exceptions.Timeout, socket.timeout)
+except Exception:
+    _PROBE_TIMEOUT_EXCEPTIONS = (socket.timeout,)
 
 
 class IncompleteChapterError(Exception):
@@ -242,12 +260,20 @@ class _ProbeSample:
     ``blob`` (whatever it had computed before failing), exactly mirroring the
     per-branch field population of the former serial loop so the re-score pass
     and throttle tail see identical state.
+
+    ``is_timeout`` marks a sample that could not be MEASURED in time (a network
+    timeout in get_chapter_images / the image fetch, or a budget-miss slot swept
+    after PROBE_SOURCE_BUDGET_S expired) — as opposed to a genuine content/CDN
+    failure. Timeouts are EXCLUDED from the score aggregate (a slow site is not a
+    broken one); genuine failures keep their 0.0. Default False so the existing
+    positional constructors (successes + genuine failures) are unchanged.
     """
     score: float
     metadata: Optional[Dict]
     image_items: Optional[List]
     picked_page_idx: Optional[int]
     blob: Optional[bytes]
+    is_timeout: bool = False
 
 
 class BaseSiteHandler:
@@ -1181,8 +1207,15 @@ class BaseSiteHandler:
             raw = list(range(n))
         return sorted(set(raw))
 
-    def _fetch_probe_item_bytes(self, item, scraper) -> Optional[bytes]:
-        """Fetch image bytes for a single probe item.
+    def _fetch_probe_item_bytes_ex(self, item, scraper) -> Tuple[Optional[bytes], bool]:
+        """Fetch image bytes for a single probe item, reporting timeout-vs-not.
+
+        Returns ``(bytes_or_None, timed_out)``. ``timed_out`` is True ONLY when a
+        network timeout (``_PROBE_TIMEOUT_EXCEPTIONS``) was raised — the caller
+        EXCLUDES those from the quality aggregate (slowness, not a quality
+        signal). A definitive failure (non-image dict, HTTP >= 400, non-image
+        bytes, or any non-timeout exception) returns ``(None, False)`` so it
+        still scores as a genuine 0.0.
 
         Handles both `get_chapter_images` return shapes:
           - `str` (most handlers): URL — fetched via scraper.get
@@ -1192,20 +1225,28 @@ class BaseSiteHandler:
             if item.get("type") == "binary_image":
                 blob = item.get("data")
                 if isinstance(blob, (bytes, bytearray)) and looks_like_real_image(blob):
-                    return bytes(blob)
-            return None
+                    return bytes(blob), False
+            return None, False
         if isinstance(item, str) and item:
             try:
                 response = scraper.get(item, timeout=15)
                 if response.status_code >= 400:
-                    return None
-                data = response.content
+                    return None, False
+                data = response.content  # can itself time out on a chunked read
                 if not looks_like_real_image(data):
-                    return None
-                return data
+                    return None, False
+                return data, False
+            except _PROBE_TIMEOUT_EXCEPTIONS:
+                return None, True
             except Exception:
-                return None
-        return None
+                return None, False
+        return None, False
+
+    def _fetch_probe_item_bytes(self, item, scraper) -> Optional[bytes]:
+        """Bytes-only wrapper over _fetch_probe_item_bytes_ex for callers that
+        don't need to know WHY a fetch failed (the throttle tail). Keeps the
+        tail's cdn_reliability accounting unchanged."""
+        return self._fetch_probe_item_bytes_ex(item, scraper)[0]
 
     def _probe_one_pick(
         self, abs_idx, chapter, hit, scraper, make_request, score_fn,
@@ -1229,6 +1270,10 @@ class BaseSiteHandler:
         """
         try:
             image_items = self.get_chapter_images(chapter, scraper, make_request)
+        except _PROBE_TIMEOUT_EXCEPTIONS:
+            # Slow/timeout, not a content failure — mark not-measured so the
+            # aggregate excludes it instead of scoring a broken-CDN 0.0.
+            return _ProbeSample(0.0, None, None, None, None, is_timeout=True)
         except Exception:
             image_items = None
         if not image_items:
@@ -1238,9 +1283,9 @@ class BaseSiteHandler:
         )
         if page_idx is None:
             return _ProbeSample(0.0, None, image_items, None, None)
-        blob = self._fetch_probe_item_bytes(image_items[page_idx], scraper)
+        blob, timed_out = self._fetch_probe_item_bytes_ex(image_items[page_idx], scraper)
         if not blob:
-            return _ProbeSample(0.0, None, image_items, page_idx, None)
+            return _ProbeSample(0.0, None, image_items, page_idx, None, is_timeout=timed_out)
         result = score_fn(blob)
         if result is None:
             # keep blob in case re-score works (mirrors the serial base path)
@@ -1478,10 +1523,18 @@ class BaseSiteHandler:
         per_chapter_image_lists: List[Optional[List]] = []  # for throttle tail
         per_chapter_picked_page_idx: List[Optional[int]] = []
         per_chapter_blobs: List[Optional[bytes]] = []  # v5.1: kept for re-score pass
+        # Pick-aligned "was this sample NOT measured (timeout / budget-miss)?"
+        # flags. A surviving None slot = a budget miss = a timeout (never
+        # fetched). Timeouts keep a 0.0 in per_chapter_scores for POSITIONAL
+        # alignment (the throttle tail + re-score pass index into it by slot),
+        # but are excluded from the score AGGREGATE below so a slow site isn't
+        # penalized as broken. Grep per_chapter_is_timeout.
+        per_chapter_is_timeout: List[bool] = []
         for r in sample_results:
             if r is None:
-                r = _ProbeSample(0.0, None, None, None, None)
+                r = _ProbeSample(0.0, None, None, None, None, is_timeout=True)
             per_chapter_scores.append(r.score)
+            per_chapter_is_timeout.append(r.is_timeout)
             per_chapter_image_lists.append(r.image_items)
             per_chapter_picked_page_idx.append(r.picked_page_idx)
             per_chapter_blobs.append(r.blob)
@@ -1564,6 +1617,17 @@ class BaseSiteHandler:
         # the measured failure rather than camouflaging it via cover-probe
         # fallback (rizzchoros.cloud lesson from 2026-05-07).
         if not per_chapter_metas:
+            # No chapter yielded a scoreable page. Distinguish "couldn't measure
+            # anything IN TIME" from "measured, and it's broken":
+            if all(per_chapter_is_timeout):
+                # Every pick timed out / was budget-missed — we measured NOTHING.
+                # Don't fabricate a 0.0 "broken" verdict for a merely-slow site;
+                # return None so the orchestrator falls back to the cover probe /
+                # seed prior (quality_basis becomes "seed"/"cover" → red triangle).
+                return None
+            # At least one GENUINE failure (empty list / 4xx / non-image /
+            # unscoreable) and zero successes → honest broken-CDN 0.0, unchanged
+            # (rizzchoros contract; rizzcomic's None→0.0 override relies on this).
             return 0.0, {
                 "width": 0,
                 "height": 0,
@@ -1571,19 +1635,29 @@ class BaseSiteHandler:
                 "size_bytes": 0,
                 "samples_attempted": len(chapter_picks),
                 "samples_succeeded": 0,
+                "samples_measured": sum(1 for to in per_chapter_is_timeout if not to),
+                "samples_timed_out": sum(1 for to in per_chapter_is_timeout if to),
                 "cdn_reliability": 0.0,
                 "probe_budget_exhausted": budget_exhausted,
             }
 
         # Hybrid median/mean aggregation across chapters (was: across pages
-        # within one chapter). Same rule as v4: median when all chapters
-        # succeed (suppresses content variance across chapters — e.g. a
-        # color splash chapter vs a B&W content chapter), mean when any
-        # failed (preserves the throttle/failure signal).
-        if all(s > 0.0 for s in per_chapter_scores):
-            aggregate_score = statistics.median(per_chapter_scores)
+        # within one chapter), computed over MEASURED samples only (successes +
+        # genuine failures). v5.2: timeouts / budget-misses are EXCLUDED, so a
+        # slow site is scored on what we could actually fetch, not penalized for
+        # pages we never reached. measured_scores is guaranteed non-empty here
+        # (per_chapter_metas is non-empty ⇒ ≥1 success). Same hybrid rule as v4:
+        # median when every measured sample succeeded (suppresses cross-chapter
+        # content variance — e.g. a color splash chapter vs a B&W one), mean when
+        # any measured sample was a GENUINE failure (preserves the throttle/
+        # failure signal). Grep per_chapter_is_timeout.
+        measured_scores = [
+            s for s, to in zip(per_chapter_scores, per_chapter_is_timeout) if not to
+        ]
+        if all(s > 0.0 for s in measured_scores):
+            aggregate_score = statistics.median(measured_scores)
         else:
-            aggregate_score = sum(per_chapter_scores) / len(per_chapter_scores)
+            aggregate_score = sum(measured_scores) / len(measured_scores)
 
         # Throttle-probe tail: pick the highest-scoring chapter index from
         # the breadth pass and sequentially fetch THROTTLE_TAIL_PAGES more
@@ -1702,6 +1776,13 @@ class BaseSiteHandler:
             "size_bytes": int(avg_size),
             "samples_attempted": len(chapter_picks),
             "samples_succeeded": len(per_chapter_metas),
+            # v5.2 (2026-07-14): samples that could not be MEASURED in time
+            # (network timeout or budget-miss) — EXCLUDED from the score
+            # aggregate above (slow != broken). samples_measured = attempted -
+            # timed_out = successes + genuine failures. Drives the UI partial-
+            # probe Clock hint (SearchSourceCard.jsx keys on samples_timed_out).
+            "samples_measured": sum(1 for to in per_chapter_is_timeout if not to),
+            "samples_timed_out": sum(1 for to in per_chapter_is_timeout if to),
             # Numeric T1 components (mean across successful samples).
             "bpp": _mean_field("bpp"),
             "decode_quality": _mean_field("decode_quality"),

--- a/sites/search_orchestrator.py
+++ b/sites/search_orchestrator.py
@@ -399,7 +399,11 @@ class SourceEntry:
     back to seed_quality. A measured 0.0 (e.g., aggregate probe got 0/5
     successful samples — CDN-poisoned site like rizzchoros.cloud during a
     bad period) is distinct from un-measured and IS used by the comparator,
-    so the broken-CDN signal isn't camouflaged by a high seed prior.
+    so the broken-CDN signal isn't camouflaged by a high seed prior. v5.2: a
+    probe where EVERY sampled chapter timed out (a slow-but-healthy site whose
+    budget expired, measuring nothing) now returns None → seed fallback, so
+    slowness no longer masquerades as a measured 0.0; a genuine per-page 0.0 is
+    still used. See sites/base.py:_probe_chapter_aggregate (per_chapter_is_timeout).
     """
     site: str
     url: str

--- a/tests/test_breadth_sampling.py
+++ b/tests/test_breadth_sampling.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from PIL import Image
 
 from sites.base import BaseSiteHandler, SearchHit
@@ -238,7 +239,10 @@ class _MockHandler(BaseSiteHandler):
                  page_blob: Optional[bytes] = None,
                  fail_chapters: Optional[set] = None,
                  fail_get_images: bool = False,
-                 fail_throttle_tail: bool = False):
+                 fail_throttle_tail: bool = False,
+                 timeout_chapters: Optional[set] = None,
+                 timeout_all_get_images: bool = False,
+                 timeout_fetch_chapters: Optional[set] = None):
         super().__init__()
         self._chapters = chapters
         self._pages_per_chapter = pages_per_chapter
@@ -246,6 +250,15 @@ class _MockHandler(BaseSiteHandler):
         self._fail_chapters = fail_chapters or set()
         self._fail_get_images = fail_get_images
         self._fail_throttle_tail = fail_throttle_tail
+        # v5.2: chapters whose get_chapter_images raises a TIMEOUT (slowness) —
+        # distinct from _fail_chapters, which raise a RuntimeError (a genuine
+        # content failure). The probe EXCLUDES timeouts from the score aggregate
+        # but keeps genuine failures as a scored 0.0.
+        self._timeout_chapters = timeout_chapters or set()
+        self._timeout_all_get_images = timeout_all_get_images
+        # chapters whose single image FETCH times out (the _ex (None, True)
+        # path), distinct from a get_chapter_images-level timeout.
+        self._timeout_fetch_chapters = timeout_fetch_chapters or set()
         self.fetch_image_calls: List[str] = []
 
     def fetch_comic_context(self, url, scraper, make_request):
@@ -257,6 +270,12 @@ class _MockHandler(BaseSiteHandler):
 
     def get_chapter_images(self, chapter, scraper, make_request):
         chap_label = chapter.get("label") or chapter.get("chap")
+        if self._timeout_all_get_images or chap_label in self._timeout_chapters:
+            # A network timeout (slowness), NOT a RuntimeError — the probe marks
+            # this is_timeout=True and drops it from the aggregate.
+            raise requests.exceptions.ReadTimeout(
+                f"mock: get_chapter_images timed out for {chap_label}"
+            )
         if self._fail_get_images or chap_label in self._fail_chapters:
             raise RuntimeError(f"mock: get_chapter_images failed for {chap_label}")
         return [
@@ -264,19 +283,26 @@ class _MockHandler(BaseSiteHandler):
             for i in range(self._pages_per_chapter)
         ]
 
-    def _fetch_probe_item_bytes(self, item, scraper):
-        # Track every fetch call so tests can count them.
+    def _fetch_probe_item_bytes_ex(self, item, scraper):
+        # v5.2: the probe calls _fetch_probe_item_bytes_ex (returns
+        # (bytes_or_None, timed_out)); the base _fetch_probe_item_bytes wrapper
+        # (used by the throttle tail) delegates HERE, so BOTH the breadth pass
+        # and the tail route through this override and fetch_image_calls still
+        # captures every fetch.
         self.fetch_image_calls.append(item)
-        # _fail_throttle_tail: succeed for first BREADTH_FETCH_COUNT fetches
-        # (one per chapter the orchestrator probes), then fail. The probe
-        # samples at most 8 chapters by default (or max_samples), so by the
-        # time we've answered _breadth_fetch_budget successful calls every
-        # subsequent fetch fails. Simulates a CDN that throttles after N
-        # first-request hits.
+        # Fetch-level timeout for chapters flagged via timeout_fetch_chapters
+        # (item URLs embed the chapter label as `chap-<label>`).
+        for label in self._timeout_fetch_chapters:
+            if f"/chap-{label}/" in item:
+                return None, True
+        # _fail_throttle_tail: succeed for the first _breadth_fetch_budget
+        # fetches (one per breadth chapter), then fail every subsequent (tail)
+        # fetch as a GENUINE (non-timeout) failure — a CDN that throttles after
+        # N first-request hits.
         if self._fail_throttle_tail:
             if len(self.fetch_image_calls) > self._breadth_fetch_budget:
-                return None
-        return self._page_blob
+                return None, False
+        return self._page_blob, False
 
     # How many "breadth phase" fetches succeed before the simulated CDN
     # starts throttling (used by _fail_throttle_tail). Default = 8 (one
@@ -402,4 +428,90 @@ def test_probe_chapter_aggregate_v5_throttle_tail_skipped_when_no_success():
     hit = SearchHit(site="mock", title="Mock", url="https://mock/series")
     result = handler._probe_chapter_aggregate(hit, MagicMock(), MagicMock())
     _, metadata = result
+    assert metadata["cdn_reliability"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# v5.2 — timeouts (slowness) are EXCLUDED from the score; genuine failures kept
+# ---------------------------------------------------------------------------
+# The bug: a slow-but-healthy site (atsumaru) whose breadth-probe budget expired
+# had its un-reached chapters scored 0.0, dragging an ~0.8 source down to ~0.10.
+# The fix distinguishes "couldn't measure in time" (timeout / budget-miss →
+# EXCLUDED) from "measured and broken" (empty list / 4xx / non-image → 0.0).
+# _mk_chapters(10) samples chapters 2..9 exactly (see the picker output), so
+# timing out a known label subset is deterministic.
+
+def test_probe_aggregate_timeouts_excluded_from_score():
+    """Chapters whose get_chapter_images TIMES OUT are dropped from the
+    aggregate, not scored 0.0 — the score reflects only the measured pages."""
+    handler = _MockHandler(_mk_chapters(10), timeout_chapters={"2", "4", "6"})
+    hit = SearchHit(site="mock", title="Mock", url="https://mock/series")
+    result = handler._probe_chapter_aggregate(hit, MagicMock(), MagicMock())
+    assert result is not None
+    score, metadata = result
+    # 3 of the 8 sampled chapters (2, 4, 6) timed out; 5 succeeded.
+    assert metadata["samples_attempted"] == 8
+    assert metadata["samples_timed_out"] == 3
+    assert metadata["samples_succeeded"] == 5
+    assert metadata["samples_measured"] == 5
+    # Score is the healthy median of the 5 successes — NOT dragged toward 0.
+    # (The pre-fix mean over 8 with three 0.0s would sit in the red band.)
+    assert 0.3 < score < 1.0
+
+
+def test_probe_aggregate_fetch_level_timeout_excluded():
+    """A timeout in the single-image FETCH (not get_chapter_images) is also
+    treated as not-measured via the _ex (None, True) path."""
+    handler = _MockHandler(_mk_chapters(10), timeout_fetch_chapters={"3", "5"})
+    hit = SearchHit(site="mock", title="Mock", url="https://mock/series")
+    result = handler._probe_chapter_aggregate(hit, MagicMock(), MagicMock())
+    assert result is not None
+    score, metadata = result
+    assert metadata["samples_timed_out"] == 2
+    assert metadata["samples_succeeded"] == 6
+    assert 0.3 < score < 1.0
+
+
+def test_probe_aggregate_all_timeouts_returns_none():
+    """When EVERY sampled chapter times out we measured nothing — return None
+    (→ orchestrator falls back to cover/seed), NOT a fake 0.0 broken verdict."""
+    handler = _MockHandler(_mk_chapters(10), timeout_all_get_images=True)
+    hit = SearchHit(site="mock", title="Mock", url="https://mock/series")
+    result = handler._probe_chapter_aggregate(hit, MagicMock(), MagicMock())
+    assert result is None
+
+
+def test_probe_aggregate_mixed_genuine_failure_and_timeout():
+    """Genuine failures (RuntimeError) stay a scored 0.0 (pulling the mean down —
+    the broken-CDN signal), while timeouts are excluded. Verifies the two are
+    NOT conflated."""
+    handler = _MockHandler(
+        _mk_chapters(10),
+        fail_chapters={"3"},          # genuine failure -> 0.0, KEPT in the mean
+        timeout_chapters={"5", "7"},  # timeouts -> EXCLUDED
+    )
+    hit = SearchHit(site="mock", title="Mock", url="https://mock/series")
+    result = handler._probe_chapter_aggregate(hit, MagicMock(), MagicMock())
+    assert result is not None
+    score, metadata = result
+    assert metadata["samples_timed_out"] == 2      # chapters 5, 7
+    assert metadata["samples_succeeded"] == 5      # 2, 4, 6, 8, 9
+    # measured = 5 successes + 1 genuine failure (chapter 3) = 6; timeouts excluded.
+    assert metadata["samples_measured"] == 6
+    # The genuine failure forces the MEAN branch, so the single 0.0 drags the
+    # score below the all-success median but keeps it > 0.
+    assert 0.0 < score < 1.0
+
+
+def test_probe_aggregate_genuine_failures_still_return_zero_not_none():
+    """All-GENUINE-failure (no timeouts) still returns a measured 0.0 (the
+    rizzchoros / rizzcomic contract), NOT None — only all-TIMEOUT returns None."""
+    handler = _MockHandler(_mk_chapters(10), fail_get_images=True)
+    hit = SearchHit(site="mock", title="Mock", url="https://mock/series")
+    result = handler._probe_chapter_aggregate(hit, MagicMock(), MagicMock())
+    assert result is not None
+    score, metadata = result
+    assert score == 0.0
+    assert metadata["samples_succeeded"] == 0
+    assert metadata["samples_timed_out"] == 0
     assert metadata["cdn_reliability"] == 0.0


### PR DESCRIPTION
## search: score slow sites on measured chapters, not timeout zeros

The cross-site image-quality probe samples 8 chapters under a 120s per-source budget. A WebP-native site like **atsumaru** (fast to download, slow to breadth-probe 8 full-res color pages) blew the budget, and the un-reached chapters were scored **0.0 — identical to genuinely broken pages**. Any `0.0` also flips aggregation from median to mean, so the zeros both injected and amplified: a ~0.8 source read as **~0.10**, shown with a confident `chapter_probe` basis and no warning triangle.

### Fix
`sites/base.py:_probe_chapter_aggregate` now distinguishes **"couldn't measure in time"** (network timeout or budget-miss) from **"measured and broken"** (empty list / 4xx / non-image / unscoreable):

- Timeouts are **excluded** from the score aggregate.
- Genuine failures still score `0.0` (preserves the rizzchoros / rizzcomic broken-CDN contract).
- If *every* sampled chapter times out → return `None` → cover/seed fallback (not a fake `0.0`; the UI's red basis triangle then flags it).
- New `_ProbeSample.is_timeout`; `_fetch_probe_item_bytes` split into an `_ex` variant reporting timeout-vs-definitive (bytes-only wrapper kept for the throttle tail + the orchestrator's T3 paths). New `samples_timed_out` / `samples_measured` metadata.
- **atsumaru** gets `PROBE_BREADTH_CONCURRENCY=8` so its 8 samples probe in one wave (was 2), cutting budget-misses. It stays honestly flagged "slow" in the search-health system (deliberately not exempted).
- **SearchSourceCard** shows a muted Clock hint + tooltip when samples timed out, so a fair-but-partial score is transparent (distinct from the red basis / yellow outlier triangles).

### Verified
Live, on the real atsumaru Chainsaw Man series:

| condition | old score | new score |
|---|---|---|
| 2/8 measured, 6 timed out | ~0.17 | **0.69** |
| 7/8 measured, 1 timed out | ~0.73 | **0.83** |
| 8/8 measured (~11s, concurrency 8) | — | **0.81** |

Offline: `tests/test_breadth_sampling.py` +5 timeout cases (29 pass); rizzcomic / image-cache / pairwise-ranking suites pass; the probe-budget regression test was updated from the old "slow == degraded" behavior to the new fairness behavior (a slow source now scores equal to a fast one on identical pages).

## ui: route resume through the serial download queue

Bundled repo-owner UI work from the local tree (per this fork's mega-PR convention). Resume jobs now share the single **serial download queue** with fresh downloads — both `type:"download"` and `type:"resume"` drain through the same `_startNextInQueue` / `startQueuedNow` path, so they queue and replay identically, and a queued item can be promoted to run in **parallel** with the current anchor ("start alongside"). `QueueTab` distinguishes resume cards (RotateCw icon + "Resume" badge + cached-chapter count); `App` routes resumes through the queue and jumps to the Queue tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
