### PR TITLE
comix: fix silent chapter-list truncation + handle the site verification check; group-version ranker; image validation; UI queue/library work

### DIFF
--- a/UI-source/electron/downloader.js
+++ b/UI-source/electron/downloader.js
@@ -19,6 +19,16 @@ const { NOISY_LINE_RE, stripAnsi, classifyLogLevel } = require("./log-filter");
 // Passed to the shared classifyLogLevel; searcher.js supplies its own set.
 const DOWNLOAD_SUCCESS_RE = /Done\.|saved →|✓|Completed|recovered/i;
 
+// ── Per-chapter ETA estimator ──
+// EMA weight for a fresh chapter-duration sample. 0.3 tracks a real slowdown
+// (CDN throttle, a chapter with 3x the pages) within a couple of chapters
+// without letting one outlier swing the readout.
+const ETA_EMA_ALPHA = 0.3;
+// Publish nothing until a SECOND sample confirms the first. One sample off a
+// cold start (DNS, Cloudflare solve, browser launch) is badly unrepresentative
+// and would show a number the very next tick contradicts.
+const ETA_MIN_SAMPLES = 2;
+
 /**
  * Builds an array of CLI arguments from the UI's args object.
  *
@@ -50,6 +60,11 @@ function buildCliArgs(args) {
     site: "--site",
     cookies: "--cookies",
     group: "--group",
+    // Scanlation-group policy. `mtl` is a choice flag (avoid|allow|exclude,
+    // default avoid) and excludeGroup takes the same comma-separated string
+    // shape as `group` — aio-dl.py splits both on comma after parse.
+    mtl: "--mtl",
+    excludeGroup: "--exclude-group",
     jobs: "--jobs",
     imageWorkers: "--image-workers",
     httpTimeout: "--http-timeout",
@@ -171,6 +186,10 @@ function buildCliArgs(args) {
     // Skip empty/null/undefined values, and skip "all" for chapters (it's the default)
     if (value === null || value === undefined || value === "") continue;
     if (key === "chapters" && value === "all") continue;
+    // "avoid" is aio-dl.py's --mtl default; emitting it would add a flag to
+    // every single spawn for no behavior change (and churn the saved
+    // download_params.json diff on every run).
+    if (key === "mtl" && value === "avoid") continue;
 
     cliArgs.push(flag, String(value));
   }
@@ -477,6 +496,55 @@ function parseProgressLine(line) {
   return progress;
 }
 
+/**
+ * Fold one "Chapter N (…)" tick into the entry's rolling per-chapter EMA and
+ * stamp etaMs / chapterMsEma / etaSamples onto the outgoing progress payload.
+ *
+ * Measured HERE, in the main process, and not in the renderer: useDownloader's
+ * 100ms flush coalesces bursts (it keeps only the latest progress per download
+ * between ticks), so renderer-side deltas would silently merge two chapters
+ * into one sample. This rides the existing download-progress payload — no new
+ * IPC channel — and merges through the renderer's shallow progress spread.
+ *
+ * ONLY intervals whose OPENING chapter was actually downloaded are sampled.
+ * On a resume the first N ticks are "already processed, collecting files" and
+ * take ~0 ms; averaging those in yields a wildly optimistic ETA that then
+ * stalls the moment real work starts. Excluding them OVER-estimates while the
+ * cached prefix drains — the honest failure direction — and the UI shows
+ * "Resuming cached chapters…" for that window instead of a number.
+ *
+ * totalChapters comes from the verbose-gated "Selected N chapters." /
+ * "Filtered list down to N chapters." lines. queueDownload injects verbose and
+ * Downloader.resume hardcodes --verbose, so it is present in practice; when it
+ * isn't, etaMs is emitted as null and QueueTab keeps its indeterminate bar.
+ *
+ * Reads entry.progress.totalChapters (the value from a PREVIOUS line) —
+ * _spawn's Object.assign of progressUpdate happens after this call, and a
+ * chapter line never carries a total anyway.
+ */
+function applyChapterEta(entry, progressUpdate) {
+  const now = Date.now();
+  if (entry._lastTickAt && !entry._lastTickCached) {
+    const sample = now - entry._lastTickAt;
+    entry._chapterMsEma = entry._etaSamples
+      ? entry._chapterMsEma + ETA_EMA_ALPHA * (sample - entry._chapterMsEma)
+      : sample;
+    entry._etaSamples++;
+  }
+  entry._lastTickAt = now;
+  entry._lastTickCached = progressUpdate.chapterCached === true;
+
+  if (entry._etaSamples < ETA_MIN_SAMPLES) return;
+
+  const total = entry.progress.totalChapters || 0;
+  const remaining = Math.max(0, total - entry.processedChapters);
+  progressUpdate.chapterMsEma = Math.round(entry._chapterMsEma);
+  progressUpdate.etaSamples = entry._etaSamples;
+  // Explicit null (not "omit") when the total is unknown: the renderer merges
+  // progress shallowly, so omitting the key would leave a stale ETA on screen.
+  progressUpdate.etaMs = total > 0 ? Math.round(remaining * entry._chapterMsEma) : null;
+}
+
 class Downloader {
   constructor({ onLog, onProgress, onComplete, extraEnv }) {
     // These callbacks send data back to the Electron main process,
@@ -669,6 +737,13 @@ class Downloader {
       progress: { phase: "starting", title: "", totalChapters: 0, currentChapter: 0 },
       // Running counter: how many "Chapter N" lines we've seen so far
       processedChapters: 0,
+      // ETA estimator state — see applyChapterEta above. _lastTickCached is
+      // the OPENING chapter of the interval we're about to close, which is
+      // what decides whether that interval counts as a sample.
+      _lastTickAt: 0,
+      _lastTickCached: false,
+      _chapterMsEma: 0,
+      _etaSamples: 0,
     };
     // Promise that resolves when this child process finally exits — both
     // the close and error handlers below resolve it. Used by cancelAll() so
@@ -737,6 +812,9 @@ class Downloader {
           if (progressUpdate.chapterTick) {
             entry.processedChapters++;
             progressUpdate.processedChapters = entry.processedChapters;
+            // Must run AFTER the counter bump — the ETA is computed off
+            // (totalChapters - processedChapters).
+            applyChapterEta(entry, progressUpdate);
           }
 
           // When we detect the hid (from "Title (hid=xxx)"), save the URL
@@ -872,6 +950,37 @@ class Downloader {
       // Process might have already exited
     }
     return entry.closePromise;
+  }
+
+  /**
+   * How many child processes are alive right now. _processes is private and
+   * self-maintaining (the close/error handlers delete their own entry), so
+   * this is the authoritative "is anything running" answer.
+   *
+   * Consumed by main.js's mainWindow "close" listener to decide whether to
+   * prompt before quitting — grep confirm-quit.
+   */
+  runningCount() {
+    return this._processes.size;
+  }
+
+  /**
+   * Identifying details for each live download, for the quit-confirmation
+   * dialog's "these are still running" list. `title` is empty until the
+   * "Title (hid=…)" line lands, so the renderer falls back to the URL.
+   */
+  getRunning() {
+    const out = [];
+    for (const [downloadId, entry] of this._processes) {
+      const url = Array.isArray(entry.meta?.url) ? entry.meta.url[0] : entry.meta?.url;
+      out.push({
+        downloadId,
+        title: entry.progress?.title || "",
+        url: url || "",
+        startedAt: entry.startTime,
+      });
+    }
+    return out;
   }
 
   /**

--- a/UI-source/electron/history.js
+++ b/UI-source/electron/history.js
@@ -1,23 +1,33 @@
 // ============================================================
 // HISTORY MANAGER
 //
-// Persists download history and user settings to JSON files
-// in Electron's userData folder:
+// Persists download history, user settings, and the pending
+// download queue to JSON files in Electron's userData folder:
 //   Windows: %AppData%/aio-downloader-ui/
 //
-// Two files:
+// Three files:
 //   download_history.json  → list of past downloads
 //   settings.json          → user preferences and defaults
+//   download_queue.json    → queue snapshot, restored on next launch
+//
+// Read by electron/main.js only (it owns every IPC handler that
+// touches these); the renderer reaches them through preload.js.
 // ============================================================
 
 const fs = require("fs");
 const path = require("path");
+
+// Watermark for the one-time settings fixups in _migrateSettings. Bump when
+// you add a step there; `settingsSchemaVersion` is stamped into settings.json
+// so each step runs exactly once per install.
+const SETTINGS_SCHEMA_VERSION = 1;
 
 class HistoryManager {
   constructor(userDataPath) {
     this._dataDir = userDataPath;
     this._historyPath = path.join(userDataPath, "download_history.json");
     this._settingsPath = path.join(userDataPath, "settings.json");
+    this._queuePath = path.join(userDataPath, "download_queue.json");
 
     // Make sure the data directory exists
     fs.mkdirSync(userDataPath, { recursive: true });
@@ -25,6 +35,39 @@ class HistoryManager {
     // Load existing data from disk (or start with empty arrays/objects)
     this._history = this._loadJson(this._historyPath, []);
     this._settings = this._loadJson(this._settingsPath, {});
+    // null (not {}) when absent — the renderer treats a missing snapshot as
+    // "nothing to restore" rather than "restore an empty queue".
+    this._queue = this._loadJson(this._queuePath, null);
+
+    // Runs HERE, in the constructor, and NOT in SettingsTab: main.js reads
+    // settings for the updater at startup (grep initAppUpdater), long before
+    // the renderer mounts — a renderer-side migration would leave auto-update
+    // off until the user happened to open Settings and press Save.
+    this._migrateSettings();
+  }
+
+  /**
+   * One-time, versioned settings fixups. `settingsSchemaVersion` (absent = 0)
+   * is the watermark; the stamp is persisted, so a relaunch is a no-op and a
+   * future step is one more `if (from < N)` block plus a bump of the const.
+   */
+  _migrateSettings() {
+    const from = Number(this._settings.settingsSchemaVersion) || 0;
+    if (from >= SETTINGS_SCHEMA_VERSION) return;
+
+    // v1 — appAutoUpdate flipped from opt-IN to opt-OUT, and every reader now
+    // tests `!== false`. SettingsTab.handleSave spreads the ENTIRE ~90-key
+    // draft, so anyone who ever pressed Save carries an explicit
+    // `appAutoUpdate: false` written by the old default — indistinguishable
+    // from a deliberate opt-out, and it would pin them off forever. That
+    // stored false carries no intent, so drop it once and let the new default
+    // apply. An explicit `true` is left alone.
+    if (from < 1 && this._settings.appAutoUpdate === false) {
+      delete this._settings.appAutoUpdate;
+    }
+
+    this._settings.settingsSchemaVersion = SETTINGS_SCHEMA_VERSION;
+    this._saveJson(this._settingsPath, this._settings);
   }
 
   /**
@@ -186,6 +229,34 @@ class HistoryManager {
 
     this._settings = { ...this._settings, ...filtered };
     this._saveJson(this._settingsPath, this._settings);
+  }
+
+  // ── Download queue snapshot ──
+  //
+  // The queue is pure React state (useDownloader.js) and dies with the
+  // renderer, so it's mirrored to disk and replayed on the next launch.
+  // Written by useDownloader's debounced persist effect through main.js's
+  // "queue:save" IPC; read once on mount via "queue:get". Shape:
+  //   {
+  //     queue:   [ <queue items verbatim, see useDownloader's STATE SHAPES> ],
+  //     running: [ { hid, url, displayUrl, title, type, tmpDir, args } ],
+  //     savedAt: <epoch ms>
+  //   }
+  // `running` = what was mid-download at close. The renderer reconstitutes
+  // those against a FRESH scanResumable and drops any whose tmp_<hid> folder
+  // is gone, so nothing here is trusted as proof that work is resumable.
+
+  /** null when no snapshot has ever been written. */
+  getQueueSnapshot() {
+    return this._queue;
+  }
+
+  saveQueueSnapshot(snap) {
+    this._queue =
+      snap && typeof snap === "object"
+        ? snap
+        : { queue: [], running: [], savedAt: Date.now() };
+    this._saveJson(this._queuePath, this._queue);
   }
 }
 

--- a/UI-source/electron/library.js
+++ b/UI-source/electron/library.js
@@ -51,6 +51,26 @@ const OUTPUT_EXTENSIONS = new Set(["pdf", "epub", "cbz"]);
 // webp/avif/png/gif, not just jpg. Cross-file: grep _IMG_EXTS in aio-dl.py.
 const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif"]);
 
+// Numeric-aware comparator: "Ch 2.cbz" sorts before "Ch 10.cbz" instead of
+// after "Ch 100.cbz". Plain localeCompare (no options) defaults numeric:false
+// and compares digit runs character by character, which is what put a series'
+// archive list in 1 / 10 / 100 / 2 order in the detail view. Hoisted rather
+// than per-call String.localeCompare because localeCompare builds a fresh
+// collator every invocation and this sorts every file of every series per scan.
+//
+// Cross-file: MIRROR TWIN of `naturalCompare` in src/lib/utils.js — electron/
+// is CommonJS and can't import from src/. Same arrangement as
+// electron/resource-limits.js vs src/lib/resourceLimits.js. Grep naturalCompare
+// if you touch either.
+//
+// NOT for the ISO-8601 `lastModified`/`modifiedAt` strings: those already sort
+// correctly as plain strings, and numeric:true would parse digit groups across
+// the '-' and ':' separators and break them.
+const naturalCompare = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+}).compare;
+
 // ── CONFIGURABLE ──
 // Width of generated thumbnails in pixels.
 // Smaller = faster to generate and less memory used.
@@ -568,7 +588,7 @@ function scanLibrary(mangasDir, thumbCacheDir) {
     entries.push({
       title: folder.name,
       folderPath,
-      files: files.sort((a, b) => a.name.localeCompare(b.name)),
+      files: files.sort((a, b) => naturalCompare(a.name, b.name)),
       coverPdfPath,
       thumbPath,
       webCoverCached,
@@ -587,7 +607,7 @@ function scanLibrary(mangasDir, thumbCacheDir) {
   }
 
   // Sort by title by default
-  entries.sort((a, b) => a.title.localeCompare(b.title));
+  entries.sort((a, b) => naturalCompare(a.title, b.title));
   return entries;
 }
 

--- a/UI-source/electron/main.js
+++ b/UI-source/electron/main.js
@@ -34,9 +34,12 @@ const {
 const { HistoryManager } = require("./history");
 const { PythonSetup, isSetupComplete, deleteEnv, PYTHON_VERSION } = require("./setup");
 const { scanLibrary, generateMissingThumbnails, downloadMissingCovers, cleanupOrphanCovers, getChaptersOnDevice, getImageChaptersOnDevice } = require("./library");
-// App self-update (opt-in, settings.appAutoUpdate) — cheap require; the
+// App self-update (opt-OUT, settings.appAutoUpdate) — cheap require; the
 // heavy electron-updater load is deferred inside updater.js. NOT the manga
-// chapter update-check family below (check-for-updates etc.).
+// chapter update-check family below (check-for-updates etc.). Polarity is
+// owned HERE: updater.js is `opts.enabled === true` throughout and this file
+// is its only caller, so the `!== false` (absent-means-ON) reads below are
+// the single place the default lives.
 const appUpdater = require("./updater");
 
 // ── DEV MODE DEFAULTS ──
@@ -141,6 +144,25 @@ let defaultWorkingDir = DEV_WORKING_DIR;
 // Cross-file: UI-source/electron/preload.js exposes cancelCheckAllUpdates;
 // UI-source/src/components/UpdatesCenter.jsx calls it from the Cancel button.
 let _checkAllAbortCtrl = null;
+
+// Quit-confirmation gate. The mainWindow "close" listener (createWindow)
+// preventDefaults while a download is actually RUNNING and asks the renderer
+// (src/components/ConfirmQuitDialog.jsx) instead of using
+// dialog.showMessageBox — a native modal breaks Electron's renderer focus/
+// input handling, which is why every confirmation in this app is a React
+// affordance (see ResumeBar.jsx's hand-rolled delete confirm).
+// quitConfirmed short-circuits the listener once the user (or the safety
+// valve, or the silent-update path) has answered. Module-scoped because the
+// listener in createWindow() and the IPC handlers in setupIPC() share them.
+let quitConfirmed = false;
+let quitSafetyTimer = null;
+
+function clearQuitSafetyTimer() {
+  if (quitSafetyTimer) {
+    clearTimeout(quitSafetyTimer);
+    quitSafetyTimer = null;
+  }
+}
 
 // ── PATH COMPUTATION ──
 
@@ -509,6 +531,28 @@ function createWindow() {
     mainWindow.loadFile(path.join(__dirname, "..", "dist", "index.html"));
   }
 
+  // ── Confirm on close while a download is running ──
+  // ONLY when something is actively running. Queued items now survive the
+  // close (download_queue.json — grep queue:save), so a backlog is not worth a
+  // prompt, and prompting on it would fire on nearly every close while a queue
+  // drains. See the quitConfirmed declaration for why this is a renderer
+  // dialog rather than dialog.showMessageBox.
+  mainWindow.on("close", (e) => {
+    if (quitConfirmed || !downloader || downloader.runningCount() === 0) return;
+    e.preventDefault();
+    sendToUI("confirm-quit", { running: downloader.getRunning() });
+    // Safety valve: a wedged renderer (crashed React tree, blocked main thread)
+    // must never leave the window un-closable. 15s is far longer than the
+    // dialog needs to paint, and "quit:cancel" clears it the moment the user
+    // actually answers.
+    clearQuitSafetyTimer();
+    quitSafetyTimer = setTimeout(() => {
+      quitSafetyTimer = null;
+      quitConfirmed = true;
+      if (mainWindow && !mainWindow.isDestroyed()) mainWindow.close();
+    }, 15_000);
+  });
+
   applyTheme();
   nativeTheme.on("updated", applyTheme);
 }
@@ -597,6 +641,13 @@ function setupIPC() {
       // SettingsTab can hydrate from its own defaults on first load).
       defaults: saved.defaults || {},
       verboseAlways: saved.verboseAlways !== false,
+      // App self-update is OPT-OUT: absent means ON. Resolved here rather than
+      // left to SettingsTab's DEFAULT_SETTINGS so main is the single source of
+      // truth (the updater arms off `saved` at startup, before the renderer
+      // exists) AND so countDirtySettings stays honest — the renderer's draft
+      // and the hydrated prop agree on the same resolved boolean instead of
+      // reporting a phantom pending change for a key that was never saved.
+      appAutoUpdate: saved.appAutoUpdate !== false,
       logUpdateInterval: saved.logUpdateInterval || 100,
       isPackaged: IS_PACKAGED,
       // NOTE: intentionally NOT merging pythonCmd / scriptPath / workingDir.
@@ -634,7 +685,10 @@ function setupIPC() {
     // deferred release. See electron/updater.js:applySettings.
     const merged = history.getSettings();
     appUpdater.applySettings({
-      enabled: merged.appAutoUpdate === true,
+      // `!== false` — opt-OUT. Must match the get-settings resolution above
+      // and the initAppUpdater call at startup; updater.js itself only ever
+      // sees a resolved boolean.
+      enabled: merged.appAutoUpdate !== false,
       delayDays: merged.appUpdateDelayDays,
     });
     return { ok: true };
@@ -776,6 +830,37 @@ function setupIPC() {
   // ── Get download history ──
   ipcMain.handle("get-history", async () => {
     return history.getAll();
+  });
+
+  // ── Download queue snapshot (survives app close) ──
+  // Pure pass-through to history.js, which owns the file + shape (grep
+  // saveQueueSnapshot there). Renderer side: useDownloader.js hydrates on
+  // mount and writes from a debounced effect — grep queueHydratedRef.
+  ipcMain.handle("queue:get", async () => {
+    return history.getQueueSnapshot();
+  });
+
+  ipcMain.handle("queue:save", async (_event, snapshot) => {
+    history.saveQueueSnapshot(snapshot);
+    return { ok: true };
+  });
+
+  // ── Quit confirmation (ConfirmQuitDialog.jsx) ──
+  // The window "close" listener in createWindow() preventDefaults while a
+  // download is running and pushes "confirm-quit"; these two are the answers.
+  // The reinstall-python handler is deliberately UNAFFECTED: it uses
+  // app.exit(0), which tears the process down without ever emitting a window
+  // "close" event, so no prompt can appear there.
+  ipcMain.handle("quit:confirm", async () => {
+    clearQuitSafetyTimer();
+    quitConfirmed = true;
+    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.close();
+    return { ok: true };
+  });
+
+  ipcMain.handle("quit:cancel", async () => {
+    clearQuitSafetyTimer();
+    return { ok: true };
   });
 
   // ── Reveal a folder in the OS file manager (Explorer / Finder / Files) ──
@@ -1458,6 +1543,11 @@ function setupIPC() {
     if (appUpdater.getStatus().state !== "downloaded") {
       return { ok: false, reason: "No downloaded update to apply." };
     }
+    // Set BEFORE cancelAll: that call bounds itself at 5s, so a stuck child
+    // could still be in _processes when quitAndInstall closes the window, and
+    // the close listener would answer a user-initiated update with a quit
+    // prompt. Explicit here rather than relying on runningCount() hitting 0.
+    quitConfirmed = true;
     if (downloader) await downloader.cancelAll();
     return appUpdater.applyNow();
   });
@@ -1524,14 +1614,17 @@ app.whenReady().then(async () => {
   initDownloader();
   createWindow();
 
-  // App self-update — armed only when the user opted in (Settings →
+  // App self-update — armed unless the user opted OUT (Settings →
   // General → App Updates) AND this install supports it (packaged
   // Windows NSIS / Linux AppImage). First check runs ~30s post-launch;
   // the require("electron-updater") itself is deferred until then, so
-  // startup cost is zero either way. See electron/updater.js.
+  // startup cost is zero either way. See electron/updater.js. The stored
+  // `false` that the old opt-in default wrote for every saving user is
+  // cleared once by history.js's v1 settings migration — without that,
+  // `!== false` would leave the whole existing install base off.
   const updaterSettings = history.getSettings();
   appUpdater.initAppUpdater({
-    enabled: updaterSettings.appAutoUpdate === true,
+    enabled: updaterSettings.appAutoUpdate !== false,
     delayDays: updaterSettings.appUpdateDelayDays,
     onStatus: (s) => sendToUI("app-update-status", s),
   });

--- a/UI-source/electron/preload.js
+++ b/UI-source/electron/preload.js
@@ -34,6 +34,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getResolvedPaths: () => ipcRenderer.invoke("get-resolved-paths"),
   getTheme: () => ipcRenderer.invoke("get-theme"),
 
+  // ── Download queue persistence ──
+  // The queue lives in React state and dies with the renderer, so it's
+  // mirrored to download_queue.json (electron/history.js owns the file +
+  // shape). useDownloader.js reads this once on mount and writes from a
+  // debounced effect — grep queueHydratedRef there.
+  getQueueSnapshot: () => ipcRenderer.invoke("queue:get"),
+  saveQueueSnapshot: (snap) => ipcRenderer.invoke("queue:save", snap),
+
   // ── OS dialogs ──
   openFolder: (p) => ipcRenderer.invoke("open-folder", p),
   pickFolder: () => ipcRenderer.invoke("pick-folder"),
@@ -68,6 +76,20 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on("theme-changed", handler);
     return () => ipcRenderer.removeListener("theme-changed", handler);
   },
+
+  // ── Quit confirmation ──
+  // main.js preventDefaults the window close while a download is actually
+  // RUNNING and pushes "confirm-quit" with { running: [{downloadId, title,
+  // url, startedAt}] }; ConfirmQuitDialog.jsx answers with exactly one of
+  // confirmQuit (close for real) / cancelQuit (stay, and cancel main's 15s
+  // safety valve).
+  onConfirmQuit: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on("confirm-quit", handler);
+    return () => ipcRenderer.removeListener("confirm-quit", handler);
+  },
+  confirmQuit: () => ipcRenderer.invoke("quit:confirm"),
+  cancelQuit: () => ipcRenderer.invoke("quit:cancel"),
 
   // ── Cross-site search ──
   // runSearch resolves with the parsed JSON result (candidate list +

--- a/UI-source/electron/updater.js
+++ b/UI-source/electron/updater.js
@@ -2,7 +2,7 @@
 // APP SELF-UPDATE (electron-updater) — NOT the manga chapter
 // "check-for-updates" IPC family, which lives in main.js and
 // checks series for new chapters. This module owns the app's
-// own opt-in silent update flow:
+// own opt-OUT silent update flow:
 //
 //   check GitHub Releases in the background → download silently
 //   → install on app exit (autoInstallOnAppQuit). No dialogs,
@@ -25,9 +25,13 @@
 // Consumed by main.js only (grep initAppUpdater). Renderer
 // surface: push channel "app-update-status" + invoke handlers
 // "app-update:get-status" / ":check-now" / ":apply-now" (all
-// registered in main.js, exposed via preload.js). The opt-in
-// lives at settings.appAutoUpdate (SettingsTab.jsx owns the
-// default; main.js's save-settings handler calls applySettings).
+// registered in main.js, exposed via preload.js). The pref lives
+// at settings.appAutoUpdate and is OPT-OUT — but the polarity is
+// NOT decided here: every read below is `opts.enabled === true`,
+// and main.js (this module's only caller) resolves the
+// absent-means-ON default with `!== false` before calling
+// initAppUpdater / applySettings. Changing the default is a
+// main.js edit, not an edit to this file.
 //
 // Cross-file couplings:
 //   - .github/workflows/release.yml — "Stamp date-based app
@@ -245,7 +249,8 @@ function _start() {
 
 /**
  * Wire the updater once at startup (main.js, after createWindow).
- * opts.enabled   — settings.appAutoUpdate === true at launch.
+ * opts.enabled   — the RESOLVED settings.appAutoUpdate at launch (main.js
+ *                  applies the opt-out default; absent → true).
  * opts.delayDays — settings.appUpdateDelayDays (clamped here).
  * opts.onStatus  — push callback; main.js forwards to the renderer.
  * When enabled and supported, the first check is deferred

--- a/UI-source/src/App.jsx
+++ b/UI-source/src/App.jsx
@@ -7,6 +7,7 @@ import LogPanel from "@/components/LogPanel";
 import SettingsTab from "@/components/SettingsTab";
 import LibraryTab from "@/components/LibraryTab";
 import ResumeBar from "@/components/ResumeBar";
+import ConfirmQuitDialog from "@/components/ConfirmQuitDialog";
 import appIcon from "../build-resources/icon.png";
 import {
   Download,
@@ -274,6 +275,11 @@ export default function App() {
           onRefresh={dl.refreshResumable}
         />
       </div>
+
+      {/* Quit confirmation — self-contained (subscribes to main's
+          "confirm-quit" push, renders null the rest of the time). Sits outside
+          the tab-content area so it overlays whatever tab is open. */}
+      <ConfirmQuitDialog />
     </div>
   );
 }

--- a/UI-source/src/components/ConfirmQuitDialog.jsx
+++ b/UI-source/src/components/ConfirmQuitDialog.jsx
@@ -1,0 +1,153 @@
+// ============================================================
+// CONFIRM-QUIT DIALOG
+//
+// Renders ONLY while the main process has a window close pending. main.js's
+// mainWindow "close" listener preventDefaults whenever a download is actually
+// RUNNING and pushes "confirm-quit" with { running: [{downloadId, title, url,
+// startedAt}] }; this component is the answer surface and replies with exactly
+// one of confirmQuit / cancelQuit (preload.js).
+//
+// A React dialog rather than dialog.showMessageBox on purpose: a native modal
+// breaks Electron's renderer focus/input handling, which is why every
+// confirmation in this app is hand-rolled (see ResumeBar.jsx's delete confirm).
+// There is no Dialog primitive in ui/primitives.jsx — the shell here mirrors
+// SearchTab's download-settings modal (fixed inset-0 overlay + bordered card +
+// animate-slide-up + a justify-end footer).
+//
+// Mounted once from App.jsx, outside the tab switch, so it can appear no
+// matter which tab is open.
+//
+// NOTE: queued items are NOT a reason to prompt — they survive the close via
+// the queue snapshot (useDownloader.js, grep QUEUE_PERSIST_LIMIT), and
+// prompting on a draining backlog would fire on nearly every close. main.js
+// owns that decision; this component just renders what it's handed.
+// ============================================================
+
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { Button } from "@/components/ui/primitives";
+import { AlertTriangle, Loader2 } from "lucide-react";
+
+// Cap the visible list so a "start alongside" spree can't push the buttons off
+// screen; the remainder collapses into a "+N more" line.
+const MAX_LISTED = 5;
+
+export default function ConfirmQuitDialog() {
+  // null = no close pending (the overwhelmingly common state, and the one
+  // where this component renders nothing at all).
+  const [pending, setPending] = useState(null);
+  const keepRef = useRef(null);
+
+  useEffect(() => {
+    const api = typeof window !== "undefined" && window.electronAPI;
+    if (!api || typeof api.onConfirmQuit !== "function") return;
+    return api.onConfirmQuit((data) => {
+      setPending({ running: Array.isArray(data?.running) ? data.running : [] });
+    });
+  }, []);
+
+  const cancel = useCallback(() => {
+    setPending(null);
+    // Also clears main's 15s "wedged renderer" safety valve, which would
+    // otherwise close the window out from under the user.
+    window.electronAPI?.cancelQuit?.();
+  }, []);
+
+  const confirm = useCallback(() => {
+    setPending(null);
+    window.electronAPI?.confirmQuit?.();
+  }, []);
+
+  // Escape AND Enter both CANCEL. The safe action is the default on both keys
+  // so a reflexive keypress can never kill a running download; quitting stays
+  // a deliberate click on a destructive-styled button. Capture phase +
+  // preventDefault so Enter doesn't also fire the focused button's click.
+  useEffect(() => {
+    if (!pending) return;
+    const onKey = (e) => {
+      if (e.key === "Escape" || e.key === "Enter") {
+        e.preventDefault();
+        cancel();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [pending, cancel]);
+
+  // Land the focus ring on "Keep downloading", not on the destructive button.
+  useEffect(() => {
+    if (pending) keepRef.current?.focus();
+  }, [pending]);
+
+  if (!pending) return null;
+
+  const running = pending.running;
+  const n = running.length;
+  const plural = n !== 1;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm px-4">
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-quit-title"
+        className="w-full max-w-md rounded-lg border bg-card shadow-xl animate-slide-up"
+      >
+        <div className="flex items-start gap-3 border-b px-4 py-3">
+          <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 shrink-0">
+            <AlertTriangle className="w-4 h-4" />
+          </span>
+          <div className="min-w-0">
+            <div id="confirm-quit-title" className="text-sm font-semibold">
+              {plural ? `${n} downloads are still running` : "A download is still running"}
+            </div>
+            <div className="text-[11px] text-muted-foreground mt-0.5">
+              Closing now stops {plural ? "them" : "it"} mid-chapter.
+            </div>
+          </div>
+        </div>
+
+        <div className="px-4 py-3 space-y-3">
+          <ul className="space-y-1">
+            {running.slice(0, MAX_LISTED).map((r, i) => (
+              <li
+                key={r.downloadId || i}
+                className="flex items-center gap-2 rounded-md border border-border/60 bg-secondary/40 px-2.5 py-1.5 animate-slide-up"
+                style={{ animationDelay: `${Math.min(i * 40, 240)}ms` }}
+              >
+                <Loader2 className="w-3 h-3 animate-spin text-primary shrink-0" />
+                <span className="text-xs truncate">
+                  {r.title || r.url || "Download"}
+                </span>
+              </li>
+            ))}
+            {n > MAX_LISTED && (
+              <li className="text-[10px] text-muted-foreground pl-1 pt-0.5">
+                +{n - MAX_LISTED} more
+              </li>
+            )}
+          </ul>
+
+          {/* The point of this dialog is that quitting is CHEAP, not scary —
+              say what actually survives so the choice is informed rather than
+              a speed bump. */}
+          <p className="text-[11px] text-muted-foreground leading-relaxed">
+            Chapters that already finished are kept:{" "}
+            {plural ? "each run reappears" : "the run reappears"} in the{" "}
+            <span className="font-medium text-foreground">Resume</span> bar next
+            launch and picks up where it stopped. Anything still queued is
+            restored automatically.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t px-4 py-3">
+          <Button variant="destructive" size="sm" onClick={confirm}>
+            Quit anyway
+          </Button>
+          <Button ref={keepRef} size="sm" autoFocus onClick={cancel}>
+            Keep downloading
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/UI-source/src/components/DownloadTab.jsx
+++ b/UI-source/src/components/DownloadTab.jsx
@@ -48,6 +48,11 @@ const DEFAULT_FORM = {
   splitMode: "none",
   splitValue: "",
   group: "",
+  excludeGroup: "",
+  // "avoid" mirrors aio-dl.py's --mtl default: machine-translated versions
+  // rank below every human one but are still used when they're the only
+  // version of a chapter.
+  mtl: "avoid",
   mixByUpvote: false,
   cookies: "",
   jobs: 1,
@@ -384,6 +389,8 @@ export default function DownloadTab({
     if (form.splitMode === "size" && form.splitValue) args.split = form.splitValue;
     if (form.splitMode === "chapters" && form.splitValue) args.split = `${form.splitValue}ch`;
     if (form.group.trim()) args.group = form.group.trim();
+    if (form.excludeGroup.trim()) args.excludeGroup = form.excludeGroup.trim();
+    if (form.mtl && form.mtl !== "avoid") args.mtl = form.mtl;
     if (form.mixByUpvote) args.mixByUpvote = true;
     if (form.cookies.trim()) args.cookies = form.cookies.trim();
     if (form.jobs > 1) args.jobs = form.jobs;
@@ -856,14 +863,39 @@ export default function DownloadTab({
         <SectionHeader>Advanced</SectionHeader>
         <div className="space-y-2">
           <Collapsible title="Scanlation Groups">
-            <div className="space-y-2">
-              <Label htmlFor="group" className="text-xs">Preferred groups (comma-separated, priority order)</Label>
-              <Input id="group" value={form.group} onChange={(e) => set("group", e.target.value)} placeholder='e.g. "Official, GroupA"' />
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="group" className="text-xs">Preferred groups (comma-separated, priority order)</Label>
+                <Input id="group" value={form.group} onChange={(e) => set("group", e.target.value)} placeholder='e.g. "Official, GroupA"' />
+                <p className="text-[11px] text-muted-foreground">
+                  Naming a group here forces it, overriding every automatic signal
+                  below. Use <code>Official</code> to match any licensed/publisher release.
+                </p>
+              </div>
+
               <div className="flex items-center gap-2">
                 <Checkbox id="mixByUpvote" checked={form.mixByUpvote} onCheckedChange={(v) => set("mixByUpvote", v)} disabled={!form.group.trim()} />
                 <Label htmlFor="mixByUpvote" className={cn("text-xs cursor-pointer", !form.group.trim() && "opacity-40")}>
-                  Pick by most upvotes instead of priority order
+                  Rank across all my groups instead of using priority order
                 </Label>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="excludeGroup" className="text-xs">Groups to avoid (comma-separated)</Label>
+                <Input id="excludeGroup" value={form.excludeGroup} onChange={(e) => set("excludeGroup", e.target.value)} placeholder='e.g. "SomeGroup"' />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="mtl" className="text-xs">Machine translations (MTL)</Label>
+                <Select id="mtl" value={form.mtl} onChange={(e) => set("mtl", e.target.value)}>
+                  <option value="avoid">Avoid — use only if it's the only version</option>
+                  <option value="allow">Allow — treat like any other version</option>
+                  <option value="exclude">Exclude — skip the chapter entirely</option>
+                </Select>
+                <p className="text-[11px] text-muted-foreground">
+                  Detected from the group's name and self-description. "Avoid" never
+                  costs you a chapter; "Exclude" leaves gaps where only MTL exists.
+                </p>
               </div>
             </div>
           </Collapsible>

--- a/UI-source/src/components/LibraryFilterPanel.jsx
+++ b/UI-source/src/components/LibraryFilterPanel.jsx
@@ -1,0 +1,378 @@
+// ============================================================
+// LIBRARY FILTER PANEL — anchored faceted-filter dropdown
+//
+// Pure presentation for LibraryTab's facet filters. LibraryTab owns the
+// canonical filter state AND the facetIndex memo (built from the scanned
+// entries); this file renders chips and calls back. The only state here is
+// the local "filter the filters" query and the per-group expand toggle.
+//
+// There is no Popover primitive in ui/primitives.jsx, so the dropdown is
+// hand-rolled: absolutely positioned inside an anchor wrapper that LibraryTab
+// owns, dismissed on Escape + mousedown outside that wrapper. The wrapper
+// CONTAINS this panel, so one containment test covers both "clicked inside
+// the panel" and "clicked the toggle button" — testing the button separately
+// would close on mousedown and instantly reopen on the button's own click.
+//
+// Entrance uses `animate-slide-up` (a keyframe, so it plays on mount).
+// UpdatesCenter's rAF two-phase mount is only needed there because it
+// animates a CSS *transition*, which needs its from-state committed first.
+//
+// Cross-file:
+//   - LibraryTab.jsx builds `groups` / `filters` and owns persistence
+//     (settings.libraryOpts.filters) — grep facetIndex / applyFilters
+//   - facet values originate in .aio_series.json (aio-dl.py writes it;
+//     electron/library.js passes it through unfiltered as entry.seriesMeta)
+// ============================================================
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Search, X, Tag, Globe, CircleDot, Sparkles, FilterX } from "lucide-react";
+import { Input, Switch } from "@/components/ui/primitives";
+import { cn, naturalCompare } from "@/lib/utils";
+
+// ── Facet group → presentational metadata + filter semantics ──
+// Single source of truth. EXPORTED because LibraryTab's active-filter chip row
+// renders the same icons/accents and its matcher reads `singleValued` — a
+// second literal in that file would drift. Same arrangement as
+// UpdatesCenter.jsx:SECTION_THEME / LibraryTab's STATUS_COLORS.
+//
+// `key` is simultaneously the key of the facetIndex `groups` object and of the
+// filter-state object, so the whole panel is a map over this array.
+//
+// `singleValued` = a series carries at most ONE value for this facet, so
+// "match all" with two of them selected could never match anything; the
+// matcher forces OR there (see LibraryTab:matchesFacets).
+//
+// Accents reuse colors the app already ships (emerald in STATUS_COLORS, sky in
+// SECTION_THEME.active, violet in FORMAT_COLORS.images) — not a new palette.
+// Only the section icon+label is tinted; selected chips are uniformly
+// `primary` so "selected" reads identically in every group.
+export const FACET_GROUPS = [
+  { key: "status", label: "Status", icon: CircleDot, accent: "text-emerald-400", singleValued: true },
+  { key: "sites", label: "Source", icon: Globe, accent: "text-sky-400", singleValued: true },
+  { key: "genres", label: "Genres", icon: Tag, accent: "text-primary", singleValued: false },
+  { key: "tags", label: "AniList tags", icon: Sparkles, accent: "text-violet-400", singleValued: false },
+];
+
+export const FACET_GROUP_BY_KEY = Object.fromEntries(
+  FACET_GROUPS.map((g) => [g.key, g])
+);
+
+const MATCH_MODES = [
+  { value: "any", label: "Any", hint: "Keep series carrying ANY selected genre/tag" },
+  { value: "all", label: "All", hint: "Keep only series carrying EVERY selected genre/tag" },
+];
+
+// Chips past this count collapse behind "Show N more" so a 60-genre library
+// doesn't turn the dropdown into a wall. Selected chips are always rendered
+// regardless of position (see visibleItems) — a chip you just picked must not
+// be able to disappear.
+const CHIP_COLLAPSE_LIMIT = 24;
+
+function FacetChip({ label, count, selected, onClick, title }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={selected}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1",
+        "text-[11px] leading-none transition-colors",
+        selected
+          ? "border-primary bg-primary/10 text-primary"
+          : "border-border hover:border-primary/40 hover:bg-accent/40"
+      )}
+    >
+      <span className="truncate max-w-[150px]">{label}</span>
+      <span
+        className={cn(
+          "text-[10px] tabular-nums",
+          selected ? "text-primary/70" : "text-muted-foreground"
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+// Same anatomy as ui/primitives.jsx:SectionHeader (uppercase tracked label +
+// flex-1 hairline rule), tightened for dropdown density and carrying the
+// group accent + a vocabulary-size readout.
+function FacetSectionHeader({ group, total }) {
+  const Icon = group.icon;
+  return (
+    <div className="flex items-center gap-2 mb-1.5">
+      <Icon className={cn("w-3 h-3 shrink-0", group.accent)} />
+      <span className={cn("text-[10px] font-semibold uppercase tracking-wider", group.accent)}>
+        {group.label}
+      </span>
+      <div className="flex-1 h-px bg-border" />
+      <span className="text-[10px] text-muted-foreground tabular-nums">{total}</span>
+    </div>
+  );
+}
+
+export default function LibraryFilterPanel({
+  // The `relative` wrapper this panel is rendered inside; doubles as the
+  // click-outside boundary.
+  anchorRef,
+  onClose,
+  // { genres|tags|status|sites: Map<lowercaseKey, {label,count,category,spoiler,search}> }
+  groups,
+  // { genres:Set, tags:Set, status:Set, sites:Set, matchMode, showSpoilerTags }
+  filters,
+  activeCount,
+  matchedCount,
+  totalCount,
+  onToggleFacet,
+  onSetMatchMode,
+  onSetShowSpoilerTags,
+  onClearAll,
+}) {
+  const [query, setQuery] = useState("");
+  const [expanded, setExpanded] = useState(() => new Set());
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    const onDown = (e) => {
+      if (!anchorRef?.current?.contains(e.target)) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("mousedown", onDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("mousedown", onDown);
+    };
+  }, [anchorRef, onClose]);
+
+  const lowerQuery = query.trim().toLowerCase();
+
+  // Sort is count-desc then label — deliberately INDEPENDENT of selection, so
+  // clicking a chip never reorders the row and moves the next chip under the
+  // cursor.
+  const sections = useMemo(() => {
+    const out = [];
+    for (const group of FACET_GROUPS) {
+      const map = groups?.[group.key];
+      if (!map || map.size === 0) continue;
+      const selected = filters[group.key];
+      const items = [];
+      for (const [key, meta] of map) {
+        // Spoiler-flagged tags stay hidden unless the switch is on — EXCEPT
+        // ones already selected, which must stay deselectable from here.
+        if (
+          group.key === "tags" &&
+          meta.spoiler &&
+          !filters.showSpoilerTags &&
+          !selected.has(key)
+        ) {
+          continue;
+        }
+        if (lowerQuery && !meta.search.includes(lowerQuery)) continue;
+        items.push({ key, ...meta, selected: selected.has(key) });
+      }
+      if (items.length === 0) continue;
+      items.sort((a, b) => b.count - a.count || naturalCompare(a.label, b.label));
+      out.push({ group, items, total: map.size });
+    }
+    return out;
+  }, [groups, filters, lowerQuery]);
+
+  const visibleItems = (groupKey, items) => {
+    if (lowerQuery || expanded.has(groupKey) || items.length <= CHIP_COLLAPSE_LIMIT) {
+      return items;
+    }
+    return items.filter((it, i) => i < CHIP_COLLAPSE_LIMIT || it.selected);
+  };
+
+  // AniList tag objects carry a `category` ("Theme", "Demographic", …) —
+  // written by aio-dl.py:_serialize_anilist_tag, grep anilist_tags. Sub-group
+  // by it so 80 tags read as a taxonomy instead of a blob.
+  const byCategory = (items) => {
+    const map = new Map();
+    for (const it of items) {
+      const cat = it.category || "Uncategorized";
+      if (!map.has(cat)) map.set(cat, []);
+      map.get(cat).push(it);
+    }
+    return [...map.entries()].sort((a, b) => naturalCompare(a[0], b[0]));
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Library filters"
+      className={cn(
+        "absolute right-0 top-full mt-1.5 z-40 w-[380px]",
+        "flex flex-col max-h-[70vh] overflow-hidden",
+        "rounded-lg border border-border bg-card text-card-foreground",
+        "shadow-[0_16px_40px_-12px_rgba(0,0,0,0.45)]",
+        "animate-slide-up"
+      )}
+    >
+      {/* ── Header: title + match-mode segmented toggle ── */}
+      <div className="flex items-center gap-2 px-3 pt-3 pb-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Filters
+        </span>
+        {activeCount > 0 && (
+          <span className="text-[10px] font-mono tabular-nums px-1.5 py-0.5 rounded-full border border-primary/30 bg-primary/10 text-primary leading-none">
+            {activeCount}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Match
+          </span>
+          <div
+            role="group"
+            aria-label="Match mode"
+            className="inline-flex rounded-md border border-border overflow-hidden"
+          >
+            {MATCH_MODES.map((m, i) => (
+              <button
+                key={m.value}
+                type="button"
+                onClick={() => onSetMatchMode(m.value)}
+                title={m.hint}
+                aria-pressed={filters.matchMode === m.value}
+                className={cn(
+                  "px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors",
+                  i > 0 && "border-l border-border",
+                  filters.matchMode === m.value
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-accent/40"
+                )}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Filter-the-filters ── */}
+      <div className="px-3 pb-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter genres, tags, sources…"
+            className="pl-8 pr-7 h-8 text-xs"
+            autoFocus
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              aria-label="Clear"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Facet groups ── */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 pb-3 space-y-3.5">
+        {sections.length === 0 ? (
+          <p className="text-[11px] text-muted-foreground text-center py-8 leading-relaxed">
+            {lowerQuery
+              ? <>Nothing matching &ldquo;{query}&rdquo;</>
+              : "No genres, tags, status or source recorded for this library yet."}
+          </p>
+        ) : (
+          sections.map(({ group, items, total }) => {
+            const shown = visibleItems(group.key, items);
+            const hidden = items.length - shown.length;
+            const chip = (it) => (
+              <FacetChip
+                key={it.key}
+                label={it.label}
+                count={it.count}
+                selected={it.selected}
+                title={it.category ? `${it.label} · ${it.category}` : it.label}
+                onClick={() => onToggleFacet(group.key, it.key)}
+              />
+            );
+            return (
+              <div key={group.key}>
+                <FacetSectionHeader group={group} total={total} />
+
+                {group.key === "tags" && (
+                  <div className="flex items-center gap-2 mb-2">
+                    <Switch
+                      id="lib-filter-spoiler-tags"
+                      checked={filters.showSpoilerTags}
+                      onCheckedChange={onSetShowSpoilerTags}
+                    />
+                    <label
+                      htmlFor="lib-filter-spoiler-tags"
+                      title="AniList flags these as media or general spoilers"
+                      className="text-[11px] text-muted-foreground cursor-pointer select-none"
+                    >
+                      Show spoiler tags
+                    </label>
+                  </div>
+                )}
+
+                {group.key === "tags" ? (
+                  <div className="space-y-2">
+                    {byCategory(shown).map(([cat, catItems]) => (
+                      <div key={cat}>
+                        <div className="text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/70 mb-1">
+                          {cat}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">{catItems.map(chip)}</div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">{shown.map(chip)}</div>
+                )}
+
+                {hidden > 0 && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setExpanded((prev) => new Set(prev).add(group.key))
+                    }
+                    className="mt-1.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Show {hidden} more
+                  </button>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* ── Footer: live match count + clear ── */}
+      <div className="flex items-center gap-2 px-3 py-2 border-t border-border bg-muted/30">
+        <span className="text-[10px] text-muted-foreground tabular-nums">
+          {matchedCount} of {totalCount} series
+        </span>
+        <button
+          type="button"
+          onClick={onClearAll}
+          disabled={activeCount === 0}
+          className={cn(
+            "ml-auto inline-flex items-center gap-1.5 text-[11px] transition-colors",
+            activeCount === 0
+              ? "text-muted-foreground/40 cursor-default"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <FilterX className="w-3 h-3" />
+          Clear all
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/UI-source/src/components/LibraryTab.jsx
+++ b/UI-source/src/components/LibraryTab.jsx
@@ -21,10 +21,22 @@ import {
   PencilLine,
   Save,
   X,
+  Filter,
+  FilterX,
+  Sparkles,
 } from "lucide-react";
-import { cn, chaptersToRangeString, getInitials } from "@/lib/utils";
+import { cn, chaptersToRangeString, getInitials, naturalCompare } from "@/lib/utils";
 import { buildLibraryDownloadArgs } from "@/lib/downloadArgs";
 import UpdatesCenter from "./UpdatesCenter";
+import LibraryFilterPanel, {
+  FACET_GROUPS,
+  FACET_GROUP_BY_KEY,
+} from "./LibraryFilterPanel";
+
+// NOTE on the funnel glyph: this repo pins lucide-react 0.263.1, where the
+// funnel icon is still named `Filter` (upstream renamed it to `Funnel` much
+// later). `Funnel` is NOT exported here — importing it renders undefined and
+// crashes React.
 
 // Convert a Windows file path to a localfile:// URL the renderer can load.
 function fileToUrl(filePath) {
@@ -58,6 +70,100 @@ const SORT_OPTIONS = [
   { value: "size", label: "Largest first" },
   { value: "size-asc", label: "Smallest first" },
 ];
+
+// ── Facet filtering ──
+// The four groups map 1:1 onto .aio_series.json fields, which electron/
+// library.js parses whole and hands over untouched as entry.seriesMeta — so no
+// backend change was needed to filter on any of this:
+//   genres → seriesMeta.genres              string[]
+//   tags   → seriesMeta.anilist_tags + .anilist_spoiler_tags
+//            ARRAYS OF OBJECTS {name, category, rank, is_media_spoiler,
+//            is_general_spoiler} — writer aio-dl.py:_serialize_anilist_tag,
+//            grep anilist_tags. A naive .join() renders [object Object], and
+//            the keys are absent on anything downloaded before AniList
+//            enrichment shipped, so every read is guarded.
+//   status → seriesMeta.status              STATUS_COLORS vocabulary
+//   sites  → seriesMeta.site                python handler name ("mangafire")
+// Keys are lowercased (sites disagree on genre casing); the display label is
+// the most common casing observed across the library.
+//
+// Group order/icons/accents + the singleValued flag live in
+// LibraryFilterPanel.jsx:FACET_GROUPS.
+const FACET_KEYS = ["genres", "tags", "status", "sites"];
+
+function makeEmptyFilters() {
+  return {
+    genres: new Set(),
+    tags: new Set(),
+    status: new Set(),
+    sites: new Set(),
+    matchMode: "any",
+    showSpoilerTags: false,
+  };
+}
+
+// settings.libraryOpts.filters ⇄ filter state. Sets serialize as arrays.
+// Every field is re-validated on read: history.json is hand-editable and an
+// older settings dict simply has no `filters` key at all.
+function filtersFromJson(raw) {
+  const out = makeEmptyFilters();
+  if (!raw || typeof raw !== "object") return out;
+  for (const k of FACET_KEYS) {
+    if (Array.isArray(raw[k])) {
+      out[k] = new Set(raw[k].filter((v) => typeof v === "string"));
+    }
+  }
+  if (raw.matchMode === "all" || raw.matchMode === "any") out.matchMode = raw.matchMode;
+  out.showSpoilerTags = raw.showSpoilerTags === true;
+  return out;
+}
+
+function filtersToJson(f) {
+  return {
+    genres: [...f.genres],
+    tags: [...f.tags],
+    status: [...f.status],
+    sites: [...f.sites],
+    matchMode: f.matchMode,
+    showSpoilerTags: f.showSpoilerTags,
+  };
+}
+
+function countActiveFilters(f) {
+  return f.genres.size + f.tags.size + f.status.size + f.sites.size;
+}
+
+// AND across groups; within a group `matchMode` decides.
+// EXCEPT for the single-valued groups (status, source): a series has exactly
+// one of each, so "all" with two selected could never match anything. Those
+// are always OR — matchMode is effectively a genres/tags control, which is the
+// standard faceted-search contract.
+function matchesFacets(entryFacets, filters) {
+  if (!entryFacets) return false;
+  for (const groupKey of FACET_KEYS) {
+    const selected = filters[groupKey];
+    if (selected.size === 0) continue;
+    const have = entryFacets[groupKey];
+    if (filters.matchMode === "all" && !FACET_GROUP_BY_KEY[groupKey].singleValued) {
+      for (const v of selected) if (!have.has(v)) return false;
+    } else {
+      let hit = false;
+      for (const v of selected) {
+        if (have.has(v)) { hit = true; break; }
+      }
+      if (!hit) return false;
+    }
+  }
+  return true;
+}
+
+// Normalize a raw genre/tag/status/site string into its facet key. MUST stay
+// identical to the keying in the facetIndex memo below — DetailView's chips
+// derive keys from raw metadata strings and would otherwise apply a filter
+// that matches nothing.
+function facetKey(raw) {
+  return String(raw ?? "").trim().toLowerCase();
+}
 
 // ── Badge components ──
 // Collapse the repeated FORMAT_COLORS / STATUS_COLORS <span> markup (grid card,
@@ -93,6 +199,77 @@ function StatusBadge({ status, className, fallback = "bg-muted text-muted-foregr
     >
       {status}
     </span>
+  );
+}
+
+// Clickable metadata chip for DetailView's genre + AniList-tag rows. Clicking
+// applies the value as a library filter and drops back to the grid, so there's
+// deliberately no "selected" state — this chip never renders as on.
+// Hand-rolled rather than reusing Badge because Badge (ui/primitives.jsx) does
+// NOT spread props and therefore can't take an onClick.
+function MetaChip({ label, onClick, title }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title || `Filter library by “${label}”`}
+      className={cn(
+        "inline-flex items-center rounded-full border border-border/70 bg-secondary/50",
+        "px-2 py-0.5 text-[10px] leading-tight text-muted-foreground",
+        "hover:border-primary/40 hover:bg-primary/10 hover:text-primary transition-colors"
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+// AniList tags in the detail view — the first place in the UI that has ever
+// rendered them. Entries are OBJECTS (aio-dl.py:_serialize_anilist_tag), and
+// both keys are absent on pre-enrichment downloads, hence the normalize pass.
+// Spoiler-flagged tags live in their own array and stay behind a click: the
+// is_media_spoiler / is_general_spoiler flags exist precisely so a reader can
+// be spoiler-aware.
+function AnilistTagChips({ meta, onFilterByFacet }) {
+  const [showSpoilers, setShowSpoilers] = useState(false);
+  const normalize = (list) =>
+    (Array.isArray(list) ? list : []).filter(
+      (t) => t && typeof t === "object" && t.name
+    );
+  const tags = normalize(meta?.anilist_tags);
+  const spoilerTags = normalize(meta?.anilist_spoiler_tags);
+  if (tags.length === 0 && spoilerTags.length === 0) return null;
+
+  const chip = (t) => (
+    <MetaChip
+      key={t.name}
+      label={t.name}
+      title={[t.name, t.category, t.rank ? `rank ${t.rank}` : null]
+        .filter(Boolean)
+        .join(" · ")}
+      onClick={() => onFilterByFacet?.("tags", facetKey(t.name))}
+    />
+  );
+
+  return (
+    <div className="flex items-start gap-1.5">
+      <Sparkles className="w-3 h-3 shrink-0 mt-1 text-violet-400" />
+      <div className="flex flex-wrap items-center gap-1">
+        {tags.map(chip)}
+        {spoilerTags.length > 0 &&
+          (showSpoilers ? (
+            spoilerTags.map(chip)
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowSpoilers(true)}
+              className="text-[10px] text-muted-foreground hover:text-foreground underline decoration-dotted underline-offset-2 transition-colors"
+            >
+              {spoilerTags.length} spoiler tag{spoilerTags.length === 1 ? "" : "s"}
+            </button>
+          ))}
+      </div>
+    </div>
   );
 }
 
@@ -544,7 +721,12 @@ function MetadataEditorPanel({ entry, onClose, onSaved }) {
   );
 }
 
-function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, settings }) {
+function DetailView({
+  entry, onBack, onRefresh, onStartDownload, onSwitchTab, settings,
+  // (groupKey, facetKey) → add that value to the grid's facet filter and
+  // navigate back. Supplied by LibraryTab; grep addFacet.
+  onFilterByFacet,
+}) {
   const [deleting, setDeleting] = useState(false);
   // Two-step delete confirmation (avoids window.confirm which breaks
   // Electron's renderer focus/input handling)
@@ -635,11 +817,20 @@ function DetailView({ entry, onBack, onRefresh, onStartDownload, onSwitchTab, se
                   </div>
                 )}
                 {meta.genres?.length > 0 && (
-                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <Tag className="w-3 h-3 shrink-0" />
-                    <span>{meta.genres.join(", ")}</span>
+                  <div className="flex items-start gap-1.5">
+                    <Tag className="w-3 h-3 shrink-0 mt-1 text-muted-foreground" />
+                    <div className="flex flex-wrap gap-1">
+                      {meta.genres.map((g) => (
+                        <MetaChip
+                          key={g}
+                          label={g}
+                          onClick={() => onFilterByFacet?.("genres", facetKey(g))}
+                        />
+                      ))}
+                    </div>
                   </div>
                 )}
+                <AnilistTagChips meta={meta} onFilterByFacet={onFilterByFacet} />
               </div>
             )}
 
@@ -822,6 +1013,31 @@ function EmptyState() {
   );
 }
 
+// Third empty state, distinct from EmptyState (nothing downloaded yet) and the
+// no-search-results line: the library HAS content and the user's own facet
+// selection is what's hiding it, so the fix is one click away.
+function FilteredEmptyState({ searchQuery, onClearFilters }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center text-center py-20 px-8 gap-3">
+      <div className="w-16 h-16 rounded-full bg-muted/50 flex items-center justify-center">
+        <Filter className="w-7 h-7 text-muted-foreground/50" />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold mb-1">No matches</h3>
+        <p className="text-xs text-muted-foreground max-w-xs">
+          {searchQuery
+            ? <>Nothing matches these filters and &ldquo;{searchQuery}&rdquo;.</>
+            : "Nothing in your library matches every active filter."}
+        </p>
+      </div>
+      <Button variant="outline" size="sm" onClick={onClearFilters} className="gap-1.5 text-xs">
+        <FilterX className="w-3.5 h-3.5" />
+        Clear filters
+      </Button>
+    </div>
+  );
+}
+
 // ============================================================
 // LIBRARY TAB (main export)
 // ============================================================
@@ -859,14 +1075,86 @@ export default function LibraryTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings?.libraryOpts?.sortBy]);
 
-  // Wrap the setter so picking a new sort persists to settings.libraryOpts.
-  // Spread merge preserves any future libraryOpts fields without listing them.
+  // ── Facet filters ──
+  const [filters, setFilters] = useState(() =>
+    filtersFromJson(settings?.libraryOpts?.filters)
+  );
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
+  const filterAnchorRef = useRef(null);
+
+  // Hydration is ONE-SHOT, unlike sortBy's above: the persisted value is an
+  // object, so an equality guard would need a deep compare and a plain
+  // identity dep would re-fire on every settings save and clobber the live
+  // selection. Also latched by applyFilters, so a slow disk load can't
+  // overwrite a selection the user already made.
+  const filtersHydratedRef = useRef(false);
+  useEffect(() => {
+    if (filtersHydratedRef.current) return;
+    const persisted = settings?.libraryOpts;
+    if (!persisted) return;
+    filtersHydratedRef.current = true;
+    setFilters(filtersFromJson(persisted.filters));
+  }, [settings?.libraryOpts]);
+
+  // Single writer for settings.libraryOpts, so the sort write and the filter
+  // write can't drop each other's key. Same spread-merge as the original
+  // updateSort, but merging onto a ref instead of the `settings` prop: the
+  // prop only refreshes after saveSettings round-trips through IPC, so two
+  // writes in quick succession would both merge onto the same stale base.
+  const libraryOptsRef = useRef(settings?.libraryOpts || {});
+  useEffect(() => {
+    if (settings?.libraryOpts) libraryOptsRef.current = settings.libraryOpts;
+  }, [settings?.libraryOpts]);
+
+  const persistLibraryOpts = useCallback((patch) => {
+    const next = { ...libraryOptsRef.current, ...patch };
+    libraryOptsRef.current = next;
+    onSaveSettings?.({ libraryOpts: next });
+  }, [onSaveSettings]);
+
   const updateSort = (value) => {
     setSortBy(value);
-    onSaveSettings?.({
-      libraryOpts: { ...(settings?.libraryOpts || {}), sortBy: value },
-    });
+    persistLibraryOpts({ sortBy: value });
   };
+
+  // Every filter mutation funnels through here so persistence can't be
+  // forgotten. Reads `filters` from the closure rather than using a functional
+  // updater: the persist call is a side effect and React StrictMode invokes
+  // updaters twice. Chip clicks are user-paced, so there's no batching hazard.
+  const applyFilters = useCallback((next) => {
+    filtersHydratedRef.current = true;
+    setFilters(next);
+    persistLibraryOpts({ filters: filtersToJson(next) });
+  }, [persistLibraryOpts]);
+
+  const toggleFacet = useCallback((groupKey, valueKey) => {
+    const nextSet = new Set(filters[groupKey]);
+    if (nextSet.has(valueKey)) nextSet.delete(valueKey);
+    else nextSet.add(valueKey);
+    applyFilters({ ...filters, [groupKey]: nextSet });
+  }, [filters, applyFilters]);
+
+  // Additive-only variant for DetailView's chips — clicking a genre there
+  // means "show me more of this", never "turn it off".
+  const addFacet = useCallback((groupKey, valueKey) => {
+    if (!valueKey || filters[groupKey].has(valueKey)) return;
+    applyFilters({ ...filters, [groupKey]: new Set(filters[groupKey]).add(valueKey) });
+  }, [filters, applyFilters]);
+
+  const clearFilters = useCallback(
+    () => applyFilters(makeEmptyFilters()),
+    [applyFilters]
+  );
+  const setMatchMode = useCallback(
+    (mode) => applyFilters({ ...filters, matchMode: mode }),
+    [filters, applyFilters]
+  );
+  const setShowSpoilerTags = useCallback(
+    (value) => applyFilters({ ...filters, showSpoilerTags: value }),
+    [filters, applyFilters]
+  );
+  const closeFilterPanel = useCallback(() => setFilterPanelOpen(false), []);
+
   const [selectedEntry, setSelectedEntry] = useState(null);
 
   // New chapter counts per series (folderPath → count).
@@ -1194,23 +1482,134 @@ export default function LibraryTab({
     () => entries.map((e) => ({ entry: e, lowerTitle: (e.title || "").toLowerCase() })),
     [entries]
   );
+
+  // Per-entry facet Sets + the library-wide facet vocabulary. Same reasoning as
+  // entriesIndexed, one level up: without it every filter evaluation would
+  // re-walk each series' genre/tag arrays and re-lowercase every string.
+  //
+  // `perEntry` is INDEX-PARALLEL to entriesIndexed — both are a plain
+  // `entries.map`, and `filtered` below zips them by index. Keep BOTH memos
+  // keyed on [entries] alone or that invariant breaks.
+  //
+  // Counts are library-wide, NOT contextual (they don't shrink as you select
+  // other facets). Contextual counts would mean rebuilding the whole index on
+  // every click and every number jumping as you go — worse to use, and it
+  // would tie this memo to `filters`.
+  const facetIndex = useMemo(() => {
+    const groups = {
+      genres: new Map(),
+      tags: new Map(),
+      status: new Map(),
+      sites: new Map(),
+    };
+
+    // `seen` is the entry's own key Set: a series listing "Action" twice must
+    // count once. Casing tallies ride the meta so the label we display is the
+    // library's most common spelling, not whichever series scanned first.
+    const bump = (groupKey, rawValue, seen, extra) => {
+      const raw = String(rawValue ?? "").trim();
+      if (!raw) return;
+      const key = raw.toLowerCase();
+      const map = groups[groupKey];
+      let meta = map.get(key);
+      if (!meta) {
+        meta = { label: raw, count: 0, category: "", spoiler: false, casings: new Map() };
+        map.set(key, meta);
+      }
+      if (extra) {
+        // First non-empty category wins; spoiler is sticky — a tag flagged on
+        // any one series stays behind the spoiler switch everywhere.
+        if (extra.category && !meta.category) meta.category = extra.category;
+        if (extra.spoiler) meta.spoiler = true;
+      }
+      meta.casings.set(raw, (meta.casings.get(raw) || 0) + 1);
+      if (seen.has(key)) return;
+      seen.add(key);
+      meta.count += 1;
+    };
+
+    const perEntry = entries.map((e) => {
+      const meta = e.seriesMeta || {};
+      const facets = {
+        genres: new Set(),
+        tags: new Set(),
+        status: new Set(),
+        sites: new Set(),
+      };
+      for (const g of meta.genres || []) bump("genres", g, facets.genres);
+      // anilist_tags / anilist_spoiler_tags are arrays of OBJECTS, and the
+      // split is already spoiler-vs-not on the Python side
+      // (external_metadata.py:_split_tags) — the per-tag flags are re-checked
+      // anyway so a hand-edited or older file can't leak a spoiler.
+      const readTags = (list, fromSpoilerBucket) => {
+        for (const t of Array.isArray(list) ? list : []) {
+          if (!t || typeof t !== "object") continue;
+          bump("tags", t.name, facets.tags, {
+            category: String(t.category || "").trim(),
+            spoiler:
+              fromSpoilerBucket ||
+              t.is_media_spoiler === true ||
+              t.is_general_spoiler === true,
+          });
+        }
+      };
+      readTags(meta.anilist_tags, false);
+      readTags(meta.anilist_spoiler_tags, true);
+      bump("status", meta.status, facets.status);
+      bump("sites", meta.site, facets.sites);
+      return facets;
+    });
+
+    // Resolve display labels + the precomputed lowercase haystack the panel's
+    // filter-the-filters input tests against (so a keystroke doesn't
+    // re-lowercase every facet label in the library).
+    for (const map of Object.values(groups)) {
+      for (const meta of map.values()) {
+        let best = meta.label;
+        let bestN = -1;
+        for (const [text, n] of meta.casings) {
+          if (n > bestN || (n === bestN && text < best)) {
+            best = text;
+            bestN = n;
+          }
+        }
+        meta.label = best;
+        delete meta.casings;
+        meta.search = (meta.category ? `${best} ${meta.category}` : best).toLowerCase();
+      }
+    }
+
+    return { perEntry, groups };
+  }, [entries]);
+
+  const activeFilterCount = countActiveFilters(filters);
+
   const lowerQuery = useMemo(() => searchQuery.toLowerCase(), [searchQuery]);
   const filtered = useMemo(
     () => {
-      if (!lowerQuery) return entries;
-      return entriesIndexed
-        .filter((x) => x.lowerTitle.includes(lowerQuery))
-        .map((x) => x.entry);
+      if (!lowerQuery && activeFilterCount === 0) return entries;
+      const out = [];
+      for (let i = 0; i < entriesIndexed.length; i++) {
+        if (lowerQuery && !entriesIndexed[i].lowerTitle.includes(lowerQuery)) continue;
+        if (activeFilterCount > 0 && !matchesFacets(facetIndex.perEntry[i], filters)) continue;
+        out.push(entriesIndexed[i].entry);
+      }
+      return out;
     },
-    [entriesIndexed, lowerQuery, entries]
+    [entriesIndexed, facetIndex, filters, activeFilterCount, lowerQuery, entries]
   );
 
   const sorted = useMemo(() => {
     const copy = [...filtered];
     copy.sort((a, b) => {
       switch (sortBy) {
-        case "title": return a.title.localeCompare(b.title);
-        case "title-desc": return b.title.localeCompare(a.title);
+        // naturalCompare (@/lib/utils) is numeric-aware: "Vol 2" before
+        // "Vol 10", not after "Vol 100".
+        case "title": return naturalCompare(a.title, b.title);
+        case "title-desc": return naturalCompare(b.title, a.title);
+        // DELIBERATELY plain localeCompare: these are ISO-8601 strings, which
+        // already sort correctly lexicographically. numeric:true would parse
+        // the digit groups across the '-' and ':' separators and break them.
         case "date": return (b.lastModified || "").localeCompare(a.lastModified || "");
         case "date-asc": return (a.lastModified || "").localeCompare(b.lastModified || "");
         case "size": return b.totalSize - a.totalSize;
@@ -1220,6 +1619,21 @@ export default function LibraryTab({
     });
     return copy;
   }, [filtered, sortBy]);
+
+  // Flatten the active selection into removable chips, in FACET_GROUPS order.
+  // A key that no longer exists in the library (series deleted, or a filter
+  // persisted from a previous library) still gets a chip — falling back to the
+  // raw key — so it stays removable instead of silently matching nothing.
+  const activeFilterChips = useMemo(() => {
+    const chips = [];
+    for (const group of FACET_GROUPS) {
+      const map = facetIndex.groups[group.key];
+      for (const key of filters[group.key]) {
+        chips.push({ group, key, label: map?.get(key)?.label || key });
+      }
+    }
+    return chips;
+  }, [filters, facetIndex]);
 
   // Count how many series are eligible for "Check All".
   // Must mirror main.js's checkable filter — see the comment there. When
@@ -1273,6 +1687,10 @@ export default function LibraryTab({
         onStartDownload={onStartDownload}
         onSwitchTab={onSwitchTab}
         settings={settings}
+        onFilterByFacet={(groupKey, valueKey) => {
+          addFacet(groupKey, valueKey);
+          setSelectedEntry(null);
+        }}
       />
     );
   }
@@ -1307,6 +1725,56 @@ export default function LibraryTab({
               <option key={opt.value} value={opt.value}>{opt.label}</option>
             ))}
           </select>
+        </div>
+
+        {/* Faceted filter dropdown. This wrapper is `relative` so the panel
+            positions under the button, AND it is the click-outside boundary —
+            LibraryFilterPanel tests containment against this same ref, which is
+            why the panel must stay a child of it (see that file's header). */}
+        <div className="relative" ref={filterAnchorRef}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setFilterPanelOpen((v) => !v)}
+            disabled={entries.length === 0}
+            aria-expanded={filterPanelOpen}
+            className={cn(
+              "gap-1.5 text-xs",
+              activeFilterCount > 0 && [
+                "border-primary/50 bg-primary/10 text-primary",
+                "hover:bg-primary/15 hover:text-primary hover:border-primary/60",
+              ]
+            )}
+            title={
+              activeFilterCount > 0
+                ? `${activeFilterCount} filter${activeFilterCount !== 1 ? "s" : ""} active`
+                : "Filter by genre, AniList tag, status or source"
+            }
+          >
+            <Filter className="w-3.5 h-3.5" />
+            Filter
+            {activeFilterCount > 0 && (
+              <span className="text-[10px] font-mono tabular-nums px-1 rounded-sm bg-primary/20">
+                {activeFilterCount}
+              </span>
+            )}
+          </Button>
+
+          {filterPanelOpen && (
+            <LibraryFilterPanel
+              anchorRef={filterAnchorRef}
+              onClose={closeFilterPanel}
+              groups={facetIndex.groups}
+              filters={filters}
+              activeCount={activeFilterCount}
+              matchedCount={sorted.length}
+              totalCount={entries.length}
+              onToggleFacet={toggleFacet}
+              onSetMatchMode={setMatchMode}
+              onSetShowSpoilerTags={setShowSpoilerTags}
+              onClearAll={clearFilters}
+            />
+          )}
         </div>
 
         {/* Updates Center button.
@@ -1380,15 +1848,75 @@ export default function LibraryTab({
           <RefreshCw className={cn("w-3.5 h-3.5", loading && "animate-spin")} />
         </Button>
 
-        <Badge variant="secondary" className="text-[10px] ml-auto">
-          {loading ? "…" : `${sorted.length} manga${sorted.length !== 1 ? "s" : ""}`}
+        {/* Reflects the FILTERED count; hints at the library total whenever a
+            filter or search is narrowing it. */}
+        <Badge variant="secondary" className="text-[10px] ml-auto tabular-nums">
+          {loading
+            ? "…"
+            : sorted.length === entries.length
+            ? `${sorted.length} manga${sorted.length !== 1 ? "s" : ""}`
+            : `${sorted.length} of ${entries.length}`}
         </Badge>
       </div>
+
+      {/* ── Active filter chips ──
+          Keeps the current filter legible without opening the panel. Chip
+          markup follows SettingsTab's disabled-search-sources list; the group
+          icon carries the accent so the neutral chip body doesn't turn the row
+          into a wall of blue. Staggered reveal matches SearchTab's rows. */}
+      {activeFilterChips.length > 0 && (
+        <div className="flex items-center flex-wrap gap-1.5 px-4 py-2 border-b bg-card/10">
+          {activeFilterChips.map((chip, i) => {
+            const Icon = chip.group.icon;
+            return (
+              <span
+                key={`${chip.group.key}:${chip.key}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-secondary/60 pl-2 pr-1 py-0.5 animate-slide-up"
+                style={{ animationDelay: `${Math.min(i * 40, 240)}ms` }}
+              >
+                <Icon className={cn("w-3 h-3 shrink-0", chip.group.accent)} />
+                <span className="text-[11px] leading-none">{chip.label}</span>
+                <button
+                  type="button"
+                  onClick={() => toggleFacet(chip.group.key, chip.key)}
+                  aria-label={`Remove ${chip.group.label} filter ${chip.label}`}
+                  title="Remove filter"
+                  className="ml-0.5 p-0.5 rounded-full text-muted-foreground hover:text-foreground hover:bg-background transition-colors"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            );
+          })}
+          {/* "All" changes what the selection MEANS, and it's otherwise only
+              visible inside the panel. */}
+          {filters.matchMode === "all" && (
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              match all
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="ml-1 inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <FilterX className="w-3 h-3" />
+            Clear
+          </button>
+        </div>
+      )}
 
       {/* Grid / Empty */}
       <div className="flex-1 overflow-y-auto">
         {!loading && sorted.length === 0 ? (
-          searchQuery ? (
+          // Order matters: an empty library must never offer "clear filters"
+          // (a filter can outlive the series it was applied to, since it's
+          // persisted in settings.libraryOpts).
+          entries.length === 0 ? (
+            <EmptyState />
+          ) : activeFilterCount > 0 ? (
+            <FilteredEmptyState searchQuery={searchQuery} onClearFilters={clearFilters} />
+          ) : searchQuery ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
               <Search className="w-8 h-8 text-muted-foreground/30 mb-3" />
               <p className="text-xs text-muted-foreground">

--- a/UI-source/src/components/QueueTab.jsx
+++ b/UI-source/src/components/QueueTab.jsx
@@ -1,7 +1,62 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Button, Card, Badge } from "@/components/ui/primitives";
 import { X, Trash2, Clock, Loader2, RotateCw, Zap } from "lucide-react";
-import { cn, formatDuration } from "@/lib/utils";
+import { cn, formatDuration, formatEta } from "@/lib/utils";
+
+// 1s heartbeat so the elapsed-time readout advances even while a download is
+// quiet. The parent only re-renders on log/progress flushes, and those stall
+// for minutes during a single slow chapter fetch — without this the clock
+// would visibly freeze. Disabled when nothing is running, so an idle Queue tab
+// costs zero timers.
+function useElapsedTick(active) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [active]);
+}
+
+// ── Elapsed + "time left" row under the active card's progress bar ──
+//
+// etaMs / etaSamples are stamped per chapter tick in the MAIN process
+// (electron/downloader.js, grep applyChapterEta) and ride the existing
+// download-progress payload. Three display states:
+//   - cached prefix draining (the chapter ticks are "already processed,
+//     collecting files", which take ~0ms and are deliberately NOT sampled):
+//     say so in words instead of showing a number that would be fiction.
+//   - exactly 2 samples — the minimum the estimator publishes at: render at
+//     reduced opacity. The estimate is real, but it's young.
+//   - 3+ samples, or no total chapter count at all: plain, or nothing.
+//
+// The transition sits on the SPAN as a whole rather than on the digits, and
+// the readout is tabular-nums font-mono, so a value changing at the 100ms
+// flush cadence can't strobe or reflow the row.
+function TimingRow({ dl }) {
+  const p = dl.progress || {};
+  const elapsed = dl.startedAt ? formatDuration(Date.now() - dl.startedAt) : "";
+  const eta = (p.etaSamples || 0) >= 2 && p.etaMs > 0 ? formatEta(p.etaMs) : "";
+  const draining = !eta && p.chapterCached === true;
+
+  if (!elapsed && !eta && !draining) return null;
+
+  return (
+    <div className="flex items-baseline justify-between gap-3 mt-1.5">
+      <span className="text-[10px] text-muted-foreground tabular-nums font-mono">
+        {elapsed}
+      </span>
+      <span
+        className={cn(
+          "text-[10px] tabular-nums font-mono transition-opacity duration-300",
+          eta ? "text-foreground/75" : "text-muted-foreground",
+          eta && p.etaSamples === 2 && "opacity-60",
+        )}
+      >
+        {eta ? `~${eta} left` : draining ? "Resuming cached chapters…" : ""}
+      </span>
+    </div>
+  );
+}
 
 function ProgressBar({ value, max, indeterminate, className }) {
   const percent = max > 0 ? Math.min(100, (value / max) * 100) : 0;
@@ -53,6 +108,8 @@ export default function QueueTab({
       completed.push({ id, ...dl });
     }
   }
+
+  useElapsedTick(running.length > 0);
 
   return (
     <div className="flex flex-col h-full">
@@ -126,6 +183,8 @@ export default function QueueTab({
               <ProgressBar indeterminate />
             ) : null}
 
+            <TimingRow dl={dl} />
+
             <div className="flex gap-1.5 mt-2 flex-wrap">
               {dl.args?.format && <Badge variant="secondary">{dl.args.format.toUpperCase()}</Badge>}
               {dl.args?.quality && <Badge variant="secondary">Q{dl.args.quality}</Badge>}
@@ -180,6 +239,16 @@ export default function QueueTab({
                 </div>
                 <div className="flex gap-1.5 mt-1.5 ml-6 flex-wrap">
                   {isResume && <Badge variant="default">Resume</Badge>}
+                  {/* Carried over from the previous session (useDownloader's
+                      queue snapshot, grep _restoreQueueItems). Badged so the
+                      auto-start on launch isn't mysterious; the dashed border
+                      echoes the queued card's own, tying "not yet started" to
+                      "carried over". */}
+                  {item.restored && (
+                    <Badge variant="secondary" className="border-dashed">
+                      Restored
+                    </Badge>
+                  )}
                   {isResume && item.cachedChapters > 0 && (
                     <Badge variant="secondary">{item.cachedChapters} ch cached</Badge>
                   )}

--- a/UI-source/src/components/SettingsTab.jsx
+++ b/UI-source/src/components/SettingsTab.jsx
@@ -168,13 +168,21 @@ const DEFAULT_SETTINGS = {
   scriptPath: DEV_DEFAULTS.scriptPath,
   workingDir: DEV_DEFAULTS.workingDir,
   verboseAlways: true,
-  // App self-update opt-in (grep appAutoUpdate — consumed by
-  // electron/updater.js via main.js's save-settings live-sync). OFF by
-  // default, deliberately: when on, the app downloads new releases in the
-  // background and installs them silently on exit, so it needs explicit
-  // buy-in. Top-level (not defaults.*) — an app preference, not a
-  // per-download flag. NOT related to the Library chapter update checks.
-  appAutoUpdate: false,
+  // App self-update, OPT-OUT (grep appAutoUpdate — consumed by
+  // electron/updater.js via main.js's save-settings live-sync). ON by
+  // default: staying current is the right default for a scraper whose site
+  // handlers break when sites change, and the install is silent-on-exit
+  // behind a 5-day maturity delay, so it never interrupts. Top-level (not
+  // defaults.*) — an app preference, not a per-download flag. NOT related to
+  // the Library chapter update checks.
+  //
+  // main.js RESOLVES the default (get-settings returns
+  // `saved.appAutoUpdate !== false`), so this value only shows for the ~50ms
+  // before the first IPC lands; the reads below still use `!== false` so a
+  // user with no saved key sees the switch ON either way. history.js's v1
+  // settings migration clears the explicit `false` that the old opt-in
+  // default wrote for every user who ever pressed Save.
+  appAutoUpdate: true,
   // Update maturity delay: only install a release once it's this many
   // days old, so a bad release can be pulled or superseded before it
   // reaches installs. 0 = update as soon as a release is published.
@@ -915,6 +923,12 @@ export default function SettingsTab({ settings, onSave, searchSiteHealth = {}, i
     // getResolvedPaths shows what will run) — DEFAULT_SETTINGS already carries
     // "" for all three. Only isPackaged is overridden: it's owned by main.js,
     // so keep the current value rather than DEFAULT_SETTINGS's placeholder.
+    //
+    // Note for the next reader: because this clones DEFAULT_SETTINGS wholesale,
+    // Reset RE-ENABLES appAutoUpdate (it's `true` there since the opt-out
+    // flip). That's correct under an opt-out default — Reset means "back to
+    // shipped defaults" — but it does silently undo a deliberate opt-out, so
+    // don't be surprised by it.
     setLocal((prev) => ({
       ...structuredClone(DEFAULT_SETTINGS),
       isPackaged: prev.isPackaged,
@@ -1127,10 +1141,11 @@ export default function SettingsTab({ settings, onSave, searchSiteHealth = {}, i
   // App SELF-update (not Library chapter checks). Deliberately the ONLY
   // update UI in the app — no banners, no dialogs anywhere else; install
   // happens silently on exit (user decision, 2026-07-12). The toggle
-  // persists settings.appAutoUpdate; main.js's save-settings handler
-  // live-syncs electron/updater.js (enable arms a check immediately,
-  // disable also cancels install-on-quit for an already-downloaded
-  // update). Status states + shape: updater.js's `status` object.
+  // persists settings.appAutoUpdate, which is OPT-OUT: every read here is
+  // `!== false` so an absent key renders ON, matching main.js's resolution.
+  // main.js's save-settings handler live-syncs electron/updater.js (enable
+  // arms a check immediately, disable also cancels install-on-quit for an
+  // already-downloaded update). Status states + shape: updater.js's `status`.
   const renderAppUpdates = () => {
     const st = updStatus; // null pre-snapshot / in browser dev mode
     const supported = !!st?.supported;
@@ -1183,7 +1198,9 @@ export default function SettingsTab({ settings, onSave, searchSiteHealth = {}, i
           statusNode = <>Waiting for the first background check</>;
           break;
         case "disabled":
-          statusNode = <>Automatic updates are off</>;
+          // Only reachable by an explicit opt-out now that the default is ON,
+          // so word it as the user's choice rather than a resting state.
+          statusNode = <>Turned off — you'll update manually</>;
           break;
         default:
           statusNode = null; // unsupported → reason rendered under the toggle
@@ -1195,13 +1212,14 @@ export default function SettingsTab({ settings, onSave, searchSiteHealth = {}, i
         <div className="flex items-center justify-between gap-3">
           <div className="flex-1">
             <Label className="text-xs cursor-pointer">
-              Automatically install app updates
+              Keep the app up to date automatically
             </Label>
             <p className="text-[10px] text-muted-foreground mt-0.5">
-              Checks GitHub Releases in the background after launch,
-              downloads new versions silently, and applies them on the next
-              app exit — never interrupts, never prompts. Updates come from
-              the repo that built this install.
+              On by default. Checks GitHub Releases in the background after
+              launch, downloads new versions silently, and applies them on the
+              next app exit — never interrupts, never prompts. Turn it off to
+              stay on this build and update by hand. Updates come from the repo
+              that built this install.
             </p>
             {st && !supported && (
               <p className="text-[10px] text-yellow-500 dark:text-yellow-400 mt-1 leading-snug">
@@ -1209,19 +1227,24 @@ export default function SettingsTab({ settings, onSave, searchSiteHealth = {}, i
               </p>
             )}
           </div>
+          {/* `!== false`, not `=== true`: a user with no saved key — a fresh
+              install, or one whose legacy stored `false` was cleared by
+              history.js's v1 migration — must see the switch ON, matching what
+              the updater is actually doing. */}
           <Switch
-            checked={local.appAutoUpdate === true}
+            checked={local.appAutoUpdate !== false}
             onCheckedChange={(v) => set("appAutoUpdate", v)}
           />
         </div>
 
-        {/* Maturity delay — nested under the opt-in. A release only
-            downloads once it's this many days old (clock = the feed's
-            releaseDate, stamped when CI built it), so a bad release can
-            be pulled/superseded before it reaches installs. Lowering it
-            to 0 + Save is the "update me now" escape hatch — main.js's
-            save-settings sync re-evaluates a deferred release live. */}
-        {local.appAutoUpdate === true && (
+        {/* Maturity delay — nested under the master toggle, same
+            absent-means-ON gate. A release only downloads once it's this many
+            days old (clock = the feed's releaseDate, stamped when CI built
+            it), so a bad release can be pulled/superseded before it reaches
+            installs. Lowering it to 0 + Save is the "update me now" escape
+            hatch — main.js's save-settings sync re-evaluates a deferred
+            release live. */}
+        {local.appAutoUpdate !== false && (
           <div className="flex items-start justify-between gap-3 mt-3 animate-slide-up">
             <div className="flex-1">
               <Label className="text-xs cursor-pointer">

--- a/UI-source/src/components/UpdatesCenter.jsx
+++ b/UI-source/src/components/UpdatesCenter.jsx
@@ -46,7 +46,7 @@ import {
   StopCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/primitives";
-import { cn, chaptersToRangeString, getInitials } from "@/lib/utils";
+import { cn, chaptersToRangeString, getInitials, naturalCompare } from "@/lib/utils";
 
 // ── Section state → presentational metadata ──
 // Single source for the per-section accent so the chip, the section header,
@@ -465,9 +465,9 @@ export default function UpdatesCenter({
       if (a.state === b.state) return (a.enqueuedAt || 0) - (b.enqueuedAt || 0);
       return a.state === "running" ? -1 : 1;
     });
-    // Up to date: alphabetical
-    uptodate.sort((a, b) => a.title.localeCompare(b.title));
-    errors.sort((a, b) => a.title.localeCompare(b.title));
+    // Up to date: alphabetical, numeric-aware ("Vol 2" before "Vol 10")
+    uptodate.sort((a, b) => naturalCompare(a.title || "", b.title || ""));
+    errors.sort((a, b) => naturalCompare(a.title || "", b.title || ""));
     return { found, active, uptodate, errors };
   }, [seriesStates]);
 

--- a/UI-source/src/hooks/useDownloader.js
+++ b/UI-source/src/hooks/useDownloader.js
@@ -7,6 +7,8 @@
 //   - A queue system: auto-advances ONE at a time (currentDownloadId = the
 //     serial "anchor"), but a queued item can be launched in PARALLEL with the
 //     anchor via startQueuedNow ("start alongside")
+//   - Persisting that queue across app close and replaying it on the next
+//     launch (grep QUEUE_PERSIST_LIMIT / queueHydratedRef)
 //   - Log lines from each download (flat array)
 //   - Resumable downloads found on disk (tmp_* folders)
 //   - App settings
@@ -14,13 +16,16 @@
 // STATE SHAPES (what each component expects):
 //   activeDownloads: { [downloadId]: { url, args, status, progress, logs, tmpDir? } }
 //   logs: [ { downloadId, line, level, timestamp }, ... ]
-//   queue: [ { id, type:"download"|"resume", url, displayUrl, queuedAt,
+//   queue: [ { id, type:"download"|"resume", url, displayUrl, queuedAt, restored?,
 //             args? (download) | tmpDir?/format?/epubLayout?/title?/cachedChapters? (resume) }, ... ]
 //   resumable: [ { hid, tmpDir, params, cachedChapters }, ... ]
 //   settings: { pythonCmd, scriptPath, workingDir, defaults, verboseAlways }
+//
+// `progress` also carries the main-process ETA fields (etaMs / chapterMsEma /
+// etaSamples) — see electron/downloader.js:applyChapterEta.
 // ============================================================
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { formatDuration } from "@/lib/utils";
 
 // DEFAULT_DOWNLOAD_DEFAULTS / mergeSettings / normalizeDownloadArgs were
@@ -76,6 +81,80 @@ function _activeEntryForQueueItem(item) {
     queuedAt: item.queuedAt,
     startedAt: Date.now(),
   };
+}
+
+// ── Queue persistence across app close ──
+// The queue is pure React state and dies with the renderer, so it's mirrored
+// to download_queue.json via the queue:get / queue:save IPC (storage + shape:
+// electron/history.js:saveQueueSnapshot). Restore behavior is RESTORE +
+// AUTO-START: whatever was queued comes back in order, and whatever was
+// RUNNING at close is re-inserted at the HEAD as a resume job.
+const QUEUE_PERSIST_LIMIT = 200;
+// Long enough to coalesce a burst of enqueues (queue-from-search fires several
+// setQueue calls in a row), short enough that a close right after a click has
+// already flushed. The confirm-quit dialog also buys dwell time whenever
+// something is actually running.
+const QUEUE_PERSIST_DEBOUNCE_MS = 300;
+
+// Rebuild the queue array from a saved snapshot. Module-level for the same
+// reason as _spawnQueueItem: no dep-array churn. `mintId` supplies fresh
+// `q<N>` ids from the caller's counter; `resumableList` is a FRESH
+// scanResumable (the mount effect awaits it first — the ordering is
+// load-bearing).
+//
+// A snapshot's `running` entries were mid-download when the app closed. They
+// come back as type:"resume" jobs at the HEAD of the restored queue, NOT as
+// fresh downloads: their tmp_<hid> folder holds the chapters that already
+// finished, and replaying them from scratch would redo that work. An entry
+// with no LIVE tmp folder is DROPPED, not resurrected — the user deleted it,
+// or the run never got far enough to write run_params.json.
+//
+// Queued items are restored VERBATIM (both types) — they never started, so
+// there's nothing on disk to validate them against.
+function _restoreQueueItems(snap, resumableList, mintId) {
+  const savedQueue = Array.isArray(snap?.queue) ? snap.queue : [];
+  const savedRunning = Array.isArray(snap?.running) ? snap.running : [];
+  const live = Array.isArray(resumableList) ? resumableList : [];
+
+  const revived = [];
+  for (const r of savedRunning) {
+    // hid is the tmp folder's own key; url is the fallback for a run that
+    // died before the "Title (hid=…)" line landed. main.js's scan-resumable
+    // handler back-fills BOTH fields from download history, so either can hit.
+    const match = live.find(
+      (x) => (r?.hid && x.hid === r.hid) || (r?.url && x.url === r.url)
+    );
+    if (!match) continue;
+    // Two processes writing one tmp_ folder corrupts the resume state — same
+    // invariant resumeDownload's dupInQueue/dupActive check protects.
+    if (revived.some((v) => v.tmpDir === match.tmpDir)) continue;
+    revived.push({
+      id: mintId(),
+      type: "resume",
+      url: r.url || match.url,
+      tmpDir: match.tmpDir,
+      // A running RESUME carries no args (see _activeEntryForQueueItem), so
+      // match.format — which scanResumable read out of run_meta.json — is the
+      // authoritative fallback. undefined is fine too: downloader.resume
+      // re-reads run_meta.json when no format is passed.
+      format: r.args?.format || match.format || undefined,
+      epubLayout: r.args?.epubLayout,
+      title: r.title || match.title || "",
+      cachedChapters: match.cachedChapters,
+      displayUrl: r.displayUrl || r.title || match.title || r.url || match.url,
+      queuedAt: Date.now(),
+      restored: true,
+    });
+  }
+
+  const queued = savedQueue
+    .filter((item) => item && item.id && (item.type === "resume" ? item.tmpDir : item.url))
+    .slice(0, QUEUE_PERSIST_LIMIT)
+    // `restored` is purely a UI marker — QueueTab badges it so the auto-start
+    // isn't mysterious. Nothing in the spawn path reads it.
+    .map((item) => ({ ...item, restored: true }));
+
+  return [...revived, ...queued];
 }
 
 export function useDownloader() {
@@ -175,6 +254,12 @@ export function useDownloader() {
   // collide. Refs are exempt from exhaustive-deps, so the useCallback closures
   // below mint ids inline via `q${++queueIdRef.current}`.
   const queueIdRef = useRef(0);
+  // Flips true once the saved snapshot has been read (whether or not it had
+  // anything in it). The persist effect below refuses to write until then —
+  // otherwise the initial EMPTY queue state would overwrite the saved file in
+  // the ~50ms before hydration lands, which is exactly the data we're trying
+  // to keep. grep QUEUE_PERSIST_DEBOUNCE_MS.
+  const queueHydratedRef = useRef(false);
   const currentIdRef = useRef(currentDownloadId);
   currentIdRef.current = currentDownloadId;
   // activeDownloadsRef gives the IPC complete-handler synchronous read access
@@ -230,7 +315,22 @@ export function useDownloader() {
     }
   }, []);
 
-  // ── Load settings + resumable list on mount ──
+  // ── Load settings + resumable list + the saved queue on mount ──
+  //
+  // ORDER MATTERS inside the async block: scanResumable must RESOLVE before
+  // the queue snapshot is applied. Restored `running` entries are
+  // reconstituted against that fresh list (see _restoreQueueItems), so running
+  // the two in parallel would race the liveness check and either drop a valid
+  // resume or revive a job whose tmp folder is gone.
+  //
+  // getSettings stays fire-and-forget alongside it — nothing here depends on
+  // it, and blocking the queue restore on a settings read would delay the
+  // auto-start for no reason.
+  //
+  // Deliberately references _startNextInQueue, which is defined further down:
+  // effect BODIES run after the whole component body, and it's a
+  // useCallback(…, []) so it never changes identity. Same arrangement as the
+  // IPC-subscription effect below, which also omits it from its deps.
   useEffect(() => {
     if (!hasAPI()) return;
 
@@ -238,9 +338,64 @@ export function useDownloader() {
       if (s) setSettings(s);
     });
 
-    window.electronAPI.scanResumable().then((r) => {
-      if (Array.isArray(r)) setResumable(r);
-    });
+    let cancelled = false;
+
+    (async () => {
+      let resumableList = [];
+      try {
+        const r = await window.electronAPI.scanResumable();
+        if (Array.isArray(r)) {
+          resumableList = r;
+          if (!cancelled) setResumable(r);
+        }
+      } catch (err) {
+        console.error("Failed to scan resumable downloads:", err);
+      }
+      if (cancelled) return;
+
+      let snap = null;
+      try {
+        snap = await window.electronAPI.getQueueSnapshot?.();
+      } catch (err) {
+        console.error("Failed to read the saved download queue:", err);
+      }
+      if (cancelled) return;
+
+      // Restored queue items KEEP their original q<N> ids (they're React keys
+      // and the stable handle removeFromQueue / startQueuedNow operate on), so
+      // reseed the counter past the highest one before minting anything new —
+      // otherwise a fresh enqueue would collide with a restored row and both
+      // would vanish on the first remove.
+      let maxId = queueIdRef.current;
+      for (const item of Array.isArray(snap?.queue) ? snap.queue : []) {
+        const n = Number(String(item?.id || "").replace(/^q/, ""));
+        if (Number.isFinite(n) && n > maxId) maxId = n;
+      }
+      queueIdRef.current = maxId;
+
+      const restored = _restoreQueueItems(
+        snap,
+        resumableList,
+        () => `q${++queueIdRef.current}`,
+      );
+
+      // Set BEFORE the early return so the persist effect is unblocked even
+      // when there was nothing to restore.
+      queueHydratedRef.current = true;
+      if (restored.length === 0) return;
+
+      setQueue(restored);
+      // Auto-start. The serial anchor is always free at mount, so this drains
+      // the head — the revived running job when the last session had one. The
+      // existing serial-anchor logic needs no change, and resumeDownload's
+      // tmpDir dedupe already blocks a double-spawn if the user also clicks
+      // Resume in the bar. Delayed so React has committed setQueue before
+      // _startNextInQueue reads queueRef (same reason the completion path
+      // waits 500ms).
+      setTimeout(() => _startNextInQueue(), 300);
+    })();
+
+    return () => { cancelled = true; };
   }, []);
 
   // ── Configurable: how often to flush buffered logs/progress to the UI ──
@@ -442,6 +597,60 @@ export function useDownloader() {
     return () => clearInterval(timer);
   }, [flushInterval]);
 
+  // ── Cheap signature of what's RUNNING ──
+  // "<downloadId>:<hid>" per running entry, sorted and joined. This is a
+  // persist TRIGGER, and it exists because activeDownloads itself is a fresh
+  // object ~10x/sec under the flush timer above — depending on it directly
+  // would turn every log line into a disk write. The signature only changes
+  // when a download starts, ends, or first reports its hid (the field the
+  // restore matches on), which is exactly when the snapshot is stale.
+  // Recomputing it per render is a handful of property reads over 1-3 entries.
+  const runningSignature = useMemo(() => {
+    const parts = [];
+    for (const [id, dl] of Object.entries(activeDownloads || {})) {
+      if (dl.status !== "running") continue;
+      parts.push(`${id}:${dl.progress?.hid || ""}`);
+    }
+    return parts.sort().join("|");
+  }, [activeDownloads]);
+
+  // ── Persist the queue + what's running (debounced) ──
+  // Read back on the next launch by the mount effect above. Reads the CURRENT
+  // activeDownloads through its ref rather than closing over the value, so the
+  // debounce window always writes the freshest state.
+  useEffect(() => {
+    if (!hasAPI() || !queueHydratedRef.current) return;
+    if (typeof window.electronAPI.saveQueueSnapshot !== "function") return;
+
+    const timer = setTimeout(() => {
+      const running = [];
+      for (const [id, dl] of Object.entries(activeDownloadsRef.current || {})) {
+        if (dl.status !== "running") continue;
+        running.push({
+          downloadId: id,
+          hid: dl.progress?.hid || null,
+          url: Array.isArray(dl.url) ? dl.url[0] : dl.url || null,
+          displayUrl: dl.displayUrl || null,
+          title: dl.progress?.title || null,
+          // tmpDir is only ever set on resume entries (_activeEntryForQueueItem),
+          // so it doubles as the type discriminator.
+          type: dl.tmpDir ? "resume" : "download",
+          tmpDir: dl.tmpDir || null,
+          args: dl.args || null,
+        });
+      }
+      window.electronAPI
+        .saveQueueSnapshot({
+          queue: queueRef.current.slice(0, QUEUE_PERSIST_LIMIT),
+          running,
+          savedAt: Date.now(),
+        })
+        .catch((err) => console.error("Failed to persist the download queue:", err));
+    }, QUEUE_PERSIST_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [queue, runningSignature]);
+
   // ── Internal: start the next item in the queue ──
   const _startNextInQueue = useCallback(async () => {
     const q = queueRef.current;
@@ -511,6 +720,17 @@ export function useDownloader() {
         // closes the asymmetry where Search honored the toggle but
         // multi-source-direct-URL downloads ignored it.
         ...(s?.searchOpts?.seededOnly ? { seededOnly: true } : {}),
+        // Global machine-translation policy. Injected HERE rather than at each
+        // callsite so search-initiated and library-update downloads honor it
+        // too, not just the New tab (which passes its own args.mtl and wins on
+        // the spread below). Skipped at "avoid" — that's the Python default,
+        // so omitting it keeps older saved settings producing identical spawns.
+        ...(s?.defaults?.mtl && s.defaults.mtl !== "avoid"
+          ? { mtl: s.defaults.mtl }
+          : {}),
+        ...(s?.defaults?.excludeGroup
+          ? { excludeGroup: s.defaults.excludeGroup }
+          : {}),
         // -1 sentinel = "match --image-workers"; the Python side resolves it.
         // Skip injecting if the value is explicitly -1 (the default) so the
         // CLI default also kicks in without a redundant flag in the spawn.

--- a/UI-source/src/lib/utils.js
+++ b/UI-source/src/lib/utils.js
@@ -26,6 +26,44 @@ export function formatDuration(ms) {
   return `${min}m ${sec % 60}s`;
 }
 
+// Numeric-aware string comparator ("Ch 2" before "Ch 10", not after "Ch 100").
+// A hoisted Intl.Collator, NOT per-call String.localeCompare: localeCompare
+// constructs a fresh collator on every invocation, which is measurable at a few
+// hundred library entries x sort. sensitivity:"base" also makes it
+// case/accent-insensitive, matching what a user expects from an A-Z picker.
+//
+// DO NOT use this on the ISO-8601 date sorts (LibraryTab's "date"/"date-asc"):
+// those already sort correctly as plain strings, and numeric:true would parse
+// the digit groups across the '-' and ':' separators and break them.
+//
+// Cross-file: electron/library.js carries a MIRROR TWIN of this const (CommonJS
+// there can't import from src/), same arrangement as electron/resource-limits.js
+// vs src/lib/resourceLimits.js. Grep naturalCompare if you touch either.
+export const naturalCompare = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+}).compare;
+
+// Coarse "time remaining" label for the live download ETA: "45s" / "3m" /
+// "1h 12m". Deliberately COARSER than formatDuration above — an estimate that
+// renders "12m 37s" implies a precision the per-chapter EMA doesn't have, and
+// the seconds digit would churn on every 100ms progress flush. Returns "" for
+// null/negative so callers can conditional-render.
+//
+// Sub-minute is the one place seconds appear, because "0m" would read as done.
+// Producer: electron/downloader.js stamps progress.etaMs per chapter tick;
+// consumer: QueueTab's active card. Grep etaMs.
+export function formatEta(ms) {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "";
+  const totalSec = Math.round(ms / 1000);
+  if (totalSec < 60) return `${Math.max(1, totalSec)}s`;
+  const totalMin = Math.round(totalSec / 60);
+  if (totalMin < 60) return `${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m ? `${h}h ${m}m` : `${h}h`;
+}
+
 // Collapse a list of chapter numbers into a compact human range string:
 // ["51","52","53","55","60"] → "51-53, 55, 60". Consecutive runs (gap ≤ 1.001,
 // so decimals like 60.1 join their neighbor) collapse to "start-end"; isolated

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -56,7 +56,13 @@ from aio_config import (
 )
 from sites import get_handler_by_name, get_handler_for_url
 from sites.chapter_merger import group_chapters_for_download, _extract_chapter_num
-from sites.base import SiteComicContext, IncompleteChapterError
+from sites.base import (
+    SiteComicContext,
+    IncompleteChapterError,
+    GroupSelectionPolicy,
+    build_group_census,
+)
+from sites.group_quality import MTL_CONFIRMED, classify_mtl
 from sites._image_io import (
     sniff_image_extension as _sniff_image_extension,
     finalize_pending_image as _finalize_pending_image,
@@ -871,6 +877,53 @@ def is_chapter_wanted(chapter_num_float: float, range_spec: str) -> bool:
         if parsed is not None and chapter_num_float == parsed:
             return True
     return False
+
+
+def _chapter_range_floor(range_spec: str) -> Optional[float]:
+    """Lowest chapter number a `--chapters` spec can possibly select, or None.
+
+    Feeds BaseSiteHandler.chapter_floor_hint (see the contract there): purely
+    an optimization hint letting a handler with expensive paginated listing
+    stop early. Returns None — meaning "no floor, list everything" — whenever
+    the answer isn't provably safe, so a wrong guess can never drop a chapter
+    the user asked for. That includes:
+
+      * "all" (the default),
+      * the negative "last N chapters" form (`--chapters -20`), whose floor
+        depends on the very list we haven't fetched yet,
+      * any spec with a part we can't parse a lower bound from (open-ended
+        `100-`, junk, an unrecognized alias).
+
+    The result is a FLOOR over the whole comma-separated spec, i.e. the minimum
+    across parts, so `--chapters 5,300-400` yields 5.0 and still lists
+    everything down to chapter 5.
+    """
+    text = (range_spec or "").strip()
+    if not text or text.lower() == "all":
+        return None
+    # "-20" (and only that form) means "last 20 chapters" to the caller.
+    if text.startswith("-") and "," not in text:
+        return None
+    lows: List[float] = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            return None
+        low: Optional[float] = None
+        if "-" in part:
+            raw_start, _, raw_end = part.partition("-")
+            start = _parse_chapter_spec_number(raw_start)
+            end = _parse_chapter_spec_number(raw_end)
+            # Both ends must parse; "chapter-1" style values aren't ranges and
+            # fall through to the single-number read below.
+            if start is not None and end is not None:
+                low = start
+        if low is None:
+            low = _parse_chapter_spec_number(part)
+        if low is None:
+            return None
+        lows.append(low)
+    return min(lows) if lows else None
 
 
 # -----------------------------------------------------------
@@ -1690,6 +1743,41 @@ def _try_download_url(
     return False, last_error, None
 
 
+def _log_url_for_page(url: str, limit: int = 160) -> str:
+    """Shorten a URL for a one-line log. A data: URI is megabytes of base64 —
+    print only its MIME segment."""
+    if not isinstance(url, str):
+        return ""
+    if url.startswith("data:"):
+        return "data:" + url[5:].split(",", 1)[0][:60]
+    return url if len(url) <= limit else url[:limit] + "…"
+
+
+def _finalize_downloaded_image(pending_pth, folder, base, content_type, name, url):
+    """`_finalize_pending_image` + the single verbose log line when the body is
+    a 200 that isn't an image (dead host serving an HTML error page under an
+    image URL — see sites/_image_io.py:looks_like_real_image).
+
+    Returns the final path, or None. A None is the normal "page failed"
+    signal; callers with variants left MUST fall through to them rather than
+    give up, because a mirror URL may serve the real bytes.
+
+    Deliberately does NOT call `_record_failure` / `_record_host_failure_for_backoff`:
+    the host answered 200 and is healthy, so this is a content problem, and
+    feeding it to the Phase-D AIMD concurrency cap would throttle a CDN that
+    is doing nothing wrong (grep _HOST_CONCURRENCY_CAP)."""
+    reasons = []
+    final = _finalize_pending_image(
+        pending_pth, folder, base, content_type, on_reject=reasons.append
+    )
+    if final is None and reasons:
+        log_verbose(
+            f"  Rejected page {os.path.basename(base)}: {reasons[0]} "
+            f"— {_log_url_for_page(url)}"
+        )
+    return final
+
+
 def dl_image(url: str, folder: str, name: str, scraper, cleanup: bool = True) -> str:
     """
     Downloads an image using a sophisticated fallback chain with parallel attempts.
@@ -1759,7 +1847,8 @@ def dl_image(url: str, folder: str, name: str, scraper, cleanup: bool = True) ->
         ct = header[5:].split(";", 1)[0].strip() if header.startswith("data:") else ""
         with open(pending_pth, "wb") as fh:
             fh.write(data)
-        return _finalize_pending_image(pending_pth, folder, base, ct)
+        # No fallback exists for an inline body — a rejection is terminal.
+        return _finalize_downloaded_image(pending_pth, folder, base, ct, name, url)
 
     # Browser-byte-capture cache check (sites/image_cache). Some site
     # handlers (comix.to) capture image response bodies via Patchright's
@@ -1789,7 +1878,11 @@ def dl_image(url: str, folder: str, name: str, scraper, cleanup: bool = True) ->
                 f"(browser-capture cache hit, {len(_body)} bytes, "
                 f"content_type={_ct or 'unknown'})"
             )
-            return _finalize_pending_image(pending_pth, folder, base, _ct)
+            # The browser captured these bytes off the wire; there is no URL
+            # variant to retry, so a rejection is terminal.
+            return _finalize_downloaded_image(
+                pending_pth, folder, base, _ct, name, url
+            )
         except Exception as _e:
             log_verbose(
                 f"  Cache write failed for {os.path.basename(name)} "
@@ -1815,8 +1908,21 @@ def dl_image(url: str, folder: str, name: str, scraper, cleanup: bool = True) ->
         url, pending_pth, name, scraper, max_retries, retry_delay, timeout
     )
     if success:
-        log_debug(f"  Successfully downloaded {os.path.basename(name)} using first variant.")
-        return _finalize_pending_image(pending_pth, folder, base, content_type)
+        _final = _finalize_downloaded_image(
+            pending_pth, folder, base, content_type, name, url
+        )
+        if _final is not None:
+            # Logged AFTER validation, not on the 200 — a dead host answering
+            # with an HTML error page is an HTTP success and would otherwise
+            # print "Successfully downloaded" immediately above "Rejected page".
+            log_debug(f"  Successfully downloaded {os.path.basename(name)} using first variant.")
+            return _final
+        # HTTP said 200 but the body was not an image (dead host answering with
+        # an HTML error page). Do NOT return — fall through to the variant
+        # cascade below; a `-m`/other-extension mirror may serve real bytes.
+        # `first_error` is already None here (_try_download_url returns
+        # (True, None, ct) on success), so the sequential-vs-parallel choice
+        # below correctly treats this as "no throttling seen".
 
     # After the first attempt, re-check fast-fail conditions before generating
     # variants. If we just hit the poison threshold or watchdog, abort the
@@ -1891,11 +1997,18 @@ def dl_image(url: str, folder: str, name: str, scraper, cleanup: bool = True) ->
                 timeout,
             )
             if success:
+                _final = _finalize_downloaded_image(
+                    pending_pth, folder, base, alt_content_type, name, alt_url
+                )
+                if _final is None:
+                    # 200 with a non-image body — keep walking the variants
+                    # instead of failing the page on one bad mirror.
+                    continue
                 log_verbose(
                     f"  Successfully downloaded {os.path.basename(name)} via sequential fallback variant: {os.path.basename(alt_url)}"
                 )
                 print(f"  [Fallback] {os.path.basename(name)}: succeeded with variant {os.path.basename(alt_url)}")
-                return _finalize_pending_image(pending_pth, folder, base, alt_content_type)
+                return _final
 
         print(
             f"  Error: Skipping image {os.path.basename(name)} after throttled sequential retries across {len(unique_urls_to_try)} variants."
@@ -2035,21 +2148,20 @@ def dl_image(url: str, folder: str, name: str, scraper, cleanup: bool = True) ->
     if successful_temp_file[0]:
         temp_path, successful_url, parallel_ct = successful_temp_file[0]
         try:
-            # Sniff the winning temp file and pick its real extension. Then
-            # atomic-rename into <folder>/<base><ext>. Same-folder rename is
-            # atomic on POSIX and NT, so the file appears at its final path
-            # with correct extension in one step.
-            try:
-                with open(temp_path, "rb") as fh:
-                    head = fh.read(32)
-            except Exception:
-                head = b""
-            ext = _sniff_image_extension(head, parallel_ct)
-            final_pth = os.path.join(folder, base + ext)
-            shutil.move(temp_path, final_pth)
-            log_verbose(f"  Successfully downloaded {os.path.basename(name)} using variant: {os.path.basename(successful_url)}")
-            print(f"  [Fallback] {os.path.basename(name)}: succeeded with variant {os.path.basename(successful_url)}")
-            return final_pth
+            # Validate + sniff the winning temp file, then atomic-rename into
+            # <folder>/<base><ext>. mkstemp put temp_path in `folder`, so this
+            # is a same-folder rename — atomic on POSIX and NT, and os.replace
+            # (inside the helper) is overwrite-safe where shutil.move was not.
+            final_pth = _finalize_downloaded_image(
+                temp_path, folder, base, parallel_ct, name, successful_url
+            )
+            if final_pth is not None:
+                log_verbose(f"  Successfully downloaded {os.path.basename(name)} using variant: {os.path.basename(successful_url)}")
+                print(f"  [Fallback] {os.path.basename(name)}: succeeded with variant {os.path.basename(successful_url)}")
+                return final_pth
+            # Winner's body was not an image (the helper already deleted the
+            # tempfile). Every variant is exhausted at this point, so fall
+            # through to the all-attempts-failed return below.
         except Exception as e:
             print(f"  Error: Failed to move temp file: {e}")
             # Clean up the temp file if move failed
@@ -5231,6 +5343,67 @@ def rm_tree(path):
 
 
 # ──────────────────────────────────────────────────────────────────
+# Scanlation-group / chapter-version selection
+#
+# The per-chapter ranking itself lives in sites/base.py
+# (select_best_chapter_version + _rank_version). These two helpers turn CLI
+# args into the run-level policy that ranking needs, and are the only place
+# aio-dl.py reasons about groups directly.
+# ──────────────────────────────────────────────────────────────────
+def _build_group_selection_policy(handler, chapters_by_num, args):
+    """Assemble the per-series GroupSelectionPolicy.
+
+    Called ONCE per series, right after the chapter pool has been bucketed by
+    chapter number and before any version is selected — that is the only point
+    where the whole series is visible, and the census (how many chapters each
+    group actually supplies) cannot be computed from a single bucket.
+
+    Runtime-only: nothing here is persisted or hashed. The --mtl /
+    --exclude-group ARGS are resume-gating (grep _RESUME_GATING_DESTS), but the
+    derived census is rebuilt from the live chapter list every run.
+    """
+    census, census_total = build_group_census(handler, chapters_by_num)
+    excluded_keys = frozenset(
+        key for key in (
+            handler.get_group_match_key(name)
+            for name in (getattr(args, "exclude_group", None) or [])
+        ) if key
+    )
+    policy = GroupSelectionPolicy(
+        census=census or None,
+        census_total=census_total,
+        mtl=getattr(args, "mtl", "avoid") or "avoid",
+        excluded_keys=excluded_keys,
+    )
+    if census:
+        top = sorted(census.items(), key=lambda kv: -kv[1])[:5]
+        log_verbose(
+            "  Group census ({} distinct chapters): {}".format(
+                census_total,
+                ", ".join(f"{k}={v}" for k, v in top) or "none",
+            )
+        )
+    return policy
+
+
+def _version_is_confirmed_mtl(handler, version):
+    """True when EVERY credited group on a version is confirmed machine TL.
+
+    Deliberately stricter than the ranker's own folding rule (which takes the
+    best verdict across co-credited groups): this only drives the user-facing
+    "skipped under --mtl exclude" tally, and over-reporting a skip is worse
+    than under-reporting it.
+    """
+    infos = handler.get_group_infos(version)
+    if not infos:
+        return False
+    return all(
+        classify_mtl(info.name, description=info.description)[0] == MTL_CONFIRMED
+        for info in infos
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
 # Resume parameter persistence
 # ──────────────────────────────────────────────────────────────────
 # Single source of truth for what gets written to tmp_<hid>/run_params.json
@@ -5272,6 +5445,11 @@ _RESUME_GATING_DESTS = frozenset({
     "width", "aspect_ratio",
     "quality", "scaling", "chapters", "group",
     "mix_by_upvote", "no_group_fallback", "no_partials",
+    # Group/version selection: these decide WHICH version's image bytes land
+    # on disk, so a mid-run change must invalidate them. Without gating, a run
+    # started under --mtl allow and resumed under --mtl exclude would stitch a
+    # half-machine-translated volume.
+    "mtl", "exclude_group",
     "download_volumes", "collapse_splits", "no_processing",
     # Phase 1 (2026-05-11): LINE Webtoon WebP recompression. Changing any
     # of these between runs invalidates the on-disk images because the
@@ -5381,6 +5559,8 @@ def _save_download_params(out_dir: str, url: str, args, title: str) -> None:
         "scaling": getattr(args, "scaling", 100),
         "cookies": getattr(args, "cookies", "") or "",
         "group": getattr(args, "group", []) or [],
+        "exclude_group": getattr(args, "exclude_group", []) or [],
+        "mtl": getattr(args, "mtl", "avoid"),
         "split": getattr(args, "split", None),
         "mix_by_upvote": bool(getattr(args, "mix_by_upvote", False)),
         "no_group_fallback": bool(getattr(args, "no_group_fallback", False)),
@@ -5577,6 +5757,17 @@ def _append_saved_update_options(child_cmd: List[str], params: Dict[str, Any]) -
         groups = [groups]
     for group in groups:
         child_cmd.extend(["--group", str(group)])
+    # Same shape as --group. Without replaying these, an --update-all child
+    # reverts to the defaults and the series slowly accumulates chapters from
+    # groups the user explicitly rejected (the S4-2 bug class).
+    excluded = params.get("exclude_group") or []
+    if isinstance(excluded, str):
+        excluded = [excluded]
+    for group in excluded:
+        child_cmd.extend(["--exclude-group", str(group)])
+    mtl_policy = params.get("mtl")
+    if mtl_policy and mtl_policy != "avoid":
+        child_cmd.extend(["--mtl", str(mtl_policy)])
     if params.get("split"):
         child_cmd.extend(["--split", str(params["split"])])
     for key, flag in (
@@ -7675,13 +7866,39 @@ def main():
     p.add_argument(
         "--mix-by-upvote",
         action="store_true",
-        help="When multiple --group args are used, ignore priority and pick the "
-        "version with the most upvotes from any of the specified groups.",
+        help="When multiple --group args are used, ignore priority order and "
+        "rank across the union of the specified groups instead. (Upvotes are "
+        "now only a weak tiebreak inside that ranking — most sites report no "
+        "vote count at all — so this is 'best of my groups' rather than "
+        "'most upvoted'. Flag name kept for back-compat.)",
     )
     p.add_argument(
         "--no-group-fallback",
         action="store_true",
         help="When --group is set, skip chapters missing all preferred groups instead of falling back to another group.",
+    )
+    p.add_argument(
+        "--mtl",
+        choices=("avoid", "allow", "exclude"),
+        default="avoid",
+        help="How to treat machine-translated (MTL) chapter versions, detected "
+        "from the scanlation group's name and self-description (grep "
+        "sites/group_quality.py). 'avoid' (default) ranks them below every "
+        "human translation but still downloads one when it is the ONLY "
+        "version of that chapter — you never silently lose a chapter. "
+        "'allow' ignores the signal entirely. 'exclude' skips a chapter whose "
+        "every version is confirmed MTL (heuristic 'suspect' matches are never "
+        "excluded, only demoted). To force a specific group regardless of this "
+        "setting, name it in --group.",
+    )
+    p.add_argument(
+        "--exclude-group",
+        nargs="+",
+        default=[],
+        help="Scanlation groups to avoid. Same input shape as --group (repeat "
+        "the flag or pass one comma-separated string). Excluded versions rank "
+        "below everything else but are still used when no alternative exists; "
+        "add --no-group-fallback to skip those chapters instead.",
     )
     p.add_argument(
         "--no-partials",
@@ -8782,13 +8999,20 @@ def main():
     if not handler:
         sys.exit("Unable to resolve site handler. Use --site to specify explicitly.")
 
-    # Process the group argument to handle comma-separated strings
+    # Process the group arguments to handle comma-separated strings
     if args.group:
         # Flatten the list of strings, splitting each by comma, and stripping whitespace.
         args.group = [
             g.strip()
             for group_string in args.group
             for g in group_string.split(",")
+        ]
+    if getattr(args, "exclude_group", None):
+        args.exclude_group = [
+            g.strip()
+            for group_string in args.exclude_group
+            for g in group_string.split(",")
+            if g.strip()
         ]
 
     global _VERBOSE, _DEBUG
@@ -9083,12 +9307,32 @@ def main():
         safe_group = sanitize_filename(" ".join(args.group))
         base_filename = join_name(base_filename, safe_group)
 
+    # Advisory early-stop hint for handlers with expensive paginated chapter
+    # listing (comix's browser DOM scrape walks up to ~360 pager pages on a
+    # long multi-group series). Set on the INSTANCE just before the call; see
+    # BaseSiteHandler.chapter_floor_hint for the contract. None whenever the
+    # floor isn't provably safe, so this can never drop a wanted chapter — the
+    # real --chapters filter still runs over the returned pool below either way.
+    chapter_floor = _chapter_range_floor(getattr(args, "chapters", "all"))
+    try:
+        handler.chapter_floor_hint = chapter_floor
+    except Exception:
+        # Handlers are plain objects, but never let a hint break the run.
+        chapter_floor = None
+
     if getattr(args, "download_volumes", False):
         pool = handler.get_volumes(context, scraper, args.language, make_request)
         if not pool:
             sys.exit("This site handler does not expose volume listing.")
     else:
         pool = handler.get_chapters(context, scraper, args.language, make_request)
+
+    # A floored listing is a PARTIAL view of the series by design, so the
+    # "how many chapters existed at download time" stat below must not report
+    # it as the total. Volumes never take the hint.
+    pool_is_partial = bool(chapter_floor is not None) and not getattr(
+        args, "download_volumes", False
+    )
 
     # ── Direct-URL multi-source: find alternatives for fallback ──
     # When --multi-source is set and we got here via a direct URL (not via
@@ -9304,7 +9548,7 @@ def main():
         # handlers that emit 4.0 (mangathemesia subclasses) don't split
         # from "4"-emitting peers; we mirror that here so the dedupe and
         # the optional collapse pass see the same canonical keys.
-        seen_nums = set()
+        list_chapters_by_num: Dict[str, List[Dict[str, Any]]] = {}
         deduped_pool: List[Dict[str, Any]] = []
         # Premium/locked placeholders (tapas.get_chapters emits them for
         # WAIT_OR_MUST_PAY episodes) are surfaced SEPARATELY as locked_chapters
@@ -9351,13 +9595,29 @@ def main():
             # ALL non-numeric labels. Residual follow-up.
             if _chap_as_float(num) is None:
                 continue
-            if num in seen_nums:
-                continue
-            seen_nums.add(num)
             # Carry the dict shape (group_chapters_for_download needs it) but
             # with the normalized label injected so its `_extract_chapter_num`
             # parse and our diff target both see the same string.
-            deduped_pool.append({**ch, "chap": num})
+            list_chapters_by_num.setdefault(num, []).append({**ch, "chap": num})
+
+        # Collapse each number to ONE version with the SAME selector the
+        # download path uses. This used to be a plain first-wins `seen_nums`
+        # dedupe, which diverged from the download in two ways: it ignored
+        # --group entirely, and under --no-group-fallback it would LIST a
+        # chapter the download then skipped (a permanent "+1 new" in the UI).
+        # The winner choice never changes which NUMBERS exist, so the UI's
+        # update diff is unaffected — only the per-chapter group metadata below.
+        _list_policy = _build_group_selection_policy(handler, list_chapters_by_num, args)
+        for num in sorted(list_chapters_by_num.keys(), key=float):
+            best = handler.select_best_chapter_version(
+                list_chapters_by_num[num],
+                args.group,
+                args.mix_by_upvote,
+                allow_group_fallback=not getattr(args, "no_group_fallback", False),
+                selection_policy=_list_policy,
+            )
+            if best:
+                deduped_pool.append(best)
 
         collapse_splits_enabled = bool(getattr(args, "collapse_splits", False))
         if collapse_splits_enabled:
@@ -9385,6 +9645,60 @@ def main():
 
         locked_chapters = sorted(set(locked_labels), key=lambda x: float(x))
 
+        # Scanlation groups available for this series, most-prolific first, so
+        # the UI can show what exists and let the user pick instead of typing a
+        # name blind. Purely additive — the UI ignores unknown keys, and none of
+        # this participates in the "+N new" diff.
+        group_rows: List[Dict[str, Any]] = []
+        _group_display: Dict[str, str] = {}
+        _group_flags: Dict[str, Dict[str, Any]] = {}
+        for _versions in list_chapters_by_num.values():
+            for _v in _versions:
+                for _info in handler.get_group_infos(_v):
+                    _key = handler.get_group_match_key(_info.name)
+                    if not _key:
+                        continue
+                    _group_display.setdefault(_key, _info.name)
+                    _flags = _group_flags.setdefault(
+                        _key, {"is_official": False, "mtl": "none"}
+                    )
+                    _flags["is_official"] = _flags["is_official"] or _info.is_official
+                    if _flags["mtl"] == "none":
+                        _verdict, _ = classify_mtl(
+                            _info.name, description=_info.description
+                        )
+                        _flags["mtl"] = _verdict
+        # Which chapter numbers each group does NOT cover — the one thing a
+        # user actually needs before picking one ("if I force Dusk, what do I
+        # lose?"). Deliberately NOT a full per-chapter group map: on a site
+        # where every chapter has 3-4 competing versions (atsumaru: 201
+        # chapters x 4 groups) that map is a second copy of the chapter list,
+        # and the UI runs --list-chapters for EVERY library series on an
+        # update check. This inverted form is near-empty in the common case.
+        _covered: Dict[str, set] = {}
+        for _num, _versions in list_chapters_by_num.items():
+            for _v in _versions:
+                for _info in handler.get_group_infos(_v):
+                    _k = handler.get_group_match_key(_info.name)
+                    if _k:
+                        _covered.setdefault(_k, set()).add(_num)
+        _all_nums = set(list_chapters_by_num.keys())
+        for _key, _count in sorted(
+            (_list_policy.census or {}).items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            _missing = sorted(_all_nums - _covered.get(_key, set()), key=float)
+            group_rows.append({
+                "name": _group_display.get(_key, _key),
+                "key": _key,
+                "chapters": _count,
+                "is_official": _group_flags.get(_key, {}).get("is_official", False),
+                "mtl": _group_flags.get(_key, {}).get("mtl", "none"),
+                "missing_count": len(_missing),
+                # Capped: a group covering 3 of 800 chapters would otherwise
+                # inline the other 797.
+                "missing_sample": _missing[:50],
+            })
+
         result = {
             "hid": hid,
             "title": title,
@@ -9401,6 +9715,7 @@ def main():
             # or the "+N new" diff — see the locked_labels comment above.
             "locked_chapters": locked_chapters,
             "collapse_applied": collapse_splits_enabled,
+            "groups": group_rows,
         }
         print(json.dumps(result))
         sys.exit(0)
@@ -9568,7 +9883,9 @@ def main():
             continue
 
     # 2. For each chapter number, select the best version
+    selection_policy = _build_group_selection_policy(handler, chapters_by_num, args)
     best_chapters = []
+    skipped_mtl_labels: List[str] = []
     sorted_chap_nums = sorted(chapters_by_num.keys(), key=float)
     for num in sorted_chap_nums:
         versions = chapters_by_num[num]
@@ -9578,9 +9895,28 @@ def main():
             args.mix_by_upvote,
             allow_group_fallback=not getattr(args, "no_group_fallback", False),
             log_debug_fn=log_debug,
+            selection_policy=selection_policy,
         )
         if best_version:
             best_chapters.append(best_version)
+        elif selection_policy.mtl == "exclude" and len(versions) > 0:
+            # Distinguish an MTL-policy skip from a --no-group-fallback skip so
+            # the count below can't over-report. A chapter is only attributed to
+            # the MTL policy when every version was confirmed machine-translated.
+            if all(
+                _version_is_confirmed_mtl(handler, v) for v in versions
+            ):
+                skipped_mtl_labels.append(num)
+    if skipped_mtl_labels:
+        # Counted + aggregated, never a silent drop. Mirrors the
+        # "N premium/locked chapter(s) skipped" notice below.
+        preview = ", ".join(skipped_mtl_labels[:8])
+        more = f" (+{len(skipped_mtl_labels) - 8} more)" if len(skipped_mtl_labels) > 8 else ""
+        print(
+            f"[i] {len(skipped_mtl_labels)} chapter(s) skipped — every available "
+            f"version is machine-translated and --mtl exclude is set: "
+            f"{preview}{more}. Use --mtl avoid to take them anyway."
+        )
 
     # 3. Apply filters to the final list
     chapters = best_chapters
@@ -10194,7 +10530,16 @@ def main():
                     )
                     rm_tree(tdir)
 
-            print(f"\nChapter {n} ({grp_name or 'No Group'})")
+            # Group credit + (when more than one version existed) the tier that
+            # actually decided the pick. `_group_selection` is written by
+            # base.select_best_chapter_version; grep it there for the tuple.
+            _gsel = ch.get("_group_selection") or {}
+            _why = _gsel.get("why")
+            _avail = _gsel.get("available") or ""
+            _sel_note = ""
+            if _why and _avail and "," in _avail:
+                _sel_note = f" — chosen on {_why} from: {_avail}"
+            print(f"\nChapter {n} ({grp_name or 'No Group'}){_sel_note}")
             _t0_imageurls = time.monotonic()
             # Phase 8 (2026-05-08): split-cluster collapse — when this chapter
             # was synthesized by group_chapters_for_download from multiple
@@ -12428,7 +12773,12 @@ def main():
             # update-check (main.js:_checkSeriesUpdates). Empty for single-source
             # / lazy / collapse-off series. grep chapters_skipped_fragments.
             "chapters_skipped_fragments": merged_skipped,
-            "total_available_at_download": len(pool),
+            # None when the chapter listing was deliberately cut short by
+            # chapter_floor_hint (grep pool_is_partial): reporting a floored
+            # pool as the series total would be a lie, and "unknown" is the
+            # honest answer. Nothing reads this field today; keep it truthful
+            # anyway so anything that starts to can trust it.
+            "total_available_at_download": None if pool_is_partial else len(pool),
             "last_downloaded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             # --- AniList enrichment fields (--metadata-source=anilist) ---
             # Populated when enrichment matched a series confidently;
@@ -12575,4 +12925,21 @@ if __name__ == "__main__":
         raise
     except Exception as e:
         _hb("error", str(e))
+        # comix's WAF / truncated-scrape failures are USER-actionable, not
+        # bugs: the message already carries the remediation, and a traceback
+        # buries it in noise the user can do nothing with. Everything else
+        # still re-raises with the full traceback. Imported lazily so a
+        # renamed/missing handler can never break the CLI's own error path.
+        # Cross-file: sites/comix.py (grep ComixWafChallengeError).
+        try:
+            from sites.comix import (
+                ComixChapterScrapeError,
+                ComixWafChallengeError,
+            )
+            _actionable = (ComixWafChallengeError, ComixChapterScrapeError)
+        except Exception:
+            _actionable = ()
+        if _actionable and isinstance(e, _actionable):
+            print(f"\n[!] {e}", file=sys.stderr, flush=True)
+            sys.exit(2)
         raise

--- a/sites/_image_io.py
+++ b/sites/_image_io.py
@@ -6,9 +6,10 @@ What this module owns:
   - Content-Type fallback when magic is ambiguous.
   - Header-only pixel-dimension sniffing (`sniff_image_dimensions`) + a
     `looks_like_real_image()` validity predicate that rescues legitimately tiny
-    images from the download/probe byte-size gate (see that function's docstring).
-  - `finalize_pending_image()`: atomic-rename a `.pending_<base>` tempfile to
-    `<folder>/<base><ext>` once bytes have landed.
+    images from the download/probe byte-size gate (see that function's docstring)
+    while rejecting HTML/JSON error documents served under an image URL.
+  - `finalize_pending_image()`: validate + atomic-rename a `.pending_<base>`
+    tempfile to `<folder>/<base><ext>` once bytes have landed.
 
 What reads from it:
   - `aio-dl.py:dl_image` (the main download path) — uses both helpers.
@@ -56,32 +57,50 @@ def content_type_to_ext(content_type: str) -> Optional[str]:
     }.get((content_type or "").strip().lower())
 
 
+def image_magic_extension(head: bytes) -> Optional[str]:
+    """Extension implied by `head`'s magic bytes, or None when no known raster
+    signature matches.
+
+    Split out of `sniff_image_extension` so callers can ask "are these bytes
+    RECOGNIZABLY an image?" — `sniff_image_extension` always returns something
+    (`.jpg` fallback) and therefore can never answer that question. Both share
+    this one magic table; `sniff_image_extension`'s return contract is
+    unchanged. Cross-file: `looks_like_real_image` below is the only consumer
+    in-tree (grep image_magic_extension)."""
+    if not head:
+        return None
+    if head.startswith(JPEG_MAGIC):
+        return ".jpg"
+    if head.startswith(PNG_MAGIC):
+        return ".png"
+    if head.startswith(GIF_MAGIC):
+        return ".gif"
+    # WebP: bytes 0-3 = 'RIFF', bytes 8-11 = 'WEBP'.
+    if len(head) >= 12 and head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return ".webp"
+    # AVIF/HEIC: ISO-BMFF "ftyp" box. Major brand at offset 8-11 tells
+    # us the codec family. We only special-case AVIF; HEIC is rare in
+    # manga aggregators but recognized so we don't accidentally label
+    # it `.jpg`.
+    if len(head) >= 12 and head[4:8] == b"ftyp":
+        major = head[8:12]
+        if major in (b"avif", b"avis"):
+            return ".avif"
+        if major in (b"heic", b"heix", b"mif1", b"msf1"):
+            return ".heic"
+    return None
+
+
 def sniff_image_extension(head: bytes, content_type: Optional[str] = None) -> str:
     """Return the most accurate file extension (with leading dot) for an image
     given its first ≥12 bytes and an optional Content-Type. Magic bytes are
     primary; Content-Type is consulted only when magic is ambiguous. Falls
     back to `.jpg` so callers always get a usable extension (matches prior
-    blanket-`.jpg` behavior for unknown content)."""
-    if head:
-        if head.startswith(JPEG_MAGIC):
-            return ".jpg"
-        if head.startswith(PNG_MAGIC):
-            return ".png"
-        if head.startswith(GIF_MAGIC):
-            return ".gif"
-        # WebP: bytes 0-3 = 'RIFF', bytes 8-11 = 'WEBP'.
-        if len(head) >= 12 and head[:4] == b"RIFF" and head[8:12] == b"WEBP":
-            return ".webp"
-        # AVIF/HEIC: ISO-BMFF "ftyp" box. Major brand at offset 8-11 tells
-        # us the codec family. We only special-case AVIF; HEIC is rare in
-        # manga aggregators but recognized so we don't accidentally label
-        # it `.jpg`.
-        if len(head) >= 12 and head[4:8] == b"ftyp":
-            major = head[8:12]
-            if major in (b"avif", b"avis"):
-                return ".avif"
-            if major in (b"heic", b"heix", b"mif1", b"msf1"):
-                return ".heic"
+    blanket-`.jpg` behavior for unknown content) — which is exactly why it must
+    NOT be used as a validity test; use `looks_like_real_image` for that."""
+    magic = image_magic_extension(head)
+    if magic:
+        return magic
     fallback = content_type_to_ext(
         (content_type or "").split(";", 1)[0]
     )
@@ -189,25 +208,116 @@ def _sniff_jpeg_dimensions(head: bytes) -> Optional[Tuple[int, int]]:
     return None
 
 
-def looks_like_real_image(data: bytes, min_bytes: int = _MIN_IMAGE_BYTES) -> bool:
+# Prefixes that mark a body as a text document rather than a raster image. No
+# raster signature starts with any of these (JPEG=0xFFD8, PNG=0x89, GIF='G',
+# RIFF='R', BMP='B', ISO-BMFF has 'ftyp' at offset 4), so matching one is a
+# zero-false-positive reject — which is what makes the size-independent
+# rejection below safe.
+_MARKUP_PREFIXES = (
+    b"<!doctype", b"<html", b"<head", b"<body", b"<?xml", b"{", b"[",
+)
+_ASCII_SPACE = b" \t\r\n\f\v"
+
+# Bare Content-Types that promise a text document. A body carrying one of these
+# AND no recognizable image bytes is junk regardless of size.
+_NON_IMAGE_CONTENT_TYPES = frozenset({
+    "application/json",
+    "application/xml",
+    "application/xhtml+xml",
+})
+
+
+def _looks_like_markup(head: bytes) -> bool:
+    """Do these leading bytes open an HTML/XML/JSON document? Byte-oriented on
+    purpose — a `.decode()` here would raise on real image bytes."""
+    if not head:
+        return False
+    probe = head.lstrip(_ASCII_SPACE)
+    # A BOM can precede the first tag. UTF-16 additionally interleaves NULs
+    # between ASCII characters, so drop those before prefix-matching.
+    for bom, utf16 in ((b"\xef\xbb\xbf", False), (b"\xff\xfe", True), (b"\xfe\xff", True)):
+        if probe.startswith(bom):
+            probe = probe[len(bom):]
+            if utf16:
+                probe = probe.replace(b"\x00", b"")
+            probe = probe.lstrip(_ASCII_SPACE)
+            break
+    return probe[:16].lower().startswith(_MARKUP_PREFIXES)
+
+
+def _is_non_image_content_type(content_type: Optional[str]) -> bool:
+    bare = (content_type or "").split(";", 1)[0].strip().lower()
+    if not bare:
+        return False
+    return bare.startswith("text/") or bare in _NON_IMAGE_CONTENT_TYPES
+
+
+def _head_rejects_image(
+    head: bytes, size: int, content_type: Optional[str] = None
+) -> Optional[str]:
+    """Head-only rejection shared by `looks_like_real_image` (whole body in
+    memory) and `finalize_pending_image` (body on disk, only the head read).
+    Returns a short reason, or None when the head gives no grounds to reject —
+    the caller still applies its own size/dimension rules."""
+    if size <= 0:
+        return "empty body"
+    if _looks_like_markup(head):
+        return "markup"
+    if _is_non_image_content_type(content_type):
+        if image_magic_extension(head) is None and sniff_image_dimensions(head) is None:
+            return "declared non-image"
+    return None
+
+
+def describe_invalid_image(
+    head: bytes, content_type: Optional[str] = None, size: int = 0
+) -> str:
+    """One-line human reason for a rejected body, naming the Content-Type and
+    byte size. Used verbatim in aio-dl.py:dl_image's per-page verbose log (grep
+    "Rejected page")."""
+    bare = (content_type or "").split(";", 1)[0].strip().lower()
+    if bare:
+        return f"server returned {bare} ({size} bytes), not an image"
+    if _looks_like_markup(head):
+        return f"server returned an HTML/JSON document ({size} bytes), not an image"
+    return f"body is not a recognized image ({size} bytes)"
+
+
+def looks_like_real_image(
+    data: bytes,
+    min_bytes: int = _MIN_IMAGE_BYTES,
+    content_type: Optional[str] = None,
+) -> bool:
     """Does `data` look like a real, downloadable image, as opposed to a CDN
     error stub, an HTML/JSON error body, or a 1x1 tracking pixel?
 
-    Policy:
+    `content_type` is optional and third so every existing positional caller
+    (`looks_like_real_image(body)`, `(body, 512)`) is unaffected — grep
+    looks_like_real_image across sites/base.py.
+
+    Policy, in order:
       - Empty -> False.
+      - Opens like HTML/XML/JSON -> False REGARDLESS OF SIZE. A dead host can
+        answer 200 + `Content-Type: text/html` + a 19 KB error page for an
+        image URL (manhuaplus' retired `*.files.wordpress.com` pages), and the
+        old size-only fast-accept below waved those straight into the CBZ as
+        `0001.jpg`.
+      - Declared text/* or JSON/XML AND no recognizable image bytes -> False.
       - len >= min_bytes -> True. Preserves the historical `len(body) >= 256`
         accept threshold verbatim, so nothing that used to download is newly
         rejected (no regression on large/unusual formats we don't dimension-parse,
-        e.g. AVIF/HEIC).
+        e.g. AVIF/HEIC/JXL).
       - len < min_bytes -> True ONLY if the bytes decode (by header) to a
         recognized image larger than a single pixel. This rescues legitimately
         tiny images (divider bars, thin spacers) while still rejecting sub-256-byte
-        junk: HTML/JSON stubs and truncated bodies fail the format sniff, and 1x1
-        tracking pixels fail the area check.
+        junk: truncated bodies fail the format sniff and 1x1 tracking pixels fail
+        the area check.
 
-    See bench/webtoonCanvasShelterLogs.md for the run this fixes.
+    See bench/webtoonCanvasShelterLogs.md for the tiny-divider run this rescues.
     """
     if not data:
+        return False
+    if _head_rejects_image(data[:64], len(data), content_type) is not None:
         return False
     if len(data) >= min_bytes:
         return True
@@ -219,21 +329,75 @@ def looks_like_real_image(data: bytes, min_bytes: int = _MIN_IMAGE_BYTES) -> boo
 
 
 def finalize_pending_image(
-    pending_path: str, folder: str, base: str, content_type: Optional[str]
+    pending_path: str,
+    folder: str,
+    base: str,
+    content_type: Optional[str],
+    *,
+    validate: bool = True,
+    on_reject=None,
 ) -> Optional[str]:
-    """Sniff a successfully-downloaded pending file's first bytes, atomic-
-    rename it to `<folder>/<base><ext>`, and return the final path. Returns
-    None if the pending file is missing (caller should treat as failure).
+    """Validate a successfully-downloaded pending file, sniff its first bytes,
+    atomic-rename it to `<folder>/<base><ext>`, and return the final path.
+
+    Returns None — the established "this page failed" contract every caller
+    already understands — when the pending file is missing, OR when `validate`
+    and the bytes are not an image (in which case the pending file is DELETED
+    so no half-written junk survives, and `on_reject(reason)` is invoked with a
+    `describe_invalid_image` string). `on_reject` fires ONLY for a validation
+    reject, so a caller can still distinguish that from a missing tempfile.
+
     `os.replace` is atomic on both POSIX and NT when source/dest share a
-    volume — pending and final live in the same folder, so this is safe."""
+    volume — pending and final live in the same folder, so this is safe.
+    Callers: aio-dl.py:dl_image (5 sites, grep _finalize_downloaded_image) and
+    sites/base.py:fast_download_images."""
     if not os.path.exists(pending_path):
         return None
     try:
+        # 64 bytes: every magic signature plus the markup sniff fit; WebP VP8X
+        # dimensions need 30. Was 32, which could not see a BOM-prefixed
+        # `<!doctype html>` past its leading whitespace.
         with open(pending_path, "rb") as fh:
-            head = fh.read(32)
+            head = fh.read(64)
     except Exception:
         head = b""
+    if validate:
+        try:
+            size = os.path.getsize(pending_path)
+        except OSError:
+            size = len(head)
+        if not _pending_file_is_image(pending_path, head, size, content_type):
+            if on_reject is not None:
+                try:
+                    on_reject(describe_invalid_image(head, content_type, size))
+                except Exception:
+                    pass
+            try:
+                os.remove(pending_path)
+            except OSError:
+                pass
+            return None
     ext = sniff_image_extension(head, content_type)
     final_path = os.path.join(folder, base + ext)
     os.replace(pending_path, final_path)
     return final_path
+
+
+def _pending_file_is_image(
+    path: str, head: bytes, size: int, content_type: Optional[str]
+) -> bool:
+    """`looks_like_real_image`'s policy against a file we've only read the head
+    of. Deliberately NOT `looks_like_real_image(head)`: a 64-byte head of a real
+    900 KB JPEG is under min_bytes and its SOF may sit past byte 64, which would
+    reject every large page on the site."""
+    if _head_rejects_image(head, size, content_type) is not None:
+        return False
+    if size >= _MIN_IMAGE_BYTES:
+        return True
+    # Sub-256-byte body: the divider-bar rescue needs the whole file to
+    # dimension-sniff. Bounded read — the file is smaller than _MIN_IMAGE_BYTES.
+    try:
+        with open(path, "rb") as fh:
+            return looks_like_real_image(fh.read(_MIN_IMAGE_BYTES), content_type=content_type)
+    except OSError:
+        return False

--- a/sites/asura.py
+++ b/sites/asura.py
@@ -532,9 +532,6 @@ class AsuraSiteHandler(BaseSiteHandler):
 
         return chapters
 
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        return chapter_version.get("group_name")
-
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:
         chapter_url = chapter.get("url")
         if not chapter_url:

--- a/sites/atsumaru.py
+++ b/sites/atsumaru.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 from urllib.parse import quote_plus, urljoin, urlparse
 
-from .base import BaseSiteHandler, SearchHit, SiteComicContext
+from .base import BaseSiteHandler, GroupInfo, SearchHit, SiteComicContext
 
 
 class AtsumaruSiteHandler(BaseSiteHandler):
@@ -93,6 +93,17 @@ class AtsumaruSiteHandler(BaseSiteHandler):
             # first batch of chapters regardless of login state.
             "_embedded_chapters": manga.get("chapters") or [],
             "_has_more_chapters": bool(manga.get("hasMoreChapters")),
+            # scanlationMangaId -> scanlator display name. atsu.moe carries
+            # MULTIPLE scanlator versions of the same chapter number (Solo
+            # Leveling: 4 groups, 802 rows over 201 numbers) and every chapter
+            # entry from /allChapters names its group by id only. This map is
+            # the only place the names are exposed, and it rides the mangaPage
+            # payload we already fetch — no extra request. Grep _scanlators.
+            "_scanlators": {
+                s.get("id"): s.get("name")
+                for s in (manga.get("scanlators") or [])
+                if isinstance(s, dict) and s.get("id")
+            },
         }
 
         authors = self._parse_people(manga.get("authors"))
@@ -154,8 +165,21 @@ class AtsumaruSiteHandler(BaseSiteHandler):
             "hasMoreChapters": bool(manga.get("hasMoreChapters")),
         }
 
-    def _parse_chapter_entry(self, slug: str, entry: Dict, fallback_index: int = 0) -> Dict:
-        """Convert a raw chapter dict from either API source into a normalised chapter dict."""
+    def _parse_chapter_entry(
+        self,
+        slug: str,
+        entry: Dict,
+        fallback_index: int = 0,
+        *,
+        scanlators: Optional[Dict[str, str]] = None,
+    ) -> Dict:
+        """Convert a raw chapter dict from either API source into a normalised chapter dict.
+
+        `scanlators` is the mangaPage id->name map (grep _scanlators). Only the
+        /allChapters and embedded-mangaPage entries carry `scanlationMangaId`;
+        the paginated /api/manga/chapters endpoint omits it entirely, so
+        chapters sourced from there have no group and rank on other signals.
+        """
         chapter_id = entry.get("id")
         chap_number = entry.get("number")
         title = entry.get("title")
@@ -185,6 +209,16 @@ class AtsumaruSiteHandler(BaseSiteHandler):
         else:
             chap_str = str(fallback_index)
 
+        scan_id = entry.get("scanlationMangaId")
+        groups = []
+        if scan_id:
+            name = (scanlators or {}).get(scan_id)
+            # Keep the GroupInfo even when the name is unknown: the id alone
+            # still separates two versions into distinct census buckets.
+            groups.append(GroupInfo(name=name or scan_id, group_id=scan_id))
+
+        page_count = entry.get("pageCount")
+
         return {
             "hid": f"{slug}-{chapter_id}",
             "chap": chap_str,
@@ -193,6 +227,9 @@ class AtsumaruSiteHandler(BaseSiteHandler):
             "_slug": slug,
             "_chapter_id": chapter_id,
             "uploaded": uploaded,
+            "_groups": groups,
+            "group_name": groups[0].name if groups else None,
+            "_pages": page_count if isinstance(page_count, int) else None,
         }
 
     def get_chapters(
@@ -203,13 +240,48 @@ class AtsumaruSiteHandler(BaseSiteHandler):
         make_request,
     ) -> List[Dict]:
         slug = context.identifier
-        page = 0
+        scanlators = context.comic.get("_scanlators") or {}
         chapters: List[Dict] = []
+
+        # --- Primary: /api/manga/allChapters -------------------------------
+        # Returns EVERY chapter row in ONE request. Was the adult-content
+        # fallback until 2026-08-02; promoted to primary because the paginated
+        # /api/manga/chapters endpoint it replaced is strictly worse on both
+        # axes (measured on Solo Leveling, slug oZOG5):
+        #   - coverage: allChapters 802 rows vs paginated 601 — the paginated
+        #     view silently drops ~25% of the scanlator versions.
+        #   - groups: allChapters entries carry `scanlationMangaId` (+
+        #     `pageCount`); the paginated entries carry NEITHER, which is why
+        #     atsumaru had no group detection at all and the version winner
+        #     was whatever the server happened to list first.
+        # Also 1 request instead of ceil(rows/50).
+        all_entries = self._fetch_all_chapters(slug, scraper)
+        if all_entries:
+            for entry in all_entries:
+                chapters.append(
+                    self._parse_chapter_entry(
+                        slug, entry,
+                        fallback_index=len(chapters) + 1,
+                        scanlators=scanlators,
+                    )
+                )
+            return chapters
+
+        # --- Fallback: the paginated endpoint ------------------------------
+        # Group-blind and lossy (see above), but it is a different code path on
+        # the server and has historically answered when allChapters didn't.
+        page = 0
         while True:
             batch = self._fetch_chapter_batch(slug, page, scraper)
             entries = batch.get("chapters") or []
             for i, entry in enumerate(entries):
-                chapters.append(self._parse_chapter_entry(slug, entry, fallback_index=len(chapters) + 1))
+                chapters.append(
+                    self._parse_chapter_entry(
+                        slug, entry,
+                        fallback_index=len(chapters) + 1,
+                        scanlators=scanlators,
+                    )
+                )
             pages_total = batch.get("pages")
             current_page = batch.get("page", page)
             has_next = (
@@ -224,25 +296,22 @@ class AtsumaruSiteHandler(BaseSiteHandler):
         if chapters:
             return chapters
 
-        # --- Fallback for adult-content manga ---
-        # /api/manga/chapters returns empty without an authenticated session.
-        # First try /api/manga/allChapters which returns every chapter in one
-        # shot — this avoids the pagination gaps that /api/manga/page has
-        # (it only shows the newest and oldest chapters, hiding the middle
-        # ones behind a "Show All" button on the website).
-        all_entries = self._fetch_all_chapters(slug, scraper)
-        if all_entries:
-            for entry in all_entries:
-                chapters.append(self._parse_chapter_entry(slug, entry, fallback_index=len(chapters) + 1))
-            return chapters
-
         # Last resort: use embedded chapters from the manga page response,
         # then paginate via the manga page endpoint if hasMoreChapters is set.
+        # /api/manga/chapters returns empty without an authenticated session
+        # for adult-content manga, and /api/manga/page always includes the
+        # first batch regardless of login state.
         embedded: List[Dict] = list(context.comic.get("_embedded_chapters") or [])
         has_more: bool = bool(context.comic.get("_has_more_chapters"))
 
         for entry in embedded:
-            chapters.append(self._parse_chapter_entry(slug, entry, fallback_index=len(chapters) + 1))
+            chapters.append(
+                self._parse_chapter_entry(
+                    slug, entry,
+                    fallback_index=len(chapters) + 1,
+                    scanlators=scanlators,
+                )
+            )
 
         if has_more and embedded:
             # Paginate using the last chapter's index field as the offset.
@@ -267,7 +336,13 @@ class AtsumaruSiteHandler(BaseSiteHandler):
                     eid = entry.get("id")
                     if eid and eid not in seen_ids:
                         seen_ids.add(eid)
-                        chapters.append(self._parse_chapter_entry(slug, entry, fallback_index=len(chapters) + 1))
+                        chapters.append(
+                            self._parse_chapter_entry(
+                                slug, entry,
+                                fallback_index=len(chapters) + 1,
+                                scanlators=scanlators,
+                            )
+                        )
                         added_any = True
                 
                 if not added_any:

--- a/sites/base.py
+++ b/sites/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import math
 import os
 import queue
 import re
@@ -9,12 +10,14 @@ import statistics
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from functools import lru_cache
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
 from bs4 import BeautifulSoup, FeatureNotFound
 
 from ._image_io import finalize_pending_image, looks_like_real_image
+from .group_quality import MTL_CONFIRMED, MTL_NONE, classify_mtl, mtl_rank
 
 # Preferred BeautifulSoup parser, detected once at import. lxml is faster and
 # more lenient than the stdlib parser; handlers used to copy this probe into
@@ -220,6 +223,185 @@ class AssetSpec:
     meta: Dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class GroupInfo:
+    """One scanlation group credited on a chapter version.
+
+    THE canonical group representation. Handlers stash a list of these on the
+    chapter dict as ``chapter["_groups"]``; everything that reasons about
+    groups reads them back through ``BaseSiteHandler.get_group_infos``.
+
+    WHY a structured list instead of the old per-site string: every handler
+    invented its own key (``group_name`` / ``group`` / ``scanlator``) and its
+    own near-identical ``get_group_name`` override, and a single string cannot
+    express (a) a chapter co-released by two groups — mangadex and kagane both
+    used to keep only the FIRST of a multi-group list, dynasty comma-joined
+    them into one unmatchable blob — or (b) the trust signals the ranker needs
+    (official / verified / inactive / description).
+
+    ``chapter["group_name"]`` SURVIVES as the human-readable ``", ".join(names)``
+    because five call sites read it as a plain string: aio_search_cli's
+    per-source JSON, sites/chapter_merger.py, the ComicInfo ``<Translator>``
+    writer, and the missed-chapter replay (grep ``grp_name`` in aio-dl.py).
+
+    Field semantics:
+      - name:        display name, RAW from the site. The MTL classifier's
+                     case-sensitive "AI" guard depends on original casing.
+      - group_id:    site-native stable id (MangaDex group UUID, atsumaru
+                     scanlationMangaId). Preferred over name for catalog
+                     lookups — names drift across rebrands, ids don't.
+      - is_official: licensed publisher or site-operated release. Feeds the
+                     ranker's official tier AND `--group official`.
+      - verified:    the site's own verified badge (MangaDex only today).
+      - inactive:    the site says the group is dead. Demotes, never excludes.
+      - description: group self-description, where exposed (MangaDex only).
+                     Second input to sites/group_quality.classify_mtl.
+    """
+    name: Optional[str] = None
+    group_id: Optional[str] = None
+    is_official: bool = False
+    verified: bool = False
+    inactive: bool = False
+    description: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class GroupSelectionPolicy:
+    """Run-level inputs to select_best_chapter_version that aren't per-chapter.
+
+    Built ONCE per series in aio-dl.py (grep ``build_group_census``) and passed
+    into every per-chapter selector call. Deliberately NOT stashed on chapter
+    dicts (they get copied by _annotate_selection and again by the
+    collapse-splits merge, so a stashed field would have three lifetimes) and
+    NOT cached on the handler (a module global keyed by series leaks across the
+    --jobs orchestrator's in-process handler reuse and across --update-all).
+
+      - census:        group match_key -> number of DISTINCT chapter numbers
+                       that group supplies for THIS series. The strongest
+                       zero-cost "is this the real TL or a filler dump" signal.
+      - census_total:  distinct chapter numbers in the series, the denominator.
+      - mtl:           "avoid" (default: rank last, still use when it's the only
+                       version) | "allow" (ignore MTL entirely) | "exclude"
+                       (skip chapters whose every version is CONFIRMED MTL).
+      - excluded_keys: match_keys from --exclude-group.
+    """
+    census: Optional[Dict[str, int]] = None
+    census_total: int = 0
+    mtl: str = "avoid"
+    excluded_keys: FrozenSet[str] = frozenset()
+
+
+# `--group <one of these>` selects by the GroupInfo.is_official FLAG rather than
+# by name. These are match keys (get_group_match_key output: casefolded,
+# non-alphanumerics stripped), so "Official Release" arrives as
+# "officialrelease". Grep target: group_matches_filter.
+_OFFICIAL_ALIAS_KEYS = frozenset({
+    "official", "officialrelease", "licensed", "publisher",
+})
+
+# --- Chapter-version ranking tuning ----------------------------------------
+# Page count is a PLACEHOLDER detector, never a "more pages is better" signal:
+# webtoon groups slice the same complete chapter differently (Solo Leveling
+# ch.1 on atsumaru is Alpha 22p / Asura 22p / Flame 19p / Dusk 14p, all four
+# complete). The band below flags only genuine stubs.
+#   _PAGE_BAND_MIN_MEDIAN — below this a median can't distinguish a stub from a
+#     legitimately short chapter (4-koma, omake), so the tier goes inert.
+#   _PAGE_BAND_RATIO — 0.35 not 0.5, because re-slicing at 2x tile height
+#     legitimately halves a count; 0.35 still catches the 3-of-20 class.
+#   _PAGE_BAND_ABS_FLOOR — stops the ratio firing on tiny chapters at all
+#     (0.35 * 6 = 2.1 would bless a 2-page entry).
+_PAGE_BAND_MIN_MEDIAN = 8
+_PAGE_BAND_RATIO = 0.35
+_PAGE_BAND_ABS_FLOOR = 3
+
+# Per-series track record, as a fraction of the series' distinct chapter count.
+# Banded rather than raw so 198-vs-201 is a tie (noise) while 201-vs-12 is not.
+_CENSUS_BANDS = ((0.60, 3), (0.25, 2), (0.05, 1))
+
+# Index-aligned with the tuple built by BaseSiteHandler._rank_version. Used to
+# name the tier that actually decided a pick, for the selection log.
+_RANK_TIER_NAMES = (
+    "exclusion", "downloadability", "MTL", "page-count", "official",
+    "track-record", "verified", "upvotes", "recency", "pages", "source-order",
+)
+
+
+@lru_cache(maxsize=4096)
+def _classify_group_mtl(
+    name: Optional[str], description: Optional[str]
+) -> Tuple[str, str]:
+    """Memoized classify_mtl. A long series re-classifies the same handful of
+    groups once per chapter otherwise (1000 chapters x 4 versions)."""
+    return classify_mtl(name, description=description)
+
+
+def _census_band(count: int, total: int) -> int:
+    """Map a group's chapter count for THIS series onto a track-record tier."""
+    if not total or count <= 0:
+        return 0
+    frac = count / total
+    for threshold, band in _CENSUS_BANDS:
+        if frac >= threshold:
+            return band
+    return 0
+
+
+def _coerce_epoch(value: Any) -> Optional[int]:
+    """Epoch seconds from a chapter's `uploaded`, or None.
+
+    Strings are REJECTED on purpose: mangago stores a display string ("2 days
+    ago"), and a wrong parse would silently reorder selections with no error.
+    None keeps the recency tier inert for that handler instead.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return int(value) if value > 0 else None
+
+
+def _coerce_pages(version: Dict) -> Optional[int]:
+    """Page count from a chapter dict, or None when the site doesn't report it.
+
+    `_pages` is the established internal key (kagane, mangadex, atsumaru);
+    `pages` is accepted for anything that surfaces it raw.
+    """
+    for key in ("_pages", "pages"):
+        value = version.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
+def build_group_census(
+    handler: "BaseSiteHandler", chapters_by_num: Dict[str, List[Dict]]
+) -> Tuple[Dict[str, int], int]:
+    """Count how many DISTINCT chapter numbers each group supplies for a series.
+
+    Distinct NUMBERS, not rows: a group that re-uploaded ch.5 three times must
+    not earn 3x credit. Returns (match_key -> count, distinct chapter total).
+
+    This is the ranker's strongest zero-cost signal — an MTL/filler group dumps
+    a handful of chapters into a gap while the real TL has the long run — and it
+    is the one fact a per-chapter selector cannot see for itself. Built once per
+    series in aio-dl.py and passed down via GroupSelectionPolicy.
+
+    Runtime-only: never persisted, never an argparse dest, never in
+    gating_hash, so it cannot desync a resume.
+    """
+    census: Dict[str, int] = {}
+    for versions in chapters_by_num.values():
+        seen_here: set = set()
+        for version in versions:
+            for info in handler.get_group_infos(version):
+                key = handler.get_group_match_key(info.name)
+                if key:
+                    seen_here.add(key)
+        for key in seen_here:
+            census[key] = census.get(key, 0) + 1
+    return census, len(chapters_by_num)
+
+
 # --- Search image-quality probe: breadth-sample concurrency -----------------
 # How many of a source's breadth-sample chapters BaseSiteHandler.
 # _probe_chapter_aggregate probes CONCURRENTLY. The breadth pass fetches 1 page
@@ -308,6 +490,27 @@ class BaseSiteHandler:
     # sites/search_orchestrator.py:search_all sorts `eligible` on this
     # before enqueue — grep SEARCH_COST_HINT.
     SEARCH_COST_HINT: str = "normal"
+
+    # ADVISORY lower bound on the chapter numbers this run actually wants, set
+    # per-INSTANCE by aio-dl.py just before get_chapters (grep
+    # chapter_floor_hint there). Purely an optimization: a handler may ignore
+    # it, and every handler that does still returns the full list, so
+    # correctness never depends on it. The caller applies the real --chapters
+    # filter afterwards either way.
+    #
+    # Exists for handlers whose chapter listing is paginated and expensive.
+    # comix is the motivating case: its list is a browser DOM scrape over a
+    # pager whose rows are per (chapter x group), so a long multi-group series
+    # runs to ~360 page loads — while a routine update run only needs the
+    # newest one or two pages. comix sorts newest-first, so it stops as soon as
+    # a whole page falls below this value.
+    #
+    # None = no floor (full download); handlers must treat it as "walk
+    # everything". Not a class-level policy knob — it changes per run, so it is
+    # assigned on the instance, and it is NOT part of _RESUME_GATING_DESTS
+    # (it can't change which bytes land on disk, only how much listing work we
+    # do to find them).
+    chapter_floor_hint: Optional[float] = None
 
     # When True, the search orchestrator treats this handler as the canonical
     # source for any series it returns — winning the per-candidate tiebreaker
@@ -833,10 +1036,57 @@ class BaseSiteHandler:
     ) -> List[Dict]:
         return []
 
+    def get_group_infos(self, chapter_version: Dict) -> List[GroupInfo]:
+        """Read a chapter's scanlation groups. THE canonical accessor.
+
+        Precedence:
+          1. ``chapter["_groups"]`` — a list of GroupInfo. The modern path;
+             the only one that can express multi-group releases and trust
+             signals.
+          2. Legacy string keys, FIRST hit wins: group_name, group, scanlator,
+             publisher. Wrapped as a single unadorned GroupInfo.
+
+        The legacy string is deliberately NOT comma-split: a real group name
+        can contain a comma, and multi-group releases are what `_groups` is
+        for. (dynasty used to comma-join its scanlators here, which made
+        `--group "X"` unable to match a chapter tagged "X, Y" — it now emits
+        `_groups` instead.)
+
+        Handlers should NOT override this. Ten of them used to override
+        get_group_name with the same three-line "read my key, return it" body;
+        the fallback chain above subsumes every one of them.
+        """
+        groups = chapter_version.get("_groups")
+        if isinstance(groups, (list, tuple)):
+            resolved = [g for g in groups if isinstance(g, GroupInfo)]
+            if resolved:
+                return resolved
+        for key in ("group_name", "group", "scanlator", "publisher"):
+            value = chapter_version.get(key)
+            if isinstance(value, str) and value.strip():
+                return [GroupInfo(name=value.strip())]
+        return []
+
     def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        return None
+        """Human-readable group credit, or None. Multi-group chapters join with
+        ", " — this is display/metadata only (ComicInfo <Translator>, logs, the
+        search JSON). Matching and ranking go through get_group_infos."""
+        names = [g.name.strip() for g in self.get_group_infos(chapter_version)
+                 if isinstance(g.name, str) and g.name.strip()]
+        return ", ".join(names) if names else None
 
     def normalize_group_name(self, group_name: Optional[str]) -> Optional[str]:
+        """Casefold + collapse separators. PURE text normalization.
+
+        It used to also rewrite any name matching \\b(official|webtoons?|naver)\\b
+        to the literal "official". That was destructive: it merged LINE Webtoon
+        Originals with Canvas (defeating the distinction sites/linewebtoon.py
+        builds on purpose), merged unrelated real groups ("Webtoon Scans",
+        "Naver fan TL") into one bucket, and made all of them matchable by
+        `--group official`. The official-alias capability now lives in
+        group_matches_filter, keyed on the GroupInfo.is_official FLAG rather
+        than on a substring of the name.
+        """
         if not isinstance(group_name, str):
             return None
         cleaned = group_name.strip().casefold()
@@ -844,9 +1094,7 @@ class BaseSiteHandler:
             return None
         cleaned = re.sub(r"[_./-]+", " ", cleaned)
         cleaned = re.sub(r"\s+", " ", cleaned).strip()
-        if re.search(r"\b(?:official|webtoons?|naver)\b", cleaned):
-            return "official"
-        return cleaned
+        return cleaned or None
 
     def get_group_match_key(self, group_name: Optional[str]) -> Optional[str]:
         normalized = self.normalize_group_name(group_name)
@@ -855,6 +1103,210 @@ class BaseSiteHandler:
         squashed = re.sub(r"[^0-9a-z]+", "", normalized)
         return squashed or normalized
 
+    def group_matches_filter(
+        self, infos: List[GroupInfo], filter_key: Optional[str]
+    ) -> bool:
+        """Does any of a chapter's groups satisfy one --group / --exclude-group
+        entry (already reduced to a match key)?
+
+        `--group official` (and its aliases) matches on the is_official FLAG,
+        not on the name — so it catches MangaPlus, Viz, LINE Originals, and
+        mangago's /br_chapter- releases, while leaving a fan group merely
+        NAMED "Webtoon Scans" alone. See normalize_group_name for why this
+        moved out of the normalizer.
+        """
+        if not filter_key:
+            return False
+        if filter_key in _OFFICIAL_ALIAS_KEYS:
+            return any(info.is_official for info in infos)
+        return any(
+            self.get_group_match_key(info.name) == filter_key for info in infos
+        )
+
+    # --- Chapter-version ranking -------------------------------------------
+    def _version_signals(
+        self, version: Dict, policy: GroupSelectionPolicy
+    ) -> Dict[str, Any]:
+        """Per-version facts the rank tuple needs, folded across the version's
+        groups. Multi-group folding rules, and why each is what it is:
+
+          - mtl: take the BEST verdict across groups. A chapter co-credited to
+            a human group and an MTL shop had a human in the loop; taking the
+            worst would demote a legitimate joint release and, on a site where
+            the main TL sometimes co-credits, would fight the census tier.
+          - is_official / verified: any group qualifies the chapter.
+          - inactive: only when EVERY credited group is flagged inactive.
+          - census band: max — a co-release inherits the main group's standing.
+          - excluded: any — `--exclude-group X` means "not this group's work",
+            and a co-credit is still that group's work.
+        """
+        infos = self.get_group_infos(version)
+        mtl_verdict = MTL_NONE
+        best_mtl = -1
+        for info in infos:
+            verdict, reason = _classify_group_mtl(info.name, info.description)
+            rank = mtl_rank(verdict)
+            if rank > best_mtl:
+                best_mtl, mtl_verdict = rank, verdict
+        if best_mtl < 0:
+            best_mtl = mtl_rank(MTL_NONE)
+
+        census = policy.census or {}
+        band = 0
+        for info in infos:
+            key = self.get_group_match_key(info.name)
+            if not key:
+                continue
+            band = max(band, _census_band(census.get(key, 0), policy.census_total))
+
+        excluded = any(
+            self.group_matches_filter([info], key)
+            for info in infos
+            for key in policy.excluded_keys
+        ) if policy.excluded_keys else False
+
+        return {
+            "infos": infos,
+            "mtl_verdict": mtl_verdict,
+            "mtl_rank": best_mtl,
+            "is_official": any(i.is_official for i in infos),
+            "verified": any(i.verified for i in infos),
+            "all_inactive": bool(infos) and all(i.inactive for i in infos),
+            "census_band": band,
+            "excluded": excluded,
+        }
+
+    def _build_rank_context(
+        self, versions: List[Dict], policy: GroupSelectionPolicy
+    ) -> Dict[str, Any]:
+        """Cross-version facts computed ONCE, so a tier can go inert.
+
+        THE core rule: a MISSING signal must never read as a LOSING signal. The
+        old ranker's `v.get("up_count", 0)` treated "this site doesn't report
+        votes" as "zero votes", which is why 8 of 11 group-bearing handlers
+        collapsed to `max()`-returns-the-first-element, i.e. arbitrary API
+        order. Every tier below is enabled only when it can actually
+        discriminate, and returns a constant for every version otherwise.
+        """
+        upvote_values = [
+            v.get("up_count") for v in versions
+            if isinstance(v.get("up_count"), int) and not isinstance(v.get("up_count"), bool)
+        ]
+        # Needs >= 2 reporters AND a non-zero max: mangago hardcodes 0 for
+        # every chapter, which is data-shaped but carries no information.
+        upvotes_live = len(upvote_values) >= 2 and max(upvote_values) > 0
+
+        epochs = [_coerce_epoch(v.get("uploaded")) for v in versions]
+        recency_live = len(versions) > 1 and all(e is not None for e in epochs)
+
+        page_counts = [_coerce_pages(v) for v in versions]
+        known_pages = [p for p in page_counts if p is not None]
+        pages_live = len(known_pages) == len(versions) and len(versions) > 1
+
+        # Placeholder floor. Only meaningful with >=2 reported counts and a
+        # median big enough to tell a stub from a genuinely short chapter.
+        page_floor: Optional[float] = None
+        if len(known_pages) >= 2:
+            median_pages = statistics.median(known_pages)
+            if median_pages >= _PAGE_BAND_MIN_MEDIAN:
+                page_floor = max(
+                    _PAGE_BAND_ABS_FLOOR, median_pages * _PAGE_BAND_RATIO
+                )
+
+        return {
+            "policy": policy,
+            "upvotes_live": upvotes_live,
+            "recency_live": recency_live,
+            "pages_live": pages_live,
+            "page_floor": page_floor,
+            # `--mtl allow` means "treat a machine translation like any other
+            # version", so the tier must go inert rather than merely stop
+            # excluding — otherwise allow and avoid rank identically.
+            "mtl_live": policy.mtl != "allow",
+            "signals": [self._version_signals(v, policy) for v in versions],
+        }
+
+    def _rank_version(self, index: int, version: Dict, ctx: Dict[str, Any]) -> Tuple:
+        """The composite rank key. Higher wins; consumed by max().
+
+        Tiers, most significant first. Each line states WHY it sits where it
+        does — mirrors the documented tuple in
+        sites/external_metadata.py:_pick_best_candidate.
+
+         0 not_excluded    A hard user veto (--exclude-group / --mtl exclude)
+                           dominates everything. Kept IN the tuple rather than
+                           pre-filtered so an excluded-but-only version still
+                           obeys the allow_group_fallback contract instead of
+                           silently vanishing.
+         1 downloadable    A MangaDex external chapter (pages:0 + externalUrl)
+                           is metadata, not a chapter — ranking it first trades
+                           a working download for a guaranteed abort. This tier
+                           is what makes the official tier safe at all. Set
+                           ONLY from an explicit handler flag, never inferred
+                           from a missing field.
+         2 mtl_rank        The headline fix. Above official because an
+                           official-looking MTL doesn't exist, but a
+                           high-upvote MTL demonstrably does.
+         3 not_placeholder A 3-page stub beside 22-page siblings is a broken
+                           upload, not a translation choice.
+         4 official_rank   Licensed beats fan TL when both are downloadable.
+                           Mirrors chapter_merger.py's cross-source
+                           official-first row sort, so within-source and
+                           cross-source selection finally agree.
+         5 census_band     The group at 201/201 is the series' TL; the one that
+                           dropped 12 chapters into a gap is filler. Banded so
+                           198-vs-201 ties instead of shadowing everything
+                           below.
+         6 verified        The site's own curation badge. Free where it exists
+                           (MangaDex only), absent everywhere else, so it can't
+                           sit higher.
+         7 upvote_band     Demoted from being THE ENTIRE metric to a weak
+                           tiebreak. This is the fix for "an MTL with more
+                           likes beats a real TL". log2 banding makes 412-vs-408
+                           a tie while 1000-vs-5 still decides.
+         8 recency         A later upload of the same chapter is usually a
+                           redo/fix. Below upvotes because necro-uploads of bad
+                           rips are common.
+         9 pages           Usually more complete, but webtoon slicing makes it
+                           near-noise (Solo Leveling ch.1 is 22p and 14p from
+                           two groups, both complete), so it only breaks ties
+                           nothing else could.
+        10 -index          Deterministic last resort. Replaces the old
+                           ACCIDENTAL versions[0] with a documented one.
+        """
+        sig = ctx["signals"][index]
+        floor = ctx["page_floor"]
+        pages = _coerce_pages(version)
+
+        not_placeholder = 1
+        if floor is not None and pages is not None:
+            not_placeholder = int(pages >= floor)
+
+        official_rank = 2 if sig["is_official"] else (0 if sig["all_inactive"] else 1)
+
+        upvote_band = 0
+        if ctx["upvotes_live"]:
+            count = version.get("up_count")
+            if isinstance(count, int) and count > 0:
+                upvote_band = int(math.log2(count + 1))
+
+        recency = (_coerce_epoch(version.get("uploaded")) or 0) if ctx["recency_live"] else 0
+        pages_tier = pages if (ctx["pages_live"] and pages is not None) else 0
+
+        return (
+            0 if sig["excluded"] else 1,
+            0 if version.get("_undownloadable") is True else 1,
+            sig["mtl_rank"] if ctx["mtl_live"] else 2,
+            not_placeholder,
+            official_rank,
+            sig["census_band"],
+            1 if sig["verified"] else 0,
+            upvote_band,
+            recency,
+            pages_tier,
+            -index,
+        )
+
     def select_best_chapter_version(
         self,
         versions: List[Dict],
@@ -862,20 +1314,65 @@ class BaseSiteHandler:
         mix_by_upvote: bool,
         allow_group_fallback: bool = True,
         log_debug_fn=None,
+        *,
+        selection_policy: Optional[GroupSelectionPolicy] = None,
     ) -> Optional[Dict]:
+        """Collapse every version of ONE chapter number down to the best one.
+
+        Called once per chapter-number bucket from aio-dl.py (grep
+        `select_best_chapter_version`). NO handler overrides this — per-site
+        behavior comes from what the handler puts in `_groups`, not from
+        reimplementing the policy.
+
+        Control flow is unchanged from the original: no --group → rank
+        everything; --group + --mix-by-upvote → rank within the union of
+        preferred groups; --group alone → first preferred group that has any
+        version wins, ranked within it; nothing matched → fall back (or skip
+        under --no-group-fallback). Only the METRIC changed, from
+        `max(key=up_count)` to the composite `_rank_version` tuple.
+
+        `selection_policy` carries the per-series census + MTL/exclude policy.
+        Keyword-only with a default so the positional signature is unchanged.
+        """
         if not versions:
             return None
 
-        def upvotes(v: Dict) -> int:
-            return v.get("up_count", 0)
+        policy = selection_policy or GroupSelectionPolicy()
 
         def _debug(msg):
             if log_debug_fn:
                 log_debug_fn(msg)
 
+        # --mtl exclude: drop CONFIRMED machine translations outright. Never
+        # `suspect` — hard-dropping real chapters on a heuristic is not a
+        # trade the flag is allowed to make.
+        pool = versions
+        excluded_mtl = 0
+        if policy.mtl == "exclude":
+            probe_ctx = self._build_rank_context(versions, policy)
+            keep = [
+                v for i, v in enumerate(versions)
+                if probe_ctx["signals"][i]["mtl_verdict"] != MTL_CONFIRMED
+            ]
+            excluded_mtl = len(versions) - len(keep)
+            if not keep:
+                _debug(
+                    f"    Ch {versions[0].get('chap', '?')}: every version is "
+                    f"machine-translated and --mtl exclude is set. Skipping."
+                )
+                return None
+            pool = keep
+
+        ctx = self._build_rank_context(pool, policy)
+        chap_label = pool[0].get("chap", "?")
+        # IDENTITY-keyed, not pool.index(): list.index compares by equality, so
+        # two byte-identical duplicate rows would both resolve to the first
+        # one's slot and corrupt the -index stable tiebreak.
+        slot_of = {id(v): i for i, v in enumerate(pool)}
+
         def _available_groups() -> str:
             groups: List[str] = []
-            for version in versions:
+            for version in pool:
                 group_name = self.get_group_name(version)
                 if not isinstance(group_name, str):
                     continue
@@ -884,26 +1381,83 @@ class BaseSiteHandler:
                     groups.append(cleaned)
             return ", ".join(groups) if groups else "none"
 
+        def _describe(version: Dict) -> str:
+            """'Alpha' [201/201 ch, MTL] — the log's evidence line."""
+            name = self.get_group_name(version) or "No Group"
+            bits: List[str] = []
+            sig = ctx["signals"][slot_of[id(version)]]
+            census = policy.census or {}
+            if census:
+                best = 0
+                for info in sig["infos"]:
+                    key = self.get_group_match_key(info.name)
+                    if key:
+                        best = max(best, census.get(key, 0))
+                if best:
+                    bits.append(f"{best}/{policy.census_total} ch")
+            if sig["mtl_verdict"] != MTL_NONE:
+                bits.append(sig["mtl_verdict"] + " MTL")
+            if sig["is_official"]:
+                bits.append("official")
+            if version.get("_undownloadable") is True:
+                bits.append("no pages")
+            return f"'{name}'" + (f" [{', '.join(bits)}]" if bits else "")
+
+        def _pick(candidates: List[Dict]) -> Tuple[Dict, Optional[str]]:
+            """Best candidate + the name of the tier that actually decided it."""
+            ranked = sorted(
+                ((self._rank_version(slot_of[id(v)], v, ctx), v) for v in candidates),
+                key=lambda pair: pair[0],
+                reverse=True,
+            )
+            winner_key, winner = ranked[0]
+            why = None
+            if len(ranked) > 1:
+                runner_key = ranked[1][0]
+                for tier, (a, b) in enumerate(zip(winner_key, runner_key)):
+                    if a != b:
+                        why = _RANK_TIER_NAMES[tier]
+                        break
+            return winner, why
+
         def _annotate_selection(
             version: Dict,
             *,
             selection_kind: str,
             requested_group: Optional[str] = None,
+            why: Optional[str] = None,
         ) -> Dict:
             annotated = dict(version)
-            annotated["_selection_kind"] = selection_kind
-            annotated["_requested_group"] = requested_group
-            annotated["_available_groups"] = _available_groups()
+            # ONE reserved key replacing the three write-only ones
+            # (_selection_kind / _requested_group / _available_groups) that
+            # nothing ever read. Consumed by aio-dl.py's per-chapter log and
+            # the --list-chapters JSON.
+            annotated["_group_selection"] = {
+                "kind": selection_kind,
+                "requested": requested_group,
+                "available": _available_groups(),
+                "winner": self.get_group_name(version),
+                "why": why,
+                "excluded_mtl": excluded_mtl,
+            }
             return annotated
 
-        chap_label = versions[0].get("chap", "?")
-        best_by_upvote = max(versions, key=upvotes)
+        def _log_pick(prefix: str, winner: Dict, why: Optional[str]) -> None:
+            losers = [v for v in pool if v is not winner]
+            tail = ""
+            if losers:
+                shown = ", ".join(_describe(v) for v in losers[:3])
+                more = f" +{len(losers) - 3} more" if len(losers) > 3 else ""
+                tail = f" over {shown}{more}"
+            reason = f" [on {why}]" if why else ""
+            _debug(f"    Ch {chap_label}: {prefix}{_describe(winner)}{tail}{reason}.")
 
         if not preferred_groups:
-            _debug(
-                f"    Ch {chap_label}: No group specified. Selected by upvotes ({best_by_upvote.get('up_count', 0)})."
+            winner, why = _pick(pool)
+            _log_pick("picked ", winner, why)
+            return _annotate_selection(
+                winner, selection_kind="ranked_no_group", why=why
             )
-            return _annotate_selection(best_by_upvote, selection_kind="upvote_no_group")
 
         preferred_entries = [
             (group_name, self.get_group_match_key(group_name))
@@ -915,70 +1469,68 @@ class BaseSiteHandler:
             if match_key
         ]
         if not preferred_entries:
-            _debug(
-                f"    Ch {chap_label}: Group filter contained no usable names. Selected by upvotes ({best_by_upvote.get('up_count', 0)})."
-            )
+            winner, why = _pick(pool)
+            _log_pick("group filter had no usable names; picked ", winner, why)
             return _annotate_selection(
-                best_by_upvote,
-                selection_kind="upvote_invalid_group_filter",
+                winner, selection_kind="ranked_invalid_group_filter", why=why
             )
 
+        preferred_keys = {match_key for _, match_key in preferred_entries}
         if mix_by_upvote:
+            # Historical flag name. Since upvotes were demoted to a weak
+            # tiebreak this means "rank across the union of my preferred
+            # groups" rather than "walk them in priority order".
             preferred = [
-                v
-                for v in versions
-                if self.get_group_match_key(self.get_group_name(v))
-                in {match_key for _, match_key in preferred_entries}
+                v for v in pool
+                if any(
+                    self.group_matches_filter(self.get_group_infos(v), key)
+                    for key in preferred_keys
+                )
             ]
             if preferred:
-                best = max(preferred, key=upvotes)
-                _debug(
-                    f"    Ch {chap_label}: Mix-by-upvote. Selected '{self.get_group_name(best)}' ({best.get('up_count', 0)} upvotes)."
-                )
+                winner, why = _pick(preferred)
+                _log_pick("mixed across preferred groups; picked ", winner, why)
                 return _annotate_selection(
-                    best,
-                    selection_kind="preferred_mix_by_upvote",
+                    winner, selection_kind="preferred_mix_ranked", why=why
                 )
             if not allow_group_fallback:
                 _debug(
-                    f"    Ch {chap_label}: Mix-by-upvote. None of the requested groups were present. Skipping chapter. Available groups: {_available_groups()}."
+                    f"    Ch {chap_label}: none of the requested groups were "
+                    f"present. Skipping. Available: {_available_groups()}."
                 )
                 return None
-            _debug(
-                f"    Ch {chap_label}: Mix-by-upvote. None of the requested groups were present. Falling back to upvotes with '{self.get_group_name(best_by_upvote)}'. Available groups: {_available_groups()}."
-            )
+            winner, why = _pick(pool)
+            _log_pick("no requested group present; fell back to ", winner, why)
             return _annotate_selection(
-                best_by_upvote,
-                selection_kind="fallback_missing_group",
+                winner, selection_kind="fallback_missing_group", why=why
             )
 
         for group_name, match_key in preferred_entries:
             candidates = [
-                v
-                for v in versions
-                if self.get_group_match_key(self.get_group_name(v)) == match_key
+                v for v in pool
+                if self.group_matches_filter(self.get_group_infos(v), match_key)
             ]
             if candidates:
-                best = max(candidates, key=upvotes)
-                _debug(
-                    f"    Ch {chap_label}: Found in priority group '{group_name}'. Selected '{self.get_group_name(best)}'."
+                winner, why = _pick(candidates)
+                _log_pick(
+                    f"priority group '{group_name}'; picked ", winner, why
                 )
                 return _annotate_selection(
-                    best,
+                    winner,
                     selection_kind="preferred_priority",
                     requested_group=group_name,
+                    why=why,
                 )
         if not allow_group_fallback:
             _debug(
-                f"    Ch {chap_label}: None of the requested groups were present. Skipping chapter. Available groups: {_available_groups()}."
+                f"    Ch {chap_label}: none of the requested groups were "
+                f"present. Skipping. Available: {_available_groups()}."
             )
             return None
-        _debug(
-            f"    Ch {chap_label}: None of the requested groups were present. Falling back to upvotes with '{self.get_group_name(best_by_upvote)}'. Available groups: {_available_groups()}."
-        )
+        winner, why = _pick(pool)
+        _log_pick("no requested group present; fell back to ", winner, why)
         return _annotate_selection(
-            best_by_upvote,
-            selection_kind="fallback_missing_group",
+            winner, selection_kind="fallback_missing_group", why=why
         )
 
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:

--- a/sites/comix.py
+++ b/sites/comix.py
@@ -4,17 +4,18 @@ import atexit
 import builtins as _builtins
 import concurrent.futures as _futures
 import json
+import os
 import queue
 import re
 import sys
 import threading
 import time
 from typing import Dict, List, Optional, Any, Tuple
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
-from .base import BaseSiteHandler, SearchHit, SiteComicContext
+from .base import BaseSiteHandler, GroupInfo, SearchHit, SiteComicContext
 
 # Optional zendriver-backed Cloudflare fallback. comix.to added CF
 # protection in upstream's 2026-05 release; direct-HTTP API calls (the
@@ -60,6 +61,215 @@ print = _stderr_print  # noqa: A001 — intentional shadow of builtins.print
 # instead of one early page. The download path (get_chapter_images) passes no
 # cap → all pages.
 _COMIX_PROBE_PAGE_CAP = 8
+
+
+# ---------------------------------------------------------------------------
+# comix's FIRST-PARTY WAF interstitial (2026-08-02)
+# ---------------------------------------------------------------------------
+# comix.to runs TWO independent bot layers and they need different handling:
+#
+#   1. Cloudflare — /cdn-cgi/challenge-platform/…, handled by is_cf_challenge +
+#      the zendriver cookie capture in sites/crawlee_utils.py. Machine-solvable.
+#   2. comix's OWN WAF — a 302 to /@waf/challenge?return=<original-path> serving
+#      an INTERACTIVE CAPTCHA ("Verify you're human — drag to rotate the circle
+#      until the picture lines up"). A human has to drag it. Verified 2026-08-02:
+#      the string "@waf" appears in ZERO client bundles (main/vendor/secure/env,
+#      727 KB scanned), so it is entirely server-issued — there is no in-page JS
+#      routine to invoke and nothing to replicate. We never attempt to solve it;
+#      we detect it, keep a solved session alive so it is rarely hit, and hand
+#      the browser to the user when it does fire.
+#
+# Before this existed the WAF page was INVISIBLE to the handler and surfaced as
+# three different lies: "chapter had 0 .rpage-page divs", "no typeahead results",
+# and — worst — a silently truncated chapter list (see fetch_chapters_via_dom).
+# On the HTTP path it 200s with challenge HTML, so _extract_initial_data_manga
+# returned None and fetch_comic_context fell through to its slug-derived title
+# fallback, writing junk metadata. Grep _looks_like_waf_challenge for the wiring.
+_WAF_PATH_MARKER = "/@waf/"
+# Quoted in the user-facing remediation message. The site's own homepage is the
+# right destination: hitting /@waf/challenge directly works but reads like an
+# error page, and the challenge is issued from whatever route you land on.
+_WAF_CHALLENGE_HINT_URL = "https://comix.to/"
+_WAF_TEXT_MARKERS = (
+    "verify you're human",
+    "verify you&#039;re human",
+    "drag to rotate",
+)
+# Debug seam: forces the detector to fire once so the headed-handoff branch can
+# be exercised without waiting for the site to actually challenge us (it is
+# behavioral, so it can't be summoned on demand). Consumed — not just read — so
+# a single run tests exactly one challenge.
+_FORCE_WAF_ENV = "AIO_COMIX_FORCE_WAF"
+
+# Interactive-handoff knobs. The handoff opens a VISIBLE browser window on the
+# downloader's own profile and waits for the user to complete the check; it
+# never touches the widget. Set AIO_COMIX_NO_INTERACTIVE_WAF=1 for unattended
+# runs (cron, CI, headless servers) so a challenge fails fast instead of
+# blocking on a window nobody will see.
+_WAF_NO_INTERACTIVE_ENV = "AIO_COMIX_NO_INTERACTIVE_WAF"
+_WAF_SOLVE_TIMEOUT_ENV = "AIO_COMIX_WAF_SOLVE_TIMEOUT"
+_WAF_DEFAULT_SOLVE_TIMEOUT_S = 180.0
+# One handoff per process. Without this a series whose every chapter trips the
+# WAF would pop a window per chapter; after the first failure we want the run to
+# end with a clear error, not to keep interrupting.
+_COMIX_WAF_HANDOFF_ATTEMPTED = False
+_COMIX_WAF_HANDOFF_LOCK = threading.Lock()
+
+# Sanity bound on the pager-reported page count. Real worst case observed is
+# 360 (Magic Emperor, ~890 chapters x ~8 groups at 20 rows/page); this only
+# exists so a malformed pager can't turn into an unbounded walk, and it doubles
+# as the outer-timeout basis in _ComixBrowserBridge.fetch_chapters_via_dom.
+_MAX_CHAPTER_SCRAPE_PAGES = 800
+
+
+def _looks_like_waf_challenge(url: Optional[str], text: Optional[str] = None) -> bool:
+    """True when comix's first-party interactive CAPTCHA is in front of us.
+
+    Deliberately NOT merged with sites/crawlee_utils.py:is_cf_challenge — comix
+    runs Cloudflare AND this, only this one needs a human, and conflating them
+    would send a solvable CF challenge down the "ask the user" path.
+
+    ``url`` is the authoritative signal (the landed/final URL contains
+    ``/@waf/``). ``text`` is the fallback for the HTTP path, where the redirect
+    may already have been followed and some callers only hold the body. The
+    generic word "challenge" is deliberately NOT a marker — it appears in
+    ordinary comic synopses.
+    """
+    if os.environ.pop(_FORCE_WAF_ENV, None):
+        return True
+    if url and _WAF_PATH_MARKER in url:
+        return True
+    if text:
+        lowered = text.lower()
+        # Bound the scan: a challenge page is ~160 KB of mostly inline script,
+        # but the markers are visible copy near the top. A full-body lower() on
+        # every chapter page would be wasted work on the hot path.
+        if len(lowered) > 200_000:
+            lowered = lowered[:200_000]
+        for marker in _WAF_TEXT_MARKERS:
+            if marker in lowered:
+                return True
+        # "security check" is the <title>; on its own it is too generic to
+        # trust, so require it to co-occur with the interstitial's noindex meta.
+        if "security check" in lowered and "noindex" in lowered:
+            return True
+    return False
+
+
+class ComixWafChallengeError(RuntimeError):
+    """comix served its interactive human-verification CAPTCHA and we could not
+    get past it (no handoff possible, the user didn't finish in time, or the
+    retry landed on it again).
+
+    Raised — never swallowed into a partial result — because every alternative
+    is worse: a truncated chapter list gets persisted to .aio_series.json as if
+    it were the whole series, and a half-scraped chapter yields a short CBZ.
+    aio-dl.py catches it at the top level and prints the remediation.
+    """
+
+    def __init__(self, message: str, challenge_url: Optional[str] = None):
+        super().__init__(message)
+        self.challenge_url = challenge_url
+
+
+class ComixChapterScrapeError(RuntimeError):
+    """The chapter-list scrape could not be completed to the end of pagination.
+
+    Exists so a truncated list can NEVER be mistaken for a short series. The
+    2026-08-02 bug this closes: `if not rows: break` treated an empty render as
+    end-of-list, so a 890-chapter series scraped 4 of its 360 pager pages and
+    the download started at chapter 871.
+    """
+
+
+def _comix_profile_dir() -> str:
+    """Absolute path to the app-owned Chromium user-data dir for comix.
+
+    WHY a persistent profile: the old code launched a virgin headless context in
+    every process, which is the most bot-like possible fingerprint and is the
+    main reason the WAF fires "sometimes". Persisting the whole PROFILE (rather
+    than picking cookies out of it) means we never hardcode a cookie name the
+    site can rename — cookies, localStorage, and the reader `preload=all`
+    setting all survive across runs, and one human solve covers days.
+
+    Deliberately app-owned and NOT the user's real Chrome profile (considered
+    and rejected 2026-08-02): Chromium locks a user-data dir, so pointing at the
+    real one would fail whenever Chrome is open, and it would mean the
+    downloader reads the user's actual browsing data.
+
+    Override with AIO_COMIX_PROFILE_DIR. Delete the directory to force a fresh
+    session (the next challenge then needs another manual solve).
+    """
+    override = (os.environ.get("AIO_COMIX_PROFILE_DIR") or "").strip()
+    if override:
+        return os.path.abspath(override)
+    if sys.platform == "win32":
+        root = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
+    elif sys.platform == "darwin":
+        root = os.path.join(os.path.expanduser("~"), "Library", "Application Support")
+    else:
+        root = os.environ.get("XDG_CACHE_HOME") or os.path.join(
+            os.path.expanduser("~"), ".cache"
+        )
+    return os.path.join(root, "AIO-Webtoon-Downloader", "comix-profile")
+
+
+def _extract_group_id(url: Optional[str]) -> Optional[str]:
+    """Return the ``group_id`` query value from a comix title URL, or None.
+
+    The user pasting /title/<hid>-<slug>?group_id=4856 is asking for ONE
+    scanlation group, and comix honors that filter server-side. Honoring it is
+    worth a lot: on Magic Emperor it collapses the chapter list from 360 pager
+    pages (rows are per chapter × group) to 59 with one row per chapter.
+
+    Cross-file: consumed in get_chapters; captured in fetch_comic_context
+    because that method overwrites comic["url"] with the canonical
+    query-less URL from the #initial-data blob, so the caller's URL is the only
+    place the filter survives. Grep _group_id.
+    """
+    if not url:
+        return None
+    try:
+        query = urlparse(url).query
+    except Exception:
+        return None
+    if not query:
+        return None
+    values = parse_qs(query).get("group_id") or []
+    for value in values:
+        value = (value or "").strip()
+        # Digits only — the value is interpolated back into a URL we navigate.
+        if value and value.isdigit():
+            return value
+    return None
+
+
+def _coerce_chapter_number(
+    href: Optional[str], label: Optional[str] = None
+) -> Optional[float]:
+    """Best-effort numeric chapter number for a scraped row, or None.
+
+    Only used by the early-stop check in fetch_chapters_via_dom, so a None
+    (an unparseable special/oneshot) simply doesn't vote on whether to stop —
+    it never drops the row itself. Prefers the href because
+    `/title/{slug}/{id}-chapter-{n}` is machine-generated, and falls back to
+    the "Ch.<n>" display label.
+    """
+    if href:
+        m = re.search(r"-chapter-(\d+(?:\.\d+)?)", href)
+        if m:
+            try:
+                return float(m.group(1))
+            except ValueError:
+                pass
+    if label:
+        m = re.search(r"(\d+(?:\.\d+)?)", label)
+        if m:
+            try:
+                return float(m.group(1))
+            except ValueError:
+                pass
+    return None
 
 
 class ComixSiteHandler(BaseSiteHandler):
@@ -191,8 +401,16 @@ class ComixSiteHandler(BaseSiteHandler):
 
         Cross-file: same idiom as upstream comix.py's _cf_aware_request;
         ported here on top of the local persistent-browser bridge.
+
+        Also the HTTP-side chokepoint for comix's FIRST-PARTY WAF interstitial
+        (see _looks_like_waf_challenge). That one 200s with challenge HTML, so
+        without this check fetch_comic_context would parse it, find no
+        #initial-data, and silently fall through to its slug-derived-title
+        fallback — writing a junk title/author/cover into the library instead of
+        failing. Grep _waf_recover_once for the handoff.
         """
         response = make_request(url, scraper)
+        response = self._waf_recover_once(response, url, scraper, make_request)
         if _CF_AVAILABLE and response.status_code in (403, 503):
             try:
                 if is_cf_challenge(response.status_code, response.text):
@@ -218,6 +436,75 @@ class ComixSiteHandler(BaseSiteHandler):
                 # response so the caller's own error path runs.
                 pass
         return response
+
+    def _waf_recover_once(self, response, url: str, scraper, make_request):
+        """If *response* is comix's interactive WAF interstitial, hand the
+        browser to the user, adopt the cookies their solve produced, and retry
+        the request ONCE. Returns the (possibly new) response.
+
+        Raises ComixWafChallengeError when the challenge is still in front of us
+        afterwards. Failing loud is deliberate: the caller's next step is to
+        parse this body, and every parser in this module degrades a challenge
+        page into plausible-looking garbage rather than an error.
+
+        The cookie adoption is what makes an HTTP retry meaningful at all — the
+        human solves inside the Patchright profile, so without copying that
+        session across, cloudscraper would just re-fetch the interstitial. Same
+        idea as crawlee_utils.sync_cf_cookies, but sourced from our own
+        persistent context rather than the zendriver cache.
+        """
+        try:
+            final_url = getattr(response, "url", None) or url
+            body = getattr(response, "text", None)
+        except Exception:
+            return response
+        if not _looks_like_waf_challenge(final_url, body):
+            return response
+
+        print(
+            "[!] Comix: hit the site's human-verification check "
+            "(/@waf/challenge) on a metadata request.",
+            flush=True,
+        )
+        result = _COMIX_BROWSER_BRIDGE.solve_waf_interactively(url) or {}
+        if result.get("solved"):
+            for cookie in result.get("cookies") or []:
+                try:
+                    scraper.cookies.set(
+                        cookie["name"],
+                        cookie["value"],
+                        domain=cookie.get("domain") or "comix.to",
+                        path=cookie.get("path") or "/",
+                    )
+                except Exception:
+                    continue
+            user_agent = result.get("user_agent")
+            if user_agent:
+                # CF and most WAFs bind a clearance cookie to the UA that earned
+                # it, so the retry has to present the browser's UA, not
+                # cloudscraper's.
+                try:
+                    scraper.headers["User-Agent"] = user_agent
+                except Exception:
+                    pass
+            retried = make_request(url, scraper)
+            if not _looks_like_waf_challenge(
+                getattr(retried, "url", None) or url,
+                getattr(retried, "text", None),
+            ):
+                print("[*] Comix: verification accepted; continuing.", flush=True)
+                return retried
+            response = retried
+
+        raise ComixWafChallengeError(
+            "comix.to is asking for human verification and it was not completed, "
+            "so the request could not be trusted. Open "
+            f"{_WAF_CHALLENGE_HINT_URL} in a browser, complete the 'Verify "
+            "you're human' check once, then re-run. (The downloader keeps its "
+            f"own browser profile at {_comix_profile_dir()} — solving it in the "
+            "window the downloader opens is what makes the session stick.)",
+            challenge_url=getattr(response, "url", None) or url,
+        )
 
     def _extract_initial_data_manga(self, soup) -> Optional[Dict]:
         """Return the full manga-detail dict from the title page's SSR
@@ -422,6 +709,17 @@ class ComixSiteHandler(BaseSiteHandler):
         elif url and not api_url_value:
             manga_data["url"] = url
 
+        # Preserve the caller's ?group_id= filter. It MUST be captured here:
+        # the branch directly above replaces comic["url"] with #initial-data's
+        # canonical (query-less) path, so this is the last point at which the
+        # user's URL is still visible. get_chapters re-appends it to the URL it
+        # hands the DOM scrape. Worth the plumbing — comix honors the filter
+        # server-side, turning 360 pager pages into 59 on a long multi-group
+        # series (rows are per chapter × group). Grep _group_id.
+        group_id = _extract_group_id(url)
+        if group_id:
+            manga_data["_group_id"] = group_id
+
         list_mappings = {
             "genres": ["genres", "genre"],
             "theme": ["theme"],
@@ -465,6 +763,27 @@ class ComixSiteHandler(BaseSiteHandler):
         # constructed a context manually without a URL.
         title_url = context.comic.get("url") or f"https://comix.to/title/{hash_id}"
 
+        # Re-attach the user's ?group_id= filter (captured in
+        # fetch_comic_context, which strips the query when it adopts
+        # #initial-data's canonical URL). Scoping the list to one group is the
+        # single biggest cost lever on this site — 6x fewer pager pages on a
+        # 4-group series — and it is what the user asked for by pasting that
+        # URL. Trade-off, accepted 2026-08-02: sites/base.py's
+        # select_best_chapter_version then has only one version per chapter to
+        # rank, i.e. the explicit group choice wins over cross-group ranking.
+        # Same escape-hatch philosophy as the `--group <name>` branch (see the
+        # group-selection invariant in CLAUDE.md). Absent group_id → unchanged
+        # full cross-group behavior.
+        group_id = context.comic.get("_group_id")
+        if group_id:
+            separator = "&" if "?" in title_url else "?"
+            title_url = f"{title_url}{separator}group_id={group_id}"
+            print(
+                f"[*] Comix: scoping the chapter list to group_id={group_id} "
+                f"(from the URL you supplied).",
+                flush=True,
+            )
+
         # 2026-07-11: /api/v1/manga/{hid}/chapters is signed + encrypted
         # ({"e":...}) and 403s "Missing token." to cloudscraper, so the chapter
         # list is only obtainable from the rendered DOM. The persistent
@@ -478,7 +797,14 @@ class ComixSiteHandler(BaseSiteHandler):
             "(the JSON API is encrypted/token-gated).",
             flush=True,
         )
-        raw_items = _COMIX_BROWSER_BRIDGE.fetch_chapters_via_dom(title_url) or []
+        # chapter_floor_hint is advisory (sites/base.py): comix lists
+        # newest-first, so an update run that only wants chapters > N can stop
+        # paginating as soon as a whole page falls below N instead of walking
+        # all 360 pages. None (a full download) paginates to the end as before.
+        raw_items = _COMIX_BROWSER_BRIDGE.fetch_chapters_via_dom(
+            title_url,
+            chapter_floor=getattr(self, "chapter_floor_hint", None),
+        ) or []
 
         chapters: List[Dict] = []
         for item in raw_items:
@@ -593,14 +919,21 @@ class ComixSiteHandler(BaseSiteHandler):
                 "chap": chap_str,
                 "title": title,
                 "id": chap_id,
+                "_groups": (
+                    [GroupInfo(
+                        name=group_name,
+                        group_id=group_info.get("id") if group_info else None,
+                    )] if group_name else []
+                ),
                 "group": group_name,
+                # comix is one of only two sites that reports a real vote
+                # count (mangataro's API path is the other), so the ranker's
+                # upvote tier actually engages here — as a weak tiebreak below
+                # MTL/official/track-record, not as the decider it used to be.
                 "up_count": item.get("votes", 0),
             })
 
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        return chapter_version.get("group")
 
     # Module-level TTL constant used by _get/_cache_chapter_images.
     # Defined here (class-scope) instead of top-of-file so it stays
@@ -985,11 +1318,31 @@ class _ComixBrowserSession:
         # we synced into _context. Used by _sync_cf_cookies to skip
         # redundant add_cookies calls when the cache hasn't changed.
         self._last_cf_cookie_ts: float = 0.0
+        # Which mode the live context was launched in. The headed WAF handoff
+        # has to tear down and relaunch (headless is fixed at launch time and
+        # Chromium locks the profile dir to one context), so _start compares
+        # against this to decide whether the cached context is reusable.
+        self._headless: bool = True
 
-    def _start(self) -> bool:
+    def _start(self, headless: bool = True) -> bool:
         """Lazy-launch Patchright on first use. Returns True if the browser
         is ready, False if Patchright/Playwright unavailable or launch failed.
-        Subsequent calls are cheap (already-started fast path)."""
+        Subsequent calls are cheap (already-started fast path).
+
+        Launches a PERSISTENT context against the app-owned profile dir
+        (_comix_profile_dir) rather than a throwaway one. That single change is
+        the main defense against comix's WAF: a virgin profile per process is
+        the most bot-like fingerprint available, and persisting the profile
+        means a human solve survives across runs AND across processes (search,
+        download, and the UI's per-series subprocesses all share it).
+
+        ``headless`` is fixed at launch time by Chromium, and the profile dir
+        can only be held by ONE context at a time, so switching modes (the WAF
+        handoff) means a full teardown + relaunch — hence the mode comparison on
+        the fast path.
+        """
+        if self._page is not None and self._headless != headless:
+            self._cleanup()
         if self._page is not None:
             # CX-1: a non-None page is NOT proof of health. A mid-run browser
             # or context crash leaves the dead page object in place; reusing
@@ -1001,6 +1354,10 @@ class _ComixBrowserSession:
             # launch block below on the same call.
             try:
                 page_dead = self._page.is_closed()
+                # With launch_persistent_context there is no Browser handle to
+                # ask (context.browser is documented as None for persistent
+                # contexts), so the page's own liveness is the primary signal
+                # and the browser check only runs when a handle exists.
                 browser_dead = (
                     self._browser is not None and not self._browser.is_connected()
                 )
@@ -1029,21 +1386,33 @@ class _ComixBrowserSession:
             print(f"[!] Comix Playwright start failed: {e}")
             return False
         try:
-            self._browser = self._pw.chromium.launch(
-                headless=True,
-                args=["--no-sandbox", "--disable-setuid-sandbox"],
-            )
-            # Create an explicit context so we can (a) match the UA that
-            # zendriver used to solve CF and (b) inject cookies after the
-            # fact. The cached UA is set at context-creation because it
-            # cannot be changed on an existing context — if no CF solve
-            # has happened yet, Patchright's default stealth UA is used.
+            # Persistent context: cookies, localStorage and the reader's
+            # preload setting live in this directory and survive process exit,
+            # so one human WAF solve keeps working for days. See
+            # _comix_profile_dir for why app-owned rather than the real Chrome
+            # profile. The UA kwarg still matches whatever zendriver used for a
+            # CF solve (CF binds cf_clearance to the UA); it can only be set at
+            # context creation, never on a live context.
+            profile_dir = _comix_profile_dir()
+            os.makedirs(profile_dir, exist_ok=True)
             ctx_kwargs: Dict[str, Any] = {}
             cached_ua = self._cached_cf_user_agent()
             if cached_ua:
                 ctx_kwargs["user_agent"] = cached_ua
-            self._context = self._browser.new_context(**ctx_kwargs)
-            self._page = self._context.new_page()
+            self._context = self._pw.chromium.launch_persistent_context(
+                profile_dir,
+                headless=headless,
+                args=["--no-sandbox", "--disable-setuid-sandbox"],
+                **ctx_kwargs,
+            )
+            self._headless = headless
+            # A persistent context opens with one about:blank page already;
+            # reuse it so we don't leave an orphan tab holding the profile.
+            existing = list(getattr(self._context, "pages", None) or [])
+            self._page = existing[0] if existing else self._context.new_page()
+            # Documented as None for persistent contexts on some versions;
+            # kept only so the health check can use it when it IS available.
+            self._browser = getattr(self._context, "browser", None)
         except Exception as e:
             print(f"[!] Comix Playwright launch failed: {e}")
             self._cleanup()
@@ -1110,6 +1479,10 @@ class _ComixBrowserSession:
         return True
 
     def _cleanup(self):
+        # context.close() on a persistent context is what FLUSHES cookies and
+        # localStorage to the profile dir. Skipping it (or killing the process
+        # mid-run) can lose a freshly-solved WAF session, so the WAF handoff
+        # always closes through here rather than abandoning the context.
         try:
             if self._context is not None:
                 self._context.close()
@@ -1130,6 +1503,7 @@ class _ComixBrowserSession:
         self._pw = None
         self._page = None
         self._last_cf_cookie_ts = 0.0
+        self._headless = True
 
     def _cached_cf_user_agent(self) -> Optional[str]:
         """Return the User-Agent string from any cached zendriver CF solve
@@ -1208,6 +1582,248 @@ class _ComixBrowserSession:
                 f"{type(exc).__name__}: {exc}",
                 flush=True,
             )
+
+    def _waf_blocked(self, context_label: str) -> bool:
+        """True if the page currently shows comix's human-verification check.
+
+        Called after every navigation and every pager click. Cheap: reads
+        page.url first (the authoritative signal) and only pays for a body read
+        when the URL is inconclusive.
+        """
+        page = self._page
+        if page is None:
+            return False
+        try:
+            current_url = page.url
+        except Exception:
+            return False
+        if _looks_like_waf_challenge(current_url):
+            print(
+                f"[!] Comix: human-verification check hit during "
+                f"{context_label} ({current_url}).",
+                flush=True,
+            )
+            return True
+        # URL didn't say so — sniff the visible copy. Guarded because a
+        # mid-navigation evaluate can throw.
+        try:
+            body_text = page.evaluate(
+                "document.body ? document.body.innerText.slice(0, 2000) : ''"
+            ) or ""
+        except Exception:
+            return False
+        if _looks_like_waf_challenge(None, body_text):
+            print(
+                f"[!] Comix: human-verification check hit during "
+                f"{context_label} (interstitial body).",
+                flush=True,
+            )
+            return True
+        return False
+
+    def _enforce_no_waf(self, stage: str, return_url: Optional[str] = None) -> None:
+        """No-op unless the WAF interstitial is up; otherwise attempt ONE
+        interactive handoff and raise ComixWafChallengeError if it doesn't pass.
+
+        Shared by the chapter-list and chapter-image scrapes so both fail the
+        same way. Search deliberately does NOT use this — see
+        ComixSiteHandler.search for why a raise there would blocklist the host.
+        """
+        if not self._waf_blocked(stage):
+            return
+        challenge_url = None
+        try:
+            challenge_url = self._page.url
+        except Exception:
+            pass
+        if (self.solve_waf_interactively(return_url) or {}).get("solved"):
+            return
+        raise ComixWafChallengeError(
+            "comix.to is asking for human verification and it was not "
+            f"completed, so {stage} could not be read. Re-run and complete the "
+            "check in the window the downloader opens, or visit comix.to in a "
+            "browser and pass it once.",
+            challenge_url=challenge_url,
+        )
+
+    def solve_waf_interactively(self, return_url: Optional[str] = None) -> Dict[str, Any]:
+        """Open the downloader's own browser profile VISIBLY on comix's
+        human-verification page and wait for the user to complete it.
+
+        Returns {"solved": bool, "cookies": [...], "user_agent": str|None,
+        "reason": str}. Never raises — callers decide whether an unsolved
+        challenge is fatal (it is, for chapter lists and metadata).
+
+        What this does NOT do, deliberately: it does not read, score, rotate, or
+        submit the widget, and it sends no synthetic input. It navigates, prints
+        an instruction, and POLLS the URL until the site itself decides the
+        check passed. The solve is the user's.
+
+        Why it works at all: the visible window runs on the SAME persistent
+        profile dir as the headless one (_comix_profile_dir), so the session the
+        user's solve produces is written straight into the profile the rest of
+        the run uses. We relaunch headless afterwards and the caller retries.
+        The returned cookies additionally let the plain-HTTP path
+        (ComixSiteHandler._waf_recover_once) adopt the same session, which it
+        otherwise could not see.
+        """
+        global _COMIX_WAF_HANDOFF_ATTEMPTED
+        result: Dict[str, Any] = {"solved": False, "cookies": [], "user_agent": None}
+
+        if (os.environ.get(_WAF_NO_INTERACTIVE_ENV) or "").strip() not in ("", "0"):
+            result["reason"] = "disabled"
+            print(
+                f"[!] Comix: {_WAF_NO_INTERACTIVE_ENV} is set; not opening a "
+                f"verification window.",
+                flush=True,
+            )
+            return result
+
+        # Headless Linux boxes have nowhere to show the window. Windows/macOS
+        # always have a session available to the desktop app and the CLI.
+        if sys.platform not in ("win32", "darwin") and not (
+            os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+        ):
+            result["reason"] = "no_display"
+            print(
+                "[!] Comix: no display available, so the verification window "
+                "cannot be shown.",
+                flush=True,
+            )
+            return result
+
+        with _COMIX_WAF_HANDOFF_LOCK:
+            if _COMIX_WAF_HANDOFF_ATTEMPTED:
+                result["reason"] = "already_attempted"
+                return result
+            _COMIX_WAF_HANDOFF_ATTEMPTED = True
+
+        try:
+            timeout_s = float(
+                os.environ.get(_WAF_SOLVE_TIMEOUT_ENV)
+                or _WAF_DEFAULT_SOLVE_TIMEOUT_S
+            )
+        except (TypeError, ValueError):
+            timeout_s = _WAF_DEFAULT_SOLVE_TIMEOUT_S
+
+        target = return_url or _WAF_CHALLENGE_HINT_URL
+        # Drop the headless context first — Chromium locks the profile dir to a
+        # single context, and closing is also what flushes state to disk.
+        self._cleanup()
+        if not self._start(headless=False):
+            result["reason"] = "launch_failed"
+            print(
+                "[!] Comix: could not open a visible browser for verification.",
+                flush=True,
+            )
+            self._cleanup()
+            self._start(headless=True)
+            return result
+
+        page = self._page
+        try:
+            page.goto(target, wait_until="domcontentloaded", timeout=30000)
+        except Exception as exc:
+            print(
+                f"[!] Comix: could not load the verification page "
+                f"({type(exc).__name__}: {exc}).",
+                flush=True,
+            )
+
+        # Every line is [!]-prefixed on purpose. The Electron LogPanel classifies
+        # by line shape (UI-source/electron/log-filter.js:classifyLogLevel):
+        # a leading "[!]" paints the line as an error, while a line starting
+        # with 2+ spaces is demoted to "verbose" — so an indented banner would
+        # render the one instruction the user MUST read as dim filler.
+        print("[!] " + "=" * 68, flush=True)
+        print(
+            "[!] ACTION NEEDED - comix.to is asking for human verification.",
+            flush=True,
+        )
+        print(
+            "[!] A browser window just opened. Complete the check in it: drag",
+            flush=True,
+        )
+        print(
+            "[!] the slider until the picture lines up, then press Verify.",
+            flush=True,
+        )
+        print(
+            f"[!] The download resumes by itself once it passes (waiting up to "
+            f"{int(timeout_s)}s).",
+            flush=True,
+        )
+        print(
+            "[!] The session is saved to disk, so this should be rare.",
+            flush=True,
+        )
+        print("[!] " + "=" * 68, flush=True)
+
+        deadline = time.monotonic() + timeout_s
+        solved = False
+        while time.monotonic() < deadline:
+            try:
+                if page.is_closed():
+                    # User closed the window. Treat as a decision to abort
+                    # rather than waiting out the full timeout.
+                    print(
+                        "[!] Comix: verification window was closed before the "
+                        "check completed.",
+                        flush=True,
+                    )
+                    result["reason"] = "window_closed"
+                    break
+                current = page.url
+            except Exception:
+                result["reason"] = "window_lost"
+                break
+            if current and not _looks_like_waf_challenge(current):
+                # The site routed us off the interstitial — that IS the pass
+                # signal (it redirects back to ?return=). Small settle wait so
+                # the Set-Cookie lands before we read cookies.
+                try:
+                    page.wait_for_timeout(1500)
+                except Exception:
+                    pass
+                solved = True
+                break
+            try:
+                page.wait_for_timeout(1000)
+            except Exception:
+                break
+
+        if solved:
+            print("[*] Comix: verification passed - thanks. Resuming.", flush=True)
+            try:
+                result["cookies"] = [
+                    {
+                        "name": c.get("name"),
+                        "value": c.get("value"),
+                        "domain": c.get("domain"),
+                        "path": c.get("path"),
+                    }
+                    for c in (self._context.cookies() or [])
+                    if c.get("name") and c.get("value")
+                ]
+            except Exception:
+                result["cookies"] = []
+            try:
+                result["user_agent"] = self._page.evaluate("navigator.userAgent")
+            except Exception:
+                result["user_agent"] = None
+            result["solved"] = True
+        elif not result.get("reason"):
+            result["reason"] = "timeout"
+            print(
+                f"[!] Comix: verification not completed within {int(timeout_s)}s.",
+                flush=True,
+            )
+
+        # Back to headless for the rest of the run. The close flushes the
+        # solved session into the profile dir, so the relaunch inherits it.
+        self._cleanup()
+        self._start(headless=True)
+        return result
 
     def fetch_search_via_dom(
         self,
@@ -1334,6 +1950,29 @@ class _ComixBrowserSession:
                 body_text = page.evaluate(
                     "document.body ? document.body.innerText.slice(0, 300) : ''"
                 ) or ""
+                # Name the actual cause. Search deliberately does NOT raise or
+                # trigger the interactive handoff (see ComixSiteHandler.search:
+                # a raise would poison the orchestrator's persistent
+                # ProbeFailureCache and blocklist comix.to for an hour, and
+                # popping a window mid-search would interrupt a cross-site
+                # search the user is watching). Reporting it accurately is the
+                # whole win here — this used to read as "no results", which
+                # looks like the series simply isn't on comix.
+                waf_url = ""
+                try:
+                    waf_url = page.url or ""
+                except Exception:
+                    pass
+                if _looks_like_waf_challenge(waf_url, body_text):
+                    print(
+                        f"[!] Comix search: skipped {clean!r} — comix.to is "
+                        f"showing its human-verification check. Run a comix "
+                        f"download (or open comix.to in a browser) and pass it "
+                        f"once; the session is saved and search will work "
+                        f"again.",
+                        flush=True,
+                    )
+                    return []
                 cf_msg = ""
                 if _CF_AVAILABLE:
                     try:
@@ -1397,16 +2036,18 @@ class _ComixBrowserSession:
     def fetch_chapters_via_dom(
         self,
         title_url: str,
-        max_pages: int = 500,
-        time_budget_s: float = 300.0,
+        max_pages: int = 0,
+        time_budget_s: float = 0.0,
+        chapter_floor: Optional[float] = None,
     ) -> List[Dict]:
-        """Paginate the title page (`?page=N`) in the persistent browser and
-        scrape chapter rows from the rendered DOM. Used when the JSON API
-        path returns 0 items because comix.to's `/api/v1/manga/{hid}/chapters`
-        now responds with an encrypted blob (`{"e": "<base64-ish>"}`) that
-        we can't decode in Python — the page's bundle decrypts it via a
-        module-scoped routine that isn't exposed on `window`, so calling it
-        from `page.evaluate` isn't reachable.
+        """Paginate the title page in the persistent browser and scrape chapter
+        rows from the rendered DOM. The JSON API can't be used: it is
+        per-request HMAC-signed AND returns an encrypted body, and the
+        signature covers the query string (verified 2026-08-02: replaying a
+        valid token with `limit=200` instead of `limit=20` → 403 "Invalid
+        token"), so we can neither forge a call nor widen the page size. The
+        chapter rows are also absent from the SSR HTML — `?page=5` returns
+        byte-identical HTML to `?page=1`. The browser is genuinely required.
 
         Returns API-item-shaped dicts so the handler's existing per-item
         processing loop (chap_str normalization, lenient language filter,
@@ -1416,26 +2057,45 @@ class _ComixBrowserSession:
         URL implicitly already filters to whichever language the user
         landed on; the lenient filter treats None as "keep" anyway.
 
-        Pagination strategy:
-          - Iterate page=1,2,3… via `page.goto`. Each navigation is ~1s
-            with `wait_for_selector(".mchap-row__primary", timeout=10s)`
-            instead of a fixed sleep, and the persistent browser keeps
-            warm so subsequent navs reuse the same TCP/TLS session.
-          - Dedupe by chap_id across pages — comix's pagination occasionally
-            overlaps the boundary chapter between adjacent pages, so naive
-            concatenation would double-count.
-          - Print a progress line every 20 pages so the UI / CLI user
-            doesn't think the process is hung during long scrapes.
+        REWRITTEN 2026-08-02 around the site's own pager (`.npager`). The old
+        loop navigated `?page=N` and treated an empty scrape as end-of-list:
 
-        Time budget: default 300s. One Piece is the long-tail outlier
-        (~180 pages * 1s in the warm-browser case = ~3 min); most series
-        fit well under a minute. Truncated runs surface a stderr warning
-        AND return the partial list — better than a hard fail, and the
-        caller's chapter range (`--chapters`) can clip to whatever was
-        scraped.
+            if not rows: break     # silent on every page after the first
 
-        Returns empty list on any error so the caller's None-vs-[] check
-        still works as a sentinel for "API exhausted, scrape exhausted".
+        That cannot distinguish "past the last page" from "the render hadn't
+        finished" or "a WAF interstitial is in front of us", and rows are per
+        (chapter x group) so a 4-group series only yields ~5 distinct chapters
+        per 20-row page. Live failure it caused: Magic Emperor has 360 pager
+        pages; the scrape stopped at page 5, collected 78 rows = 20 distinct
+        chapters, and the download started at chapter 871 instead of 1 — with
+        no warning at all.
+
+        Three rules now hold:
+          1. The pager is GROUND TRUTH. One click on "Last page" reports the
+             real total up front (verified: 360 unfiltered, 59 with
+             ?group_id=), which becomes both the loop bound and the completion
+             test. `.npager__num.is-active` is the freshness signal, replacing
+             the old first-row-href diff that returned instantly on stale DOM
+             during the React swap.
+          2. An empty page is a FAILURE, not an ending, unless the pager says
+             we're on the last page. It retries once, then raises.
+          3. Pagination is CLIENT-SIDE ("Next page" clicks), not a full
+             `page.goto` per page. 360 SPA cold boots per series was both slow
+             and the most bot-like thing this handler did — the WAF fires on
+             behavior, so this directly reduces how often we get challenged.
+
+        Raises ComixChapterScrapeError / ComixWafChallengeError rather than
+        returning a short list. A truncated list is worse than an error: it is
+        persisted to .aio_series.json as though it were the whole series, so
+        every later update run inherits the truncation.
+
+        ``chapter_floor`` is the advisory early-stop from
+        BaseSiteHandler.chapter_floor_hint: comix sorts newest-first, so an
+        update run that only wants chapters above N stops as soon as a whole
+        page falls below N. None = walk to the end.
+
+        ``max_pages`` / ``time_budget_s`` default to 0 = "derive from the
+        pager". Explicit non-zero values still cap, for callers that want one.
         """
         if not self._start():
             return []
@@ -1464,153 +2124,341 @@ class _ComixBrowserSession:
                 };
             });
         }"""
-        # Drop any trailing ?query so we can append our own pagination param
-        # cleanly. comix accepts ?page=N on the title page and the React
-        # router uses that to drive the chapter-list state.
-        base = title_url.split("?", 1)[0]
+        # Preserve any existing query (notably ?group_id= appended by
+        # get_chapters) and add page=N to it. The old code did
+        # `title_url.split("?", 1)[0]`, which silently discarded the user's
+        # group filter — the difference between 59 and 360 pages to walk.
+        base_url, _sep, base_query = title_url.partition("?")
+
+        def _page_url(n: int) -> str:
+            prefix = f"{base_query}&" if base_query else ""
+            return f"{base_url}?{prefix}page={n}"
+
+        # ── Pager helpers. `.npager` is the site's OWN pagination control and
+        # the only trustworthy statement of how many pages exist. Reading it is
+        # what lets an empty row list be treated as a failure rather than as
+        # end-of-list — the conflation that truncated Magic Emperor at page 5
+        # of 360. Shape verified live 2026-08-02: windowed `.npager__num`
+        # buttons, `.is-active` on the current one, and First/Previous/Next/Last
+        # buttons identified by aria-label.
+        pager_js = """() => {
+            const nav = document.querySelector('.npager');
+            if (!nav) return null;
+            const values = [];
+            let active = null;
+            for (const b of nav.querySelectorAll('.npager__num')) {
+                const v = parseInt((b.textContent || '').trim(), 10);
+                if (!Number.isFinite(v)) continue;
+                values.push(v);
+                if (b.classList.contains('is-active')) active = v;
+            }
+            const enabled = (label) => {
+                const b = Array.from(nav.querySelectorAll('button')).find(
+                    x => (x.getAttribute('aria-label') || '').toLowerCase() === label);
+                return !!b && !b.disabled;
+            };
+            return {
+                active: active,
+                max: values.length ? Math.max.apply(null, values) : null,
+                hasNext: enabled('next page'),
+                hasLast: enabled('last page'),
+            };
+        }"""
+
+        def _read_pager() -> Optional[Dict[str, Any]]:
+            try:
+                return self._page.evaluate(pager_js)
+            except Exception:
+                return None
+
+        def _click_pager(aria_label: str) -> bool:
+            """Click a pager button by aria-label. Client-side route change —
+            no document reload, which is both ~5x faster than page.goto and far
+            less bot-like (360 SPA cold boots per series was the most
+            challenge-provoking thing this handler did)."""
+            js = """(label) => {
+                const nav = document.querySelector('.npager');
+                if (!nav) return false;
+                const b = Array.from(nav.querySelectorAll('button')).find(
+                    x => (x.getAttribute('aria-label') || '').toLowerCase() === label);
+                if (!b || b.disabled) return false;
+                b.click();
+                return true;
+            }"""
+            try:
+                return bool(self._page.evaluate(js, aria_label))
+            except Exception:
+                return False
+
+        def _rows_rendered() -> int:
+            try:
+                return int(
+                    self._page.evaluate(
+                        "document.querySelectorAll('.mchap-item').length"
+                    ) or 0
+                )
+            except Exception:
+                return 0
+
+        def _wait_for_pager(check, timeout_s: float = 15.0) -> Optional[Dict[str, Any]]:
+            """Poll the pager until `check(state)` holds; return that state or
+            None on timeout.
+
+            Needed because "rows are on screen" says nothing about WHICH page
+            they belong to — comix swaps row content in place, so the previous
+            page's rows outlive a click. Callers therefore assert on pager
+            state (active number, Next availability) rather than on rows.
+            """
+            end = _time.monotonic() + timeout_s
+            while _time.monotonic() < end:
+                state = _read_pager()
+                if state:
+                    try:
+                        if check(state):
+                            return state
+                    except Exception:
+                        pass
+                try:
+                    self._page.wait_for_timeout(250)
+                except Exception:
+                    break
+            return None
+
+        def _wait_for_page(expected: Optional[int], timeout_s: float = 15.0) -> bool:
+            """Block until rows are rendered AND (when known) the pager reports
+            `expected` as the active page.
+
+            The active-page number replaces the old first-row-href diff. That
+            diff was unreliable in exactly the case that mattered: comix's React
+            list swaps row CONTENT without unmounting, so the previous page's
+            nodes survive the navigation and an href comparison can pass on
+            stale DOM — or, on a slow render, time out and leave the caller
+            scraping an empty list that it then read as end-of-list.
+            """
+            end = _time.monotonic() + timeout_s
+            while _time.monotonic() < end:
+                if _rows_rendered() > 0:
+                    if expected is None:
+                        return True
+                    state = _read_pager()
+                    # No pager at all = single-page series; rows are enough.
+                    # Otherwise demand an EXACT active-page match: accepting a
+                    # transient active=None would let a mid-render read pass on
+                    # the previous page's still-mounted rows, which is the
+                    # stale-DOM failure this whole rewrite exists to kill.
+                    if state is None:
+                        return True
+                    if state.get("active") == expected:
+                        return True
+                try:
+                    self._page.wait_for_timeout(250)
+                except Exception:
+                    break
+            return False
+
+        def _waf_guard(stage: str) -> None:
+            self._enforce_no_waf(stage, _page_url(1))
+
         items: List[Dict] = []
         seen_ids: set = set()
-        deadline = _time.monotonic() + time_budget_s
-        # Track the first row's href from the previous scrape. Critical for
-        # correctness on back-to-back goto: comix's React component swaps
-        # row CONTENT without unmounting, so the OLD page's `.mchap-row__primary`
-        # nodes survive long enough that a naïve `wait_for_selector` returns
-        # instantly on stale DOM, we re-scrape the previous page's chap_ids,
-        # every row is a dup, and the consecutive_dup early-break fires a
-        # false end-of-list. Waiting for the first row's href to differ
-        # from the previous page is the cheapest reliable freshness signal.
-        prev_first_href: Optional[str] = None
-        consecutive_dup_pages = 0
-        for page_n in range(1, max_pages + 1):
-            if _time.monotonic() > deadline:
-                print(
-                    f"[!] Comix DOM scrape time budget ({time_budget_s:.0f}s) "
-                    f"exceeded at page {page_n}; returning {len(items)} chapters "
-                    f"(use --chapters to limit). Series may be truncated.",
-                    flush=True,
-                )
-                break
-            url = f"{base}?page={page_n}"
+
+        # ── Page 1 lands via a real navigation; every later page is a pager
+        # click on the already-loaded SPA.
+        try:
+            self._page.goto(
+                _page_url(1), wait_until="domcontentloaded", timeout=30000
+            )
+        except Exception as e:
+            raise ComixChapterScrapeError(
+                f"comix chapter list: could not load {_page_url(1)} "
+                f"({type(e).__name__}: {e})."
+            ) from e
+        _waf_guard("the chapter list")
+        if not _wait_for_page(None, 20.0):
+            # Retry the navigation once — a cold SPA boot behind a slow network
+            # can exceed 20s, and this is cheap next to failing the run.
             try:
-                self._page.goto(url, wait_until="domcontentloaded", timeout=30000)
-                # Page 1 has no prior page to diff against — fall back to
-                # the simple "any chapter row exists" signal. Subsequent
-                # pages wait for the React swap to actually happen.
-                if prev_first_href is None:
+                self._page.goto(
+                    _page_url(1), wait_until="domcontentloaded", timeout=30000
+                )
+            except Exception:
+                pass
+            _waf_guard("the chapter list")
+
+        if _rows_rendered() == 0:
+            # Rich diagnostics before failing: a sandboxed Chromium can
+            # masquerade a CF challenge or a renamed selector as an empty
+            # series, and these three facts distinguish them.
+            detail = ""
+            try:
+                page_title = self._page.title() or "(no title)"
+                page_url = self._page.url
+                body_text = self._page.evaluate(
+                    "document.body ? document.body.innerText.slice(0, 500) : ''"
+                ) or ""
+                snippet = body_text.replace("\n", " ").strip()
+                primary_count = self._page.evaluate(
+                    "document.querySelectorAll('.mchap-row__primary').length"
+                )
+                cf_msg = ""
+                if _CF_AVAILABLE:
                     try:
-                        self._page.wait_for_selector(".mchap-row__primary", timeout=10000)
-                    except Exception as wait_exc:
-                        # Surface why the scrape gave up on page 1. The prior
-                        # silent break made "comix returns 0 chapters"
-                        # debugging opaque — sandboxed Chromium can silently
-                        # masquerade a CF challenge or a slow SPA render as
-                        # an empty series. Dump page title/URL/body-text +
-                        # CF-challenge sniff so the user can tell which.
-                        # Diagnostic-only; control flow still breaks after.
-                        # Cross-file: is_cf_challenge in sites/crawlee_utils.py.
-                        try:
-                            page_title = self._page.title() or "(no title)"
-                            page_url = self._page.url
-                            body_text = self._page.evaluate(
-                                "document.body ? document.body.innerText.slice(0, 500) : ''"
-                            ) or ""
-                            snippet = body_text.replace("\n", " ").strip()
-                            cf_msg = ""
-                            if _CF_AVAILABLE:
-                                try:
-                                    if is_cf_challenge(200, body_text):
-                                        cf_msg = " — looks like a Cloudflare challenge"
-                                except Exception:
-                                    pass
-                            print(
-                                f"[!] Comix DOM scrape: page 1 selector "
-                                f"'.mchap-row__primary' did not render "
-                                f"within 10s{cf_msg}. "
-                                f"title={page_title!r} url={page_url!r}",
-                                flush=True,
-                            )
-                            if snippet:
-                                print(
-                                    f"[!] Comix DOM scrape: page 1 visible "
-                                    f"text (first 500 chars): {snippet}",
-                                    flush=True,
-                                )
-                        except Exception as diag_exc:
-                            print(
-                                f"[!] Comix DOM scrape: page 1 selector timed "
-                                f"out ({type(wait_exc).__name__}); diagnostic "
-                                f"dump also failed: {type(diag_exc).__name__}: "
-                                f"{diag_exc}",
-                                flush=True,
-                            )
-                        break
-                else:
-                    # Wait until the first row's href differs from the
-                    # previous page's first href. Times out at 10s either
-                    # because (a) we're past the last page and React kept
-                    # showing the prior content unchanged, or (b) comix
-                    # legitimately took >10s to re-render. (a) is terminal;
-                    # we treat the empty-rows result that follows as the
-                    # end signal naturally. json.dumps escapes any quotes
-                    # in the href so the literal can't break the JS parse.
-                    js_predicate = (
-                        "(() => { const a = document.querySelector('.mchap-row__primary'); "
-                        f"return a && a.getAttribute('href') !== {json.dumps(prev_first_href)}; }})"
-                    )
-                    try:
-                        self._page.wait_for_function(js_predicate, timeout=10000)
+                        if is_cf_challenge(200, body_text):
+                            cf_msg = " Looks like a Cloudflare challenge."
                     except Exception:
-                        # DOM didn't update — either past end of pagination
-                        # or React is being lazy. Either way scrape what we
-                        # have and let the post-scrape dup-detect handle it.
                         pass
+                detail = (
+                    f" title={page_title!r} url={page_url!r} "
+                    f".mchap-row__primary={primary_count}.{cf_msg} "
+                    f"Visible text: {snippet[:300]}"
+                )
+                if primary_count:
+                    detail += (
+                        " NOTE: chapter links exist but no `.mchap-item` rows — "
+                        "comix likely renamed the row container; update the "
+                        "selectors in fetch_chapters_via_dom."
+                    )
+            except Exception:
+                pass
+            raise ComixChapterScrapeError(
+                "comix chapter list: no chapter rows rendered on page 1." + detail
+            )
+
+        # ── Total page count, straight from the pager. One "Last page" click
+        # is the cheapest possible way to learn it (verified: 360 unfiltered /
+        # 59 with group_id on Magic Emperor), and it converts the whole loop
+        # from "walk until something looks like the end" to a bounded,
+        # verifiable traversal.
+        pager = _read_pager()
+        total_pages = 1
+        if pager:
+            # Floor from what's already visible. The pager window only shows a
+            # few numbers, so this is a LOWER bound, never the answer — but it
+            # guarantees we can never conclude "1 page" when the DOM plainly
+            # shows more, which is how the first cut of this code still
+            # truncated the list.
+            total_pages = max(total_pages, int(pager.get("max") or 1))
+            if pager.get("hasLast") and _click_pager("last page"):
+                # Wait for the pager to actually LAND on the last page —
+                # "rows exist" is not enough. comix's React list swaps row
+                # content in place, so page 1's rows survive the click and a
+                # rows-only wait returns instantly on stale DOM reporting
+                # active=1. The last page is the one with no Next.
+                last_state = _wait_for_pager(
+                    lambda s: not s.get("hasNext") and bool(s.get("active")),
+                    20.0,
+                )
+                if last_state and last_state.get("active"):
+                    total_pages = max(total_pages, int(last_state["active"]))
+                else:
+                    print(
+                        "[!] Comix DOM scrape: could not read the last page "
+                        "number from the pager; falling back to the highest "
+                        f"visible page ({total_pages}).",
+                        flush=True,
+                    )
+                # Back to the start. Fall back to a hard navigation if the
+                # First button doesn't take.
+                if not (_click_pager("first page") and _wait_for_page(1, 20.0)):
+                    try:
+                        self._page.goto(
+                            _page_url(1),
+                            wait_until="domcontentloaded",
+                            timeout=30000,
+                        )
+                    except Exception:
+                        pass
+                    _wait_for_page(1, 20.0)
+                _waf_guard("the chapter list")
+        if _rows_rendered() == 0:
+            raise ComixChapterScrapeError(
+                "comix chapter list: rows disappeared after reading the pager; "
+                "the page state is unusable."
+            )
+        if max_pages and max_pages > 0:
+            total_pages = min(total_pages, max_pages)
+        if total_pages > _MAX_CHAPTER_SCRAPE_PAGES:
+            print(
+                f"[!] Comix DOM scrape: pager reports {total_pages} pages, "
+                f"above the {_MAX_CHAPTER_SCRAPE_PAGES}-page sanity bound; "
+                f"clamping.",
+                flush=True,
+            )
+            total_pages = _MAX_CHAPTER_SCRAPE_PAGES
+
+        # Budget scales with the now-KNOWN size instead of being a fixed guess
+        # that a long series silently ran out of. ~1.5s per pager click plus
+        # slack, floored at the historical 300s.
+        budget = (
+            time_budget_s
+            if time_budget_s and time_budget_s > 0
+            else max(300.0, total_pages * 1.5 + 30.0)
+        )
+        started_at = _time.monotonic()
+        deadline = started_at + budget
+        print(
+            f"[*] Comix DOM scrape: {total_pages} page(s) of chapter rows to "
+            f"walk (budget {int(budget)}s).",
+            flush=True,
+        )
+
+        page_n = 0
+        while True:
+            page_n += 1
+            try:
                 rows = self._page.evaluate(scrape_js) or []
             except Exception as e:
-                print(f"[!] Comix DOM scrape failed at page {page_n}: {type(e).__name__}: {e}", flush=True)
-                break
+                raise ComixChapterScrapeError(
+                    f"comix chapter list: DOM scrape failed on page {page_n} "
+                    f"of {total_pages} ({type(e).__name__}: {e})."
+                ) from e
             if not rows:
-                # On page 1 the selector wait already passed (so
-                # `.mchap-row__primary` rendered) — `.mchap-item` returning
-                # 0 here means the DOM scheme changed. On later pages this
-                # is the normal end-of-pagination signal; silent is correct
-                # there. Probe both selectors so the user can see the gap.
-                if prev_first_href is None:
+                # An empty page is NOT end-of-list. This is precisely the bug
+                # that made an 890-chapter series start downloading at chapter
+                # 871: the old code did a bare `break` here, silently, on every
+                # page after the first. The pager knows whether more pages
+                # exist, so ask it instead of guessing.
+                on_last_page = page_n >= total_pages
+                _waf_guard(f"chapter list page {page_n}")
+                if not on_last_page:
+                    # Re-navigate this page directly and try once more; a slow
+                    # SPA render is the common benign cause.
+                    print(
+                        f"[!] Comix DOM scrape: page {page_n} of {total_pages} "
+                        f"rendered no rows; retrying it.",
+                        flush=True,
+                    )
                     try:
-                        primary_count = self._page.evaluate(
-                            "document.querySelectorAll('.mchap-row__primary').length"
+                        self._page.goto(
+                            _page_url(page_n),
+                            wait_until="domcontentloaded",
+                            timeout=30000,
                         )
-                        item_count = self._page.evaluate(
-                            "document.querySelectorAll('.mchap-item').length"
-                        )
-                        print(
-                            f"[!] Comix DOM scrape: page 1 had "
-                            f"{primary_count} `.mchap-row__primary` "
-                            f"element(s) but {item_count} `.mchap-item` "
-                            f"row(s). scrape_js queries `.mchap-item`, so "
-                            f"comix likely renamed the row container — "
-                            f"update the selectors in fetch_chapters_via_dom.",
-                            flush=True,
-                        )
-                    except Exception as diag_exc:
-                        print(
-                            f"[!] Comix DOM scrape: page 1 returned 0 rows "
-                            f"and the diagnostic probe also failed: "
-                            f"{type(diag_exc).__name__}: {diag_exc}",
-                            flush=True,
-                        )
-                break
-            # Update prev_first_href for the next iteration's freshness check.
-            # Use the raw href (not the normalized url) so the JS predicate
-            # comparison stays exact.
-            prev_first_href = rows[0].get("href")
-            # Progress: emit a heartbeat every 20 pages so the UI / CLI
-            # doesn't look stuck during long scrapes (One Piece is ~180
-            # pages = ~3 minutes wall time with a warm browser). stderr
-            # path keeps stdout clean for JSON consumers.
+                    except Exception:
+                        pass
+                    _waf_guard(f"chapter list page {page_n}")
+                    _wait_for_page(page_n, 20.0)
+                    try:
+                        rows = self._page.evaluate(scrape_js) or []
+                    except Exception:
+                        rows = []
+                if not rows:
+                    if on_last_page:
+                        # Genuinely nothing on the final page. Benign.
+                        break
+                    raise ComixChapterScrapeError(
+                        f"comix chapter list: page {page_n} of {total_pages} "
+                        f"rendered no chapter rows even after a retry. The list "
+                        f"would have been truncated at {len(items)} chapter(s) "
+                        f"— refusing to return a partial series (a short list "
+                        f"gets persisted as if it were the whole thing)."
+                    )
+            # Progress heartbeat so a long scrape doesn't look hung. stderr
+            # keeps stdout clean for --search-json consumers.
             if page_n % 20 == 0:
-                elapsed = int(_time.monotonic() - (deadline - time_budget_s))
+                elapsed = int(_time.monotonic() - started_at)
                 print(
-                    f"[*] Comix DOM scrape: page {page_n}, "
+                    f"[*] Comix DOM scrape: page {page_n}/{total_pages}, "
                     f"{len(items)} unique chapters so far ({elapsed}s elapsed).",
                     flush=True,
                 )
@@ -1654,25 +2502,90 @@ class _ComixBrowserSession:
                     "language": None,
                 })
                 page_added += 1
-            if page_added == 0:
-                # Every row was a dup of an earlier page. Could be normal
-                # boundary overlap (1-2 dups) or a sign the pagination is
-                # stuck on the same page. Break after 2 consecutive
-                # zero-add pages to bound the worst case.
-                consecutive_dup_pages += 1
-                if consecutive_dup_pages >= 2:
+
+            # Canary: with pager-driven navigation every page should contribute
+            # new rows. An all-duplicate page means the click didn't actually
+            # advance the list (stale render) — under the OLD code that state
+            # silently ended the scrape, so keep it loud even though the
+            # active-page wait should now prevent it.
+            if page_added == 0 and rows:
+                print(
+                    f"[!] Comix DOM scrape: page {page_n}/{total_pages} "
+                    f"returned {len(rows)} row(s) but none were new — the "
+                    f"pager may not have advanced.",
+                    flush=True,
+                )
+
+            # ── Early stop on the advisory chapter floor. comix sorts
+            # newest-first, so once a whole page sits below the floor every
+            # remaining page does too. Uses the page MAXIMUM (not the minimum)
+            # so a row out of order can't cut the walk short, which makes this
+            # exact rather than heuristic — no grace margin needed.
+            if chapter_floor is not None:
+                page_numbers = [
+                    n for n in (
+                        _coerce_chapter_number(r.get("href"), r.get("chap_label"))
+                        for r in rows
+                    ) if n is not None
+                ]
+                if page_numbers and max(page_numbers) < float(chapter_floor):
+                    print(
+                        f"[*] Comix DOM scrape: page {page_n}/{total_pages} is "
+                        f"entirely below the requested floor "
+                        f"(ch.{float(chapter_floor):g}); stopping early with "
+                        f"{len(items)} chapter(s).",
+                        flush=True,
+                    )
                     break
-            else:
-                consecutive_dup_pages = 0
-        # Always emit a final tally so the caller's "API returned 0
-        # chapters, falling back to DOM scrape" line in get_chapters has
-        # a corresponding "DOM scrape gave us X" line. Without this the
-        # silent-empty path looked identical to the success path from
-        # the get_chapters caller's perspective, and the user only saw
-        # "No chapters selected" with no clue what happened in between.
+
+            # ── Advance. Termination is the PAGER's word, not a heuristic.
+            if page_n >= total_pages:
+                break
+            if _time.monotonic() > deadline:
+                raise ComixChapterScrapeError(
+                    f"comix chapter list: ran out of time ({int(budget)}s) at "
+                    f"page {page_n} of {total_pages} with {len(items)} "
+                    f"chapter(s) collected. Refusing to return a partial "
+                    f"series — narrow the range with --chapters, or pass a "
+                    f"?group_id= URL to cut the list to one scanlation group."
+                )
+            next_page = page_n + 1
+            # The pager click is an OPTIMIZATION (client-side route change, no
+            # document reload), never the only way forward — a mid-render pager
+            # can briefly have no usable Next button, and letting that end the
+            # scrape would resurrect the truncation bug in a new disguise. So:
+            # click, else wait for the button and click, else hard-navigate.
+            advanced = False
+            if _click_pager("next page") or (
+                _wait_for_pager(lambda s: s.get("hasNext"), 5.0)
+                and _click_pager("next page")
+            ):
+                advanced = _wait_for_page(next_page, 20.0)
+            if not advanced:
+                try:
+                    self._page.goto(
+                        _page_url(next_page),
+                        wait_until="domcontentloaded",
+                        timeout=30000,
+                    )
+                except Exception:
+                    pass
+                _waf_guard(f"chapter list page {next_page}")
+                advanced = _wait_for_page(next_page, 20.0)
+            if not advanced:
+                raise ComixChapterScrapeError(
+                    f"comix chapter list: could not reach page {next_page} of "
+                    f"{total_pages} ({len(items)} chapter(s) collected so far) "
+                    f"— neither the pager's Next button nor a direct navigation "
+                    f"landed on it. Refusing to return a partial series."
+                )
+
+        # Final tally, always emitted so the caller's "fetching chapter list"
+        # line has a matching completion line. Now reports pages walked vs the
+        # true total, which is what makes a truncation visible at a glance.
         print(
             f"[*] Comix DOM scrape: complete. {len(items)} chapter(s) "
-            f"collected across {page_n} page(s).",
+            f"collected across {page_n}/{total_pages} page(s).",
             flush=True,
         )
         return items
@@ -1791,6 +2704,12 @@ class _ComixBrowserSession:
             )
             return []
 
+        # The WAF fires on behavior, and a chapter render is the heaviest thing
+        # we do (one navigation plus ~40-80 image loads), so this is where it
+        # most often lands. Without the check the interstitial just produced
+        # "0 .rpage-page divs" below, which reads as a broken chapter.
+        self._enforce_no_waf("the chapter page", chapter_url)
+
         # Wait for the React app to mount and the chapter API to fire,
         # which populates .rpage-page divs. Poll up to 30 s — most
         # chapters mount in 3-8 s but the CF turnstile / slow networks
@@ -1810,6 +2729,9 @@ class _ComixBrowserSession:
             page.wait_for_timeout(500)
 
         if page_count == 0:
+            # Re-check before blaming the render: a WAF redirect can land here
+            # too (it may arrive after the initial navigation settled).
+            self._enforce_no_waf("the chapter page", chapter_url)
             print(
                 f"[!] Comix: chapter had 0 .rpage-page divs in DOM "
                 f"after wait. Either the React app failed to mount or "
@@ -2159,24 +3081,63 @@ class _ComixBrowserBridge:
     def fetch_chapters_via_dom(
         self,
         title_url: str,
-        max_pages: int = 500,
-        time_budget_s: float = 300.0,
+        max_pages: int = 0,
+        time_budget_s: float = 0.0,
+        chapter_floor: Optional[float] = None,
     ) -> List[Dict]:
-        """Bridge facade for the DOM-pagination fallback. Default per-call
-        wall clock is `time_budget_s + 30s` (worker overhead + final goto
-        slack) so the bridge timeout doesn't trip BEFORE the in-method
-        budget logic has a chance to return a partial list — the inner
-        budget is the load-bearing one; this is just the outer safety net.
-        Cross-file: see _ComixBrowserSession.fetch_chapters_via_dom for
-        the actual pagination + DOM-scrape implementation.
+        """Bridge facade for the chapter-list DOM scrape.
+
+        The outer wall clock has to accommodate a scrape whose real size is
+        only known once the pager has been read: a 360-page series at ~1.5s per
+        pager click is ~9 minutes, and the inner method derives its own budget
+        the same way. Passing 0 (the default) means "let the inner method size
+        itself"; the outer cap then mirrors that formula with slack, plus room
+        for an interactive WAF solve (default 180s) which can legitimately
+        happen mid-scrape. The inner budget stays the load-bearing one.
+
+        Cross-file: see _ComixBrowserSession.fetch_chapters_via_dom.
         """
+        if time_budget_s and time_budget_s > 0:
+            outer = time_budget_s + 30.0
+        else:
+            # Worst case the inner method could choose, plus solve headroom.
+            # _MAX_CHAPTER_SCRAPE_PAGES bounds an unbounded pager.
+            outer = _MAX_CHAPTER_SCRAPE_PAGES * 1.5 + 30.0
+        outer += _WAF_DEFAULT_SOLVE_TIMEOUT_S + 60.0
         return _comix_call(
             "fetch_chapters_via_dom",
             title_url,
             max_pages,
             time_budget_s,
-            _timeout_s=time_budget_s + 30.0,
+            chapter_floor,
+            _timeout_s=outer,
         )
+
+    def solve_waf_interactively(self, return_url: Optional[str] = None) -> Dict[str, Any]:
+        """Bridge facade for the interactive WAF handoff.
+
+        Timeout is the solve window plus generous slack for the two browser
+        relaunches (headless → headed → headless) the handoff performs.
+        Never raises: a bridge-level timeout degrades to "not solved" so the
+        caller's own error path (which carries the user-facing remediation)
+        runs instead of a bare TimeoutError.
+        """
+        try:
+            solve_timeout = float(
+                os.environ.get(_WAF_SOLVE_TIMEOUT_ENV)
+                or _WAF_DEFAULT_SOLVE_TIMEOUT_S
+            )
+        except (TypeError, ValueError):
+            solve_timeout = _WAF_DEFAULT_SOLVE_TIMEOUT_S
+        try:
+            return _comix_call(
+                "solve_waf_interactively",
+                return_url,
+                _timeout_s=solve_timeout + 120.0,
+            )
+        except Exception:
+            return {"solved": False, "cookies": [], "user_agent": None,
+                    "reason": "bridge_error"}
 
     def fetch_search_via_dom(
         self,

--- a/sites/dynasty.py
+++ b/sites/dynasty.py
@@ -7,7 +7,7 @@ from urllib.parse import quote_plus, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
-from .base import BaseSiteHandler, SearchHit, SiteComicContext
+from .base import BaseSiteHandler, GroupInfo, SearchHit, SiteComicContext
 
 
 class DynastySiteHandler(BaseSiteHandler):
@@ -66,9 +66,18 @@ class DynastySiteHandler(BaseSiteHandler):
         text = soup.get_text("\n", strip=True)
         return text or None
 
-    def _chapter_scanlator(self, tags: List[Dict]) -> Optional[str]:
-        scanlators = [t["name"] for t in tags if t.get("type") == "Scanlator"]
-        return ", ".join(scanlators) if scanlators else None
+    def _chapter_scanlators(self, tags: List[Dict]) -> List[str]:
+        """Every Scanlator tag, as a LIST.
+
+        Used to comma-join into one string, which get_group_match_key then
+        squashed into a single opaque key — so `--group "X"` could never match
+        a chapter jointly released as "X, Y". Each name now becomes its own
+        GroupInfo; base.get_group_name re-joins them for display.
+        """
+        return [
+            t["name"] for t in tags
+            if t.get("type") == "Scanlator" and t.get("name")
+        ]
 
     # ----------------------------------------------------------- Base overrides
     def fetch_comic_context(
@@ -180,7 +189,7 @@ class DynastySiteHandler(BaseSiteHandler):
             title = item.get("title") or permalink.replace("_", " ")
             chap_title = f"{header} {title}".strip() if header else title
             tags = item.get("tags") or []
-            scanlator = self._chapter_scanlator(tags)
+            scanlators = self._chapter_scanlators(tags)
             chapters.append(
                 {
                     "hid": permalink,
@@ -188,17 +197,14 @@ class DynastySiteHandler(BaseSiteHandler):
                     "title": chap_title,
                     "url": f"/{self._CHAPTER_DIR}/{permalink}",
                     "uploaded": self._to_timestamp(item.get("released_on")),
-                    "group_name": scanlator,
+                    "_groups": [GroupInfo(name=n) for n in scanlators],
+                    "group_name": ", ".join(scanlators) or None,
                 }
             )
 
         if (first_page.get("type") or "").lower() != "doujin":
             chapters.reverse()
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        group = chapter_version.get("group_name")
-        return group if isinstance(group, str) and group else None
 
     def get_chapter_images(
         self,

--- a/sites/group_quality.py
+++ b/sites/group_quality.py
@@ -1,0 +1,203 @@
+"""Machine-translation (MTL) detection for scanlation group names.
+
+What this module owns:
+  - `classify_mtl(name, description=...)` → (verdict, reason). Verdict is one of
+    MTL_NONE / MTL_SUSPECT / MTL_CONFIRMED.
+
+What reads from it:
+  - sites/base.py — the composite chapter-version ranker (grep `_mtl_rank`);
+    MTL versions sink below human ones but are still selected when they are the
+    ONLY version of a chapter (the `--mtl avoid` default).
+  - aio-dl.py — the `--mtl {avoid,allow,exclude}` flag's exclude path.
+
+Deliberately REGEX-ONLY: no catalog file, no network, no state (user decision
+2026-08-02). The alternative considered and rejected was a curated
+group_quality.json mirroring official_publishers.json — rejected because a
+hand-maintained MTL roster ages badly and the escape hatch below covers the
+misfire case without one.
+
+FALSE-POSITIVE POLICY — read this before adding a pattern:
+  A misfire only DEMOTES a group (it never drops a chapter under the default
+  `avoid` policy), and naming the group in `--group "<name>"` bypasses ranking
+  entirely via the priority branch. So the cost of a false positive is a
+  suboptimal pick, not data loss. Even so, every pattern here must be
+  word-boundary anchored and must not fire on ordinary group names:
+    - "AI" is the whole risk surface. 愛 romanizes as `Ai`, never `AI`, and
+      title-case is universal for names — so the bare-token pattern is
+      CASE-SENSITIVE and runs against the RAW name. Casefolding it is a bug:
+      it would flag "Aiden Scans", "Rainbow Ai", "Aiko TL".
+    - Bare `AI` is only ever SUSPECT. Only `AI` adjacent to a translation word
+      ("AI Translations", "AI-TL") is CONFIRMED.
+    - `\b` anchors also keep `\bmtl\b` off "Formatl" and `\bbot\b` off "Botan".
+  If a real group ever gets flagged, the fix is to tighten the pattern here —
+  there is intentionally no per-group override list to fall back on.
+
+Cross-file: sites/base.py:normalize_group_name produces the normalized form the
+lowercase patterns expect (separators collapsed to single spaces, casefolded).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+MTL_NONE = "none"
+MTL_SUSPECT = "suspect"
+MTL_CONFIRMED = "confirmed"
+
+# Ranked worst-to-best; sites/base.py maps these onto the `mtl_rank` tier.
+_VERDICT_ORDER = {MTL_CONFIRMED: 0, MTL_SUSPECT: 1, MTL_NONE: 2}
+
+
+# Matched against the NORMALIZED name (casefolded, separators → spaces), so
+# "MTL-Scans" / "MTL_Scans" / "mtl.scans" all boundary-split identically.
+_MTL_CONFIRMED = (
+    (r"\bmtl\b", "name says MTL"),
+    # `machine\w*` (not a bare `machine`) so "Machiner Translate" and
+    # "MachineTranslated" hit. The trailing `translat` must still follow
+    # immediately, so "Machine Doll Translations" (a series title, not a
+    # method) does NOT match.
+    (r"machine\w*\s*translat", "name says machine translation"),
+    (r"\bgoogle\s*translat", "name says Google Translate"),
+    (r"\bdeepl\b", "name says DeepL"),
+    (r"\bpapago\b", "name says Papago"),
+    (r"\bchatgpt\b", "name says ChatGPT"),
+    (r"\bgpt\s*-?\s*[0-9]", "name says GPT-n"),
+    (r"\bauto\s*translat", "name says auto-translated"),
+    (r"\btranslated\s+by\s+(?:ai|machine|bot)\b", "name says translated by AI/machine"),
+)
+
+# The "AI" token is matched CASE-SENSITIVELY against the RAW name (see the
+# FALSE-POSITIVE POLICY above); the translation word that must follow it is
+# matched case-insensitively, since "AI Translations" / "AI-tl" / "AI TL" are
+# all the same claim. Split into two patterns rather than one regex because a
+# single `re.IGNORECASE` pass would also fold `\bAI\b` down to `Ai` and flag a
+# group named after the given name 愛.
+# NB: no `^` anchor on the tail — it is applied via `.match(text, pos)`, which
+# already anchors at pos, whereas `^` would only ever match at offset 0.
+_AI_TOKEN_CASED = re.compile(r"\bAI\b")
+_AI_TRANSLATION_TAIL = re.compile(r"\s*(?:translat|tl\b)", re.IGNORECASE)
+
+_MTL_SUSPECT = (
+    (r"\bneural\b", "name mentions neural"),
+    (r"\bbot\b", "name mentions bot"),
+)
+
+# Bare uppercase AI token — plausible as an acronym, so SUSPECT only.
+_MTL_SUSPECT_CASED = (
+    (r"\bAI\b", "name contains a bare 'AI' token"),
+)
+
+
+def _first_match(patterns, text: str, flags: int = 0) -> Optional[str]:
+    """Return the reason string of the first pattern that hits, else None."""
+    for pattern, reason in patterns:
+        if re.search(pattern, text, flags):
+            return reason
+    return None
+
+
+def _collapse_separators(text: str) -> str:
+    """Collapse `_./-` to spaces WITHOUT casefolding.
+
+    The AI checks need both properties at once: separators normalized (so
+    `\\b` sees a boundary in "AI_Translated", where `_` is a word character and
+    would otherwise swallow it) and original casing intact (so `Ai` never
+    matches the case-sensitive `AI` token).
+    """
+    return re.sub(r"\s+", " ", re.sub(r"[_./-]+", " ", text)).strip()
+
+
+def _ai_translation_claim(text: str) -> bool:
+    """True when a case-sensitive 'AI' token is directly followed by a
+    translation word ("AI Translations", "AI-TL"). A bare 'AI' is not enough —
+    that stays SUSPECT via _MTL_SUSPECT_CASED."""
+    spaced = _collapse_separators(text)
+    for match in _AI_TOKEN_CASED.finditer(spaced):
+        if _AI_TRANSLATION_TAIL.match(spaced, match.end()):
+            return True
+    return False
+
+
+def _normalize_for_match(text: str) -> str:
+    """Lowercase + collapse separators so word boundaries land predictably.
+
+    Mirrors sites/base.py:normalize_group_name's cleanup without importing it
+    (this module must stay dependency-free so it can be unit-tested standalone
+    and imported from anywhere in sites/ without a cycle).
+    """
+    cleaned = re.sub(r"[_./-]+", " ", text.casefold())
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def classify_mtl(
+    name: Optional[str],
+    *,
+    description: Optional[str] = None,
+) -> Tuple[str, str]:
+    """Classify a scanlation group as machine-translated from its metadata.
+
+    Args:
+        name: the group's display name, RAW (not pre-normalized) — the
+            case-sensitive "AI" guard depends on original casing.
+        description: the group's self-description where the site exposes one.
+            MangaDex is the only site that does today (it rides the
+            `includes[]=scanlation_group` relationship the handler already
+            fetches). Everything else passes None and degrades to name-only.
+
+    Returns:
+        (verdict, reason). `reason` is a short human string for the selection
+        debug log; empty string when the verdict is MTL_NONE.
+
+    Description promotion: a group whose NAME is clean but whose description
+    says "all machine translated" is confirmed — that class of group is
+    invisible to name matching and is exactly what descriptions are for. A
+    description can only ever RAISE the verdict, never lower it.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return MTL_NONE, ""
+
+    raw = name.strip()
+    normalized = _normalize_for_match(raw)
+
+    reason = _first_match(_MTL_CONFIRMED, normalized)
+    if reason:
+        return MTL_CONFIRMED, reason
+    if _ai_translation_claim(raw):
+        return MTL_CONFIRMED, "name says AI translation"
+
+    verdict = MTL_NONE
+    # The cased set runs on the separator-collapsed name for the same
+    # word-boundary reason _ai_translation_claim does ("AI_Scans").
+    suspect_reason = _first_match(_MTL_SUSPECT, normalized) or _first_match(
+        _MTL_SUSPECT_CASED, _collapse_separators(raw)
+    )
+    if suspect_reason:
+        verdict = MTL_SUSPECT
+
+    # Description promotion. Only the CONFIRMED patterns are consulted — the
+    # suspect set ("bot", "neural") is far too loose for free prose, where
+    # "our bot posts releases to Discord" is a routine sentence.
+    if isinstance(description, str) and description.strip():
+        desc_normalized = _normalize_for_match(description)
+        desc_reason = _first_match(_MTL_CONFIRMED, desc_normalized)
+        if desc_reason is None and _ai_translation_claim(description):
+            desc_reason = "name says AI translation"
+        if desc_reason:
+            return MTL_CONFIRMED, desc_reason.replace("name says", "description says")
+
+    return verdict, suspect_reason or ""
+
+
+def mtl_rank(verdict: str) -> int:
+    """Map a verdict onto the ranker's tier value (higher = better)."""
+    return _VERDICT_ORDER.get(verdict, 2)
+
+
+__all__ = [
+    "MTL_NONE",
+    "MTL_SUSPECT",
+    "MTL_CONFIRMED",
+    "classify_mtl",
+    "mtl_rank",
+]

--- a/sites/kagane.py
+++ b/sites/kagane.py
@@ -12,7 +12,7 @@ from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from .base import BaseSiteHandler, SiteComicContext
+from .base import BaseSiteHandler, GroupInfo, SiteComicContext
 
 try:  # Optional dependency; only needed for Kagane
     from pywidevine.cdm import Cdm
@@ -557,14 +557,18 @@ class KaganeSiteHandler(BaseSiteHandler):
                 continue
             pages = entry.get("page_count") or 0
             chap_num = entry.get("chapter_no")
-            # First group's title is the scanlation group name (most series
-            # have exactly one group per chapter).
-            group_name = None
-            groups = entry.get("groups")
-            if isinstance(groups, list) and groups and isinstance(groups[0], dict):
-                gname = groups[0].get("title") or groups[0].get("group_name")
+            # EVERY group in the list, not just groups[0]. Most series have
+            # exactly one group per chapter, but keeping only the first made a
+            # joint release unmatchable by `--group "<co-group>"`.
+            group_infos = []
+            for gentry in entry.get("groups") or []:
+                if not isinstance(gentry, dict):
+                    continue
+                gname = gentry.get("title") or gentry.get("group_name")
                 if isinstance(gname, str) and gname:
-                    group_name = gname
+                    group_infos.append(
+                        GroupInfo(name=gname, group_id=gentry.get("group_id"))
+                    )
             chapters.append(
                 {
                     "hid": chapter_id,
@@ -575,13 +579,13 @@ class KaganeSiteHandler(BaseSiteHandler):
                     "_chapter_id": chapter_id,
                     "_pages": int(pages),
                     "uploaded": entry.get("published_on"),
-                    "group_name": group_name,
+                    "_groups": group_infos,
+                    "group_name": ", ".join(
+                        g.name for g in group_infos if g.name
+                    ) or None,
                 }
             )
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        return chapter_version.get("group_name")
 
     def get_chapter_images(
         self, chapter: Dict, scraper, make_request

--- a/sites/linewebtoon.py
+++ b/sites/linewebtoon.py
@@ -72,6 +72,7 @@ from bs4 import BeautifulSoup
 from .base import (
     AssetSpec,
     BaseSiteHandler,
+    GroupInfo,
     IncompleteChapterError,
     SearchHit,
     SiteComicContext,
@@ -582,6 +583,19 @@ class LineWebtoonSiteHandler(BaseSiteHandler):
                     # kept distinct so diagnostics can tell them apart.
                     "is_official": (not is_canvas),
                     "publisher": publisher_label,
+                    # Originals vs Canvas now stay DISTINCT groups. They used
+                    # to collapse into one bucket named "official" because
+                    # base.normalize_group_name rewrote any name matching
+                    # \b(official|webtoons?|naver)\b — which defeated the very
+                    # distinction the is_official line above sets up. That
+                    # rewrite is gone; `--group official` keys on the
+                    # is_official FLAG instead (grep _OFFICIAL_ALIAS_KEYS).
+                    "_groups": [
+                        GroupInfo(
+                            name=publisher_label,
+                            is_official=(not is_canvas),
+                        )
+                    ],
                     "group_name": publisher_label,
                     "thumbnail": thumb,
                     # Audio-archival hint (faithful-archival feature). The
@@ -595,12 +609,6 @@ class LineWebtoonSiteHandler(BaseSiteHandler):
                 }
             )
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        """Surface our hardcoded `LINE Webtoon` to the orchestrator's
-        per-source diagnostics. Mirrors weebcentral.py:246–248."""
-        name = chapter_version.get("group_name")
-        return name if isinstance(name, str) and name else None
 
     # ------------------------------------------------------------- chapter images
 

--- a/sites/mangadex.py
+++ b/sites/mangadex.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 
 from .base import (
     BaseSiteHandler,
+    GroupInfo,
     IncompleteChapterError,
     SearchHit,
     SiteComicContext,
@@ -427,43 +428,87 @@ class MangaDexSiteHandler(BaseSiteHandler):
                 # alternative anyway.
                 if attr.get("isUnavailable") is True:
                     continue
-                group_name = None
-                group_id = None
+                # EVERY scanlation_group rel, not just the first: MangaDex
+                # models a joint release as multiple rels, and the old
+                # `break` silently dropped every co-group — which also made
+                # `--group "<co-group>"` unable to match its own chapters.
+                groups: List[GroupInfo] = []
+                is_official = False
+                publisher_canonical = None
                 for rel in relationships:
-                    if rel.get("type") == "scanlation_group":
-                        group_id = rel.get("id")
-                        group_name = rel.get("attributes", {}).get("name")
-                        break
-                # Phase 4c is_official annotation: match scanlation_group
-                # against sites/official_publishers.json (UUID first, name
-                # alias fallback). When True, the chapter_merger will rank
-                # this source first within a chapter row, and downstream
-                # JSON output exposes it for UI badges. canonical publisher
-                # name from the catalog (e.g. "MangaPlus" not "MangaPlus by
-                # Shueisha") is used as `publisher` so cross-site dedupe by
-                # publisher works even when group_name strings drift.
-                is_official, publisher_canonical = lookup_publisher(group_id, group_name)
+                    if rel.get("type") != "scanlation_group":
+                        continue
+                    gattr = rel.get("attributes") or {}
+                    group_id = rel.get("id")
+                    group_name = gattr.get("name")
+                    # Phase 4c is_official annotation: match scanlation_group
+                    # against sites/official_publishers.json (UUID first, name
+                    # alias fallback). When True, the chapter_merger will rank
+                    # this source first within a chapter row, and downstream
+                    # JSON output exposes it for UI badges. canonical publisher
+                    # name from the catalog (e.g. "MangaPlus" not "MangaPlus by
+                    # Shueisha") is used as `publisher` so cross-site dedupe by
+                    # publisher works even when group_name strings drift.
+                    catalog_official, canonical = lookup_publisher(group_id, group_name)
+                    # MangaDex's own `official` flag is BROADER than our
+                    # 13-entry catalog, so OR them — but `publisher` stays
+                    # catalog-only, because chapter_merger and the SearchTab
+                    # badge key on the canonical name and a MangaDex-official
+                    # group we've never catalogued has no canonical form.
+                    # (SearchTab.jsx renders `publisher || group_name ||
+                    # "Official"`, so a null publisher degrades cleanly.)
+                    group_official = bool(catalog_official or gattr.get("official"))
+                    is_official = is_official or group_official
+                    if canonical and not publisher_canonical:
+                        publisher_canonical = canonical
+                    groups.append(
+                        GroupInfo(
+                            name=group_name,
+                            group_id=group_id,
+                            is_official=group_official,
+                            verified=bool(gattr.get("verified")),
+                            inactive=bool(gattr.get("inactive")),
+                            # Feeds sites/group_quality.classify_mtl — MangaDex
+                            # is the only site exposing a group blurb, and MTL
+                            # groups routinely say so there even when their name
+                            # doesn't. Already in this response (includes[]=
+                            # scanlation_group); no extra request.
+                            description=gattr.get("description"),
+                        )
+                    )
+                page_count = attr.get("pages")
+                external_url = attr.get("externalUrl")
                 chapters.append(
                     {
                         "hid": chapter_id,
                         "chap": attr.get("chapter") or attr.get("title") or attr.get("volume"),
                         "title": attr.get("title"),
                         "url": chapter_id,
-                        "group_name": group_name,
+                        "_groups": groups,
+                        "group_name": ", ".join(
+                            g.name for g in groups if g.name
+                        ) or None,
                         "language": attr.get("translatedLanguage"),
                         "uploaded": self._parse_timestamp(attr.get("publishAt")),
                         "is_official": is_official,
                         "publisher": publisher_canonical,
+                        "_pages": page_count if isinstance(page_count, int) else None,
+                        "_external_url": external_url,
+                        # Licensed publishers (MangaPlus, Viz…) publish chapters
+                        # that live on THEIR site: pages:0 + externalUrl set.
+                        # /at-home/server returns no images for these, so
+                        # get_chapter_images raises "chapter has no pages".
+                        # They are RANKED DOWN, never filtered out — filtering
+                        # would empty the list entirely for a DMCA'd series like
+                        # One Piece, whose every English chapter is this shape.
+                        # Grep _undownloadable: sites/base.py:_rank_version.
+                        "_undownloadable": bool(external_url) and page_count == 0,
                     }
                 )
             offset += len(data)
             if offset >= total or not data:
                 break
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        group = chapter_version.get("group_name")
-        return group if isinstance(group, str) and group else None
 
     # ---------------------------------------------- chapter image download
     def _fetch_at_home_assignment(

--- a/sites/mangago.py
+++ b/sites/mangago.py
@@ -8,7 +8,7 @@ from urllib.parse import quote_plus, urljoin, urlparse
 from bs4 import BeautifulSoup
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from .base import BaseSiteHandler, SearchHit, SiteComicContext
+from .base import BaseSiteHandler, GroupInfo, SearchHit, SiteComicContext
 
 
 class MangaGoSiteHandler(BaseSiteHandler):
@@ -335,27 +335,36 @@ class MangaGoSiteHandler(BaseSiteHandler):
                         existing["uploader"] = uploader
                 continue
             seen_urls.add(url)
+            # /br_chapter- is mangago's own official-release path (see
+            # _extract_group_name), so flag it — that's what makes
+            # `--group official` and the ranker's official tier work here.
+            is_official = "/br_chapter-" in url
             chapter = {
                 "hid": self._chapter_identifier(url),
                 "chap": chap,
                 "title": label or f"Ch.{chap}",
                 "url": url,
+                # Display string, NOT an epoch ("2 days ago"-shaped). The
+                # ranker's recency tier rejects non-numeric `uploaded` on
+                # purpose rather than risk a wrong parse silently reordering
+                # picks — grep _coerce_epoch in sites/base.py.
                 "uploaded": uploaded,
+                "_groups": (
+                    [GroupInfo(name=group_name, is_official=is_official)]
+                    if group_name else []
+                ),
                 "group": group_name,
                 "publisher": group_name,
                 "uploader": uploader,
                 "language": "en",
+                # Hardcoded 0 for every chapter — mangago exposes no vote
+                # count. base._build_rank_context treats an all-zero field as
+                # "no data" and leaves the upvote tier inert.
                 "up_count": 0,
             }
             chapters_by_url[url] = chapter
             chapters.append(chapter)
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        group = chapter_version.get("group") or chapter_version.get("publisher")
-        if isinstance(group, str) and group.strip():
-            return group.strip()
-        return None
 
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:
         url = chapter.get("url")

--- a/sites/mangareader.py
+++ b/sites/mangareader.py
@@ -188,9 +188,6 @@ class MangaReaderSiteHandler(BaseSiteHandler):
             )
         return chapters
 
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        return None
-
     def get_chapter_images(
         self,
         chapter: Dict,

--- a/sites/mangataro.py
+++ b/sites/mangataro.py
@@ -9,7 +9,22 @@ from urllib.parse import urlencode, urljoin, urlparse
 
 from bs4 import BeautifulSoup, FeatureNotFound, NavigableString
 
-from .base import BaseSiteHandler, SiteComicContext
+from .base import BaseSiteHandler, GroupInfo, SiteComicContext
+
+
+def _clean_group_name(value: Optional[str]) -> Optional[str]:
+    """Strip mangataro's em-dash separator off a group label.
+
+    The site renders chapter rows as "Ch. 12 — Group Name", and both the
+    `data-group-name` attribute and the API's `group_name` occasionally keep a
+    leading/trailing em dash. Lived in a get_group_name override until the
+    canonical GroupInfo model landed; it belongs at the parse sites so the
+    stored value is clean for every reader, not just the selector.
+    """
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().strip("—").strip()
+    return cleaned or None
 
 
 class MangataroSiteHandler(BaseSiteHandler):
@@ -103,13 +118,6 @@ class MangataroSiteHandler(BaseSiteHandler):
 
         api_chapters = self._fetch_chapters_via_api(manga_id, scraper, make_request)
         return api_chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        group_name = chapter_version.get("group_name")
-        if isinstance(group_name, str) and group_name.strip():
-            cleaned = group_name.strip().strip("—").strip()
-            return cleaned or None
-        return None
 
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:
         chapter_url = chapter.get("url")
@@ -332,15 +340,21 @@ class MangataroSiteHandler(BaseSiteHandler):
             if chap_number is None:
                 continue
 
-            group_name = (link.get("data-group-name") or "").strip() or None
+            group_name = _clean_group_name(link.get("data-group-name"))
 
             chapters.append(
                 {
                     "hid": chapter_id,
                     "chap": chap_number,
                     "url": chapter_url,
+                    "_groups": [GroupInfo(name=group_name)] if group_name else [],
                     "group_name": group_name,
                     "title": (link.get("title") or "").strip() or None,
+                    # NOTE: no `up_count` on this path — the site only exposes
+                    # likes via the signed API below. base._build_rank_context
+                    # requires >=2 reporters before the upvote tier engages, so
+                    # a mixed HTML/API pool can't compare a real count against
+                    # a missing one.
                 }
             )
 
@@ -410,12 +424,14 @@ class MangataroSiteHandler(BaseSiteHandler):
             except Exception:
                 likes = 0
 
+            api_group = _clean_group_name(entry.get("group_name"))
             chapters.append(
                 {
                     "hid": chapter_id,
                     "chap": chap_number,
                     "url": chapter_url,
-                    "group_name": (entry.get("group_name") or "").strip() or None,
+                    "_groups": [GroupInfo(name=api_group)] if api_group else [],
+                    "group_name": api_group,
                     "title": (entry.get("title") or "").strip() or None,
                     "lang": (entry.get("language") or "").strip() or None,
                     "up_count": likes,

--- a/sites/manhuaplus.py
+++ b/sites/manhuaplus.py
@@ -1,14 +1,36 @@
+"""manhuaplus.com — a Madara WordPress site that does NOT subclass
+MadaraSiteHandler (its chapter list + reader markup deviate enough that the
+generic selectors miss), so it borrows the shared Madara helpers piecemeal:
+`madara_search_via_admin_ajax` for search and `_normalize_madara_image_url`
+for reader URLs. When fixing something here, check sites/madara.py first — the
+attribute ladder + selector-break loop below are deliberate mirrors of
+`MadaraSiteHandler.get_chapter_images` (grep reader_selectors).
+
+Site-specific trap: old chapters (roughly < ch.1000) point at
+`*.files.wordpress.com`, a host that was retired but still answers **HTTP 200
+with `Content-Type: text/html` and a ~19 KB error page** for every image URL.
+Nothing here can tell that apart from a real image — the rejection lives in
+`sites/_image_io.py:looks_like_real_image`, enforced by aio-dl.py:dl_image
+(grep _finalize_downloaded_image). Those chapters now fail loudly instead of
+producing a CBZ of 15 HTML documents named 0001.jpg.
+"""
 from __future__ import annotations
-from typing import Dict, List
-from urllib.parse import urljoin
+from typing import Dict, List, Optional
 from bs4 import BeautifulSoup
 from .base import BaseSiteHandler, SearchHit, SiteComicContext
-from .madara import madara_search_via_admin_ajax
+from .madara import madara_search_via_admin_ajax, _normalize_madara_image_url
 
 class ManhuaPlusSiteHandler(BaseSiteHandler):
     name = "manhuaplus"
     domains = ("manhuaplus.com", "www.manhuaplus.com")
     _BASE_URL = "https://manhuaplus.com"
+
+    # Tried in order; the FIRST one that yields any image wins. `.read-container`
+    # wraps `.reading-content` on this site, so a single comma-union select would
+    # make the two indistinguishable — matching MadaraSiteHandler.reader_selectors
+    # keeps the narrower container authoritative.
+    _READER_SELECTORS = (".reading-content img", ".read-container img")
+
     def configure_session(self, scraper, args) -> None:
         scraper.headers.update({"Referer": f"{self._BASE_URL}/"})
     def _make_soup(self, html: str) -> BeautifulSoup:
@@ -21,12 +43,27 @@ class ManhuaPlusSiteHandler(BaseSiteHandler):
         )
     def fetch_comic_context(self, url: str, scraper, make_request) -> SiteComicContext:
         soup = self._make_soup(make_request(url, scraper).text)
-        title = soup.select_one("h1, .post-title")
-        title = title.get_text(strip=True) if title else "Unknown"
+        # Madara renders promo chips ("Hot", "New") as a .manga-title-badges span
+        # INSIDE div.post-title, ahead of the <h1>. get_text on that wrapper
+        # therefore returned "HotApotheosis", which flows straight into AniList
+        # matching (sites/external_metadata.py reads comic_data["title"]), so it
+        # is not cosmetic. Drop the chips before reading any text out of the page;
+        # nothing else here consumes them.
+        for badge in soup.select(".manga-title-badges"):
+            badge.decompose()
+        title_node = soup.select_one(".post-title h1") or soup.select_one("h1, .post-title")
+        title = title_node.get_text(strip=True) if title_node else "Unknown"
         desc = soup.select_one(".summary__content p, .description-summary p")
         description = desc.get_text(strip=True) if desc else ""
-        cover = soup.select_one(".summary_image img")
-        cover = cover.get("src") if cover else None
+        # Same lazy-load ladder as the reader images: this theme's cover <img>
+        # carries the real URL in data-src and leaves `src` pointing at Madara's
+        # shared placeholder (themes/madara/images/dflazy.jpg), so reading `src`
+        # gave EVERY series the same grey placeholder as its cover.jpg / UI
+        # thumbnail / AniList site_cover fallback.
+        cover_node = soup.select_one(".summary_image img")
+        cover = self._img_src(cover_node) if cover_node else None
+        if cover:
+            cover = _normalize_madara_image_url(cover, url)
         genres = [a.get_text(strip=True) for a in soup.select(".genres-content a")]
         slug = url.rstrip("/").split("/")[-1]
         return SiteComicContext(comic={"hid": slug, "title": title, "desc": description, "cover": cover, "genres": genres, "url": url}, title=title, identifier=slug, soup=soup)
@@ -35,7 +72,47 @@ class ManhuaPlusSiteHandler(BaseSiteHandler):
         def clean_num(t):
             return self._chapter_number_from_text(t) or t
         return [{"hid": link.get("href"), "chap": clean_num(link.get_text(strip=True)), "title": link.get_text(strip=True), "url": link.get("href"), "uploaded": None} for li in soup.select(".wp-manga-chapter") if (link := li.select_one("a"))]
+
+    @staticmethod
+    def _img_src(img) -> Optional[str]:
+        """First usable URL off one reader <img>, walking the lazy-load ladder
+        this Madara theme uses. Mirrors sites/madara.py:834-861 — data-srcset is
+        a candidate LIST ("url1 720w, url2 1080w"), so take the first entry's URL
+        token, never the raw attribute. data: URIs are the lazy-load placeholder
+        (precedent: sites/tapas.py:510), not a page."""
+        for attr in ("data-src", "data-lazy-src", "data-cfsrc"):
+            value = (img.get(attr) or "").strip()
+            if value:
+                return value
+        srcset = (img.get("data-srcset") or "").strip()
+        if srcset:
+            first = srcset.split(",", 1)[0].strip()
+            if first:
+                candidate = first.split()[0]
+                if candidate:
+                    return candidate
+        return (img.get("src") or "").strip() or None
+
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:
-        url = chapter.get("url")
-        soup = self._make_soup(make_request(url, scraper).text)
-        return [urljoin(url, img.get("src") or img.get("data-src")) for img in soup.select(".read-container img, .reading-content img") if img.get("src") or img.get("data-src")]
+        chapter_url = chapter.get("url")
+        if not chapter_url:
+            raise RuntimeError("Chapter URL missing.")
+        soup = self._make_soup(make_request(chapter_url, scraper).text)
+
+        image_urls: List[str] = []
+        for selector in self._READER_SELECTORS:
+            for img in soup.select(selector):
+                src = self._img_src(img)
+                if not src or src.startswith("data:"):
+                    continue
+                src = _normalize_madara_image_url(src, chapter_url)
+                if src and src not in image_urls:
+                    image_urls.append(src)
+            if image_urls:
+                break
+
+        # Fail loud rather than returning [] — an empty list reads as "chapter
+        # has no pages" downstream and silently produces an empty CBZ.
+        if not image_urls:
+            raise RuntimeError("Unable to locate images for chapter.")
+        return image_urls

--- a/sites/tapas.py
+++ b/sites/tapas.py
@@ -462,10 +462,6 @@ class TapasSiteHandler(BaseSiteHandler):
         except (TypeError, ValueError):
             return 0
 
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        name = chapter_version.get("group_name")
-        return name if isinstance(name, str) and name else None
-
     # ------------------------------------------------------------- chapter images
     def get_chapter_images(
         self,

--- a/sites/weebcentral.py
+++ b/sites/weebcentral.py
@@ -243,14 +243,15 @@ class WeebCentralSiteHandler(BaseSiteHandler):
             abs_url = urljoin(self._BASE_URL, href)
             time_node = anchor.select_one("time[datetime]")
             uploaded = self._extract_datetime(time_node.get("datetime") if time_node else None)
-            scanlator = None
-            svg = anchor.select_one("svg[stroke]")
-            if svg:
-                stroke = svg.get("stroke")
-                if stroke == "#d8b4fe":
-                    scanlator = "Official"
-                elif stroke == "#4C4D54":
-                    scanlator = "Unknown"
+            # No group/scanlator field: WeebCentral does not credit scanlators
+            # anywhere in the chapter list. It used to derive one from an
+            # inline `svg[stroke]` hex (#d8b4fe -> "Official", #4C4D54 ->
+            # "Unknown"), but the markup is now an <img src=".../
+            # chapter-badge.svg"> with no inline SVG at all, so that selector
+            # matched nothing and every chapter got scanlator=None. Removed
+            # rather than repaired — there is no real name to recover, and the
+            # bogus "Official" string would now be read as a genuine
+            # is_official signal by base.group_matches_filter.
             chapters.append(
                 {
                     "hid": abs_url.rstrip("/"),
@@ -258,14 +259,9 @@ class WeebCentralSiteHandler(BaseSiteHandler):
                     "title": title,
                     "url": abs_url,
                     "uploaded": uploaded,
-                    "scanlator": scanlator,
                 }
             )
         return chapters
-
-    def get_group_name(self, chapter_version: Dict) -> Optional[str]:
-        group = chapter_version.get("scanlator")
-        return group if isinstance(group, str) else None
 
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:
         chapter_url = chapter.get("url")

--- a/tests/test_cli_flag_parsing.py
+++ b/tests/test_cli_flag_parsing.py
@@ -219,3 +219,58 @@ def test_image_prefetch_parallel_default_is_2():
     )
     assert block
     assert "default: 2" in block, f"block was: {block[:300]}"
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Scanlation-group / MTL flags (2026-08-02)
+#
+# --mtl and --exclude-group decide WHICH version's image bytes land on disk,
+# so both must be resume-gating: a run started under one policy and resumed
+# under another would otherwise stitch a mixed-provenance volume.
+# ────────────────────────────────────────────────────────────────────────
+
+def test_mtl_flag_appears_in_help_with_its_three_choices():
+    proc = _run_aio_dl("--help")
+    assert "--mtl {avoid,allow,exclude}" in proc.stdout
+    assert proc.returncode == 0
+
+
+def test_exclude_group_flag_appears_in_help():
+    proc = _run_aio_dl("--help")
+    assert "--exclude-group" in proc.stdout
+
+
+def test_group_flags_are_resume_gating():
+    mod = _load_aio_dl_module()
+    for dest in ("mtl", "exclude_group", "group", "mix_by_upvote",
+                 "no_group_fallback"):
+        assert dest in mod._RESUME_GATING_DESTS, dest
+
+
+def test_group_flags_are_not_also_transient():
+    """_validate_resume_categories hard-errors on overlap; assert it up front."""
+    mod = _load_aio_dl_module()
+    overlap = mod._RESUME_GATING_DESTS & mod._RESUME_TRANSIENT_DESTS
+    assert overlap == set()
+
+
+def test_mtl_and_exclude_group_are_persisted_for_update_replay():
+    """Without these keys in download_params.json, an --update-all child
+    reverts to defaults and the series accumulates mixed provenance."""
+    import argparse
+    mod = _load_aio_dl_module()
+    args = argparse.Namespace(mtl="exclude", exclude_group=["Bad"], group=[])
+    # _save_download_params builds its dict from getattr(args, ...) — exercise
+    # the same accessors the writer uses rather than doing disk I/O here.
+    assert getattr(args, "mtl", "avoid") == "exclude"
+    assert getattr(args, "exclude_group", []) == ["Bad"]
+    src = __import__("inspect").getsource(mod._save_download_params)
+    assert '"mtl"' in src
+    assert '"exclude_group"' in src
+
+
+def test_exclude_group_is_replayed_to_update_children():
+    mod = _load_aio_dl_module()
+    src = __import__("inspect").getsource(mod._append_saved_update_options)
+    assert "--exclude-group" in src
+    assert "--mtl" in src

--- a/tests/test_comix_pagination.py
+++ b/tests/test_comix_pagination.py
@@ -1,0 +1,421 @@
+"""comix WAF detection + chapter-list pagination correctness (sites/comix.py).
+
+Offline only: every test here is a pure-function or structural check, so the
+suite runs with no browser and no network. The live end-to-end check is in the
+plan file's Verification section.
+
+Each test names the defect it pins. The headline ones, both found live
+2026-08-02 against https://comix.to/title/3j50-magic-emperor:
+
+  - THE CHAPTER LIST TRUNCATED SILENTLY. `fetch_chapters_via_dom` ended its
+    pagination loop with a bare `if not rows: break`, which cannot tell "past
+    the last page" from "the render hadn't finished" or "a WAF interstitial is
+    in front of us". Rows are per (chapter x group), so a 4-group series yields
+    only ~5 distinct chapters per 20-row page. The scrape stopped at page 5 of
+    360, collected 78 rows = 20 distinct chapters, and the download began at
+    chapter 871 instead of 1 — with no warning at all. The list is now bounded
+    and terminated by the site's own `.npager` control, and a short scrape
+    RAISES instead of returning a partial series (a partial list gets persisted
+    to .aio_series.json as though it were the whole thing, so every later
+    update run would inherit the truncation).
+
+  - THE WAF INTERSTITIAL WAS INVISIBLE. comix serves a first-party interactive
+    CAPTCHA at /@waf/challenge ("Verify you're human — drag to rotate the
+    circle"), separate from the Cloudflare layer it ALSO runs. Nothing in the
+    handler detected it, so it surfaced as three different lies: "0 .rpage-page
+    divs", "no typeahead results", and — via the HTTP path, which 200s with
+    challenge HTML — a slug-derived junk title written into the library.
+
+  - THE USER'S ?group_id= WAS DISCARDED. `title_url.split("?", 1)[0]` threw
+    away the scanlation-group filter comix honors server-side: 360 pager pages
+    versus 59.
+
+Cross-file:
+  - sites/comix.py (under test).
+  - tests/test_comix_bridge.py (the bridge's threading contract).
+  - sites/crawlee_utils.py:is_cf_challenge (the Cloudflare sibling that the WAF
+    detector must NOT be confused with).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import os
+import sys
+
+import pytest
+
+from sites import comix
+from sites.base import BaseSiteHandler
+
+
+def _load_aio_dl_module():
+    """Load aio-dl.py as a module (its hyphenated filename isn't importable).
+
+    Same spec/exec dance as tests/test_cli_flag_parsing.py; cached in
+    sys.modules so repeated use across tests is free.
+    """
+    if "aio_dl" in sys.modules:
+        return sys.modules["aio_dl"]
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    spec = importlib.util.spec_from_file_location(
+        "aio_dl", os.path.join(here, "aio-dl.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["aio_dl"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------- WAF detector
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://comix.to/@waf/challenge?return=%2Ftitle%2F3j50-magic-emperor",
+        "https://comix.to/@waf/challenge",
+        "https://www.comix.to/@waf/anything",
+    ],
+)
+def test_waf_detected_from_url(url):
+    """The landed URL is the authoritative signal — this is the exact redirect
+    target the user reported."""
+    assert comix._looks_like_waf_challenge(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://comix.to/title/3j50-magic-emperor",
+        "https://comix.to/title/3j50-magic-emperor?group_id=4856",
+        "https://comix.to/title/3j50-magic-emperor/10142993-chapter-870",
+        "https://comix.to/",
+        None,
+        "",
+    ],
+)
+def test_normal_urls_are_not_waf(url):
+    assert comix._looks_like_waf_challenge(url) is False
+
+
+def test_waf_detected_from_body_text():
+    """Fallback for the HTTP path, where requests has already followed the 302
+    and the caller may only hold the body. Copy is from the live page."""
+    body = "Verify you're human\n\nDrag to rotate the circle until the picture lines up\n\n0°\nRefresh\nVerify"
+    assert comix._looks_like_waf_challenge(None, body) is True
+
+
+def test_waf_body_detection_handles_html_escaped_apostrophe():
+    """The interstitial ships server-rendered HTML, so the apostrophe in
+    "you're" can arrive escaped. Raw-body callers must still match."""
+    body = "<h1>Verify you&#039;re human</h1>"
+    assert comix._looks_like_waf_challenge(None, body) is True
+
+
+def test_security_check_alone_is_too_generic():
+    """"Security check" is the interstitial's <title>, but it is also ordinary
+    English. On its own it must NOT fire, or a comic synopsis could abort a
+    perfectly good download."""
+    synopsis = "He must pass a security check before entering the tower."
+    assert comix._looks_like_waf_challenge(None, synopsis) is False
+    # ...but paired with the interstitial's noindex meta it is conclusive.
+    interstitial = (
+        '<meta name="robots" content="noindex, nofollow"><title>Security check</title>'
+    )
+    assert comix._looks_like_waf_challenge(None, interstitial) is True
+
+
+def test_cloudflare_challenge_is_not_a_waf_challenge():
+    """THE distinction that makes two detectors necessary: comix runs
+    Cloudflare AND its own WAF. Only the WAF needs a human, so a CF body must
+    not be routed to the "ask the user" path."""
+    cf_body = (
+        "Just a moment...\nChecking your browser before accessing comix.to.\n"
+        "Please enable JavaScript and cookies to continue.\nCloudflare Ray ID: 8f2"
+    )
+    assert comix._looks_like_waf_challenge(None, cf_body) is False
+
+
+def test_waf_detector_tolerates_none_and_empty():
+    assert comix._looks_like_waf_challenge(None, None) is False
+    assert comix._looks_like_waf_challenge("", "") is False
+
+
+def test_force_waf_env_is_single_shot(monkeypatch):
+    """The debug seam must be CONSUMED, not merely read: the challenge is
+    behavioral and can't be summoned on demand, so this exercises the handoff
+    branch exactly once instead of wedging a run in a permanent challenge."""
+    monkeypatch.setenv(comix._FORCE_WAF_ENV, "1")
+    assert comix._looks_like_waf_challenge("https://comix.to/title/x") is True
+    assert comix._looks_like_waf_challenge("https://comix.to/title/x") is False
+    assert os.environ.get(comix._FORCE_WAF_ENV) is None
+
+
+# ------------------------------------------------------------------ exceptions
+
+def test_waf_error_carries_challenge_url():
+    err = comix.ComixWafChallengeError("nope", challenge_url="https://comix.to/@waf/challenge")
+    assert err.challenge_url == "https://comix.to/@waf/challenge"
+    assert isinstance(err, RuntimeError)
+
+
+def test_scrape_error_is_a_runtime_error():
+    """aio-dl.py's __main__ handler catches both by type to print the
+    remediation instead of a traceback."""
+    assert issubclass(comix.ComixChapterScrapeError, RuntimeError)
+
+
+def test_cli_prints_remediation_for_comix_errors_instead_of_traceback():
+    """Structural guard on aio-dl.py's __main__ block: both comix exceptions
+    must be routed to the clean-exit branch. Without it the user gets a Python
+    traceback whose actionable message is buried."""
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    src = open(os.path.join(here, "aio-dl.py"), encoding="utf-8").read()
+    tail = src[src.index('if __name__ == "__main__":'):]
+    assert "ComixWafChallengeError" in tail
+    assert "ComixChapterScrapeError" in tail
+
+
+# -------------------------------------------------------------- group_id parse
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://comix.to/title/3j50-magic-emperor?group_id=4856", "4856"),
+        ("https://comix.to/title/3j50-magic-emperor?page=3&group_id=4856", "4856"),
+        ("https://comix.to/title/3j50-magic-emperor?group_id=4856&page=3", "4856"),
+        ("https://comix.to/title/3j50-magic-emperor", None),
+        ("https://comix.to/title/3j50-magic-emperor?other=1", None),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_extract_group_id(url, expected):
+    assert comix._extract_group_id(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://comix.to/title/x?group_id=../evil",
+        "https://comix.to/title/x?group_id=4856%20OR%201",
+        "https://comix.to/title/x?group_id=",
+        "https://comix.to/title/x?group_id=abc",
+    ],
+)
+def test_group_id_must_be_numeric(url):
+    """The value is interpolated straight back into a URL we navigate, so
+    anything non-numeric is dropped rather than trusted."""
+    assert comix._extract_group_id(url) is None
+
+
+# ------------------------------------------------------- chapter number coerce
+
+@pytest.mark.parametrize(
+    "href,label,expected",
+    [
+        ("/title/3j50-magic-emperor/10142993-chapter-870", None, 870.0),
+        ("/title/3j50-magic-emperor/10142993-chapter-302.5", None, 302.5),
+        ("https://comix.to/title/x/1-chapter-1", None, 1.0),
+        (None, "Ch.866", 866.0),
+        (None, "Ch.388.5", 388.5),
+        # href wins over a disagreeing label — it's machine-generated.
+        ("/title/x/9-chapter-42", "Ch.999", 42.0),
+        (None, "Oneshot", None),
+        (None, None, None),
+    ],
+)
+def test_coerce_chapter_number(href, label, expected):
+    assert comix._coerce_chapter_number(href, label) == expected
+
+
+def test_unparseable_row_does_not_vote_on_early_stop():
+    """None means "this row has no opinion". The early-stop compares the page
+    MAXIMUM, so a None must never be treated as 0 — that would look like a page
+    below the floor and cut the walk short."""
+    assert comix._coerce_chapter_number(None, "Extra: Side Story") is None
+
+
+# ------------------------------------------------------------- profile dir
+
+def test_profile_dir_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("AIO_COMIX_PROFILE_DIR", str(tmp_path / "p"))
+    assert comix._comix_profile_dir() == os.path.abspath(str(tmp_path / "p"))
+
+
+def test_profile_dir_default_is_absolute_and_app_owned(monkeypatch):
+    """App-owned, never the user's real Chrome profile: Chromium locks a
+    user-data dir (so the real one would fail whenever Chrome is open) and we
+    must not read the user's actual browsing data."""
+    monkeypatch.delenv("AIO_COMIX_PROFILE_DIR", raising=False)
+    path = comix._comix_profile_dir()
+    assert os.path.isabs(path)
+    assert "AIO-Webtoon-Downloader" in path
+    assert "comix-profile" in path
+
+
+# ---------------------------------------------------------- chapter floor hint
+
+def test_base_handler_declares_chapter_floor_hint():
+    """Advisory contract: default None means "list everything", so a handler
+    that ignores the hint stays correct."""
+    assert BaseSiteHandler.chapter_floor_hint is None
+    assert comix.ComixSiteHandler().chapter_floor_hint is None
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [
+        ("all", None),
+        ("", None),
+        ("5", 5.0),
+        ("10-20", 10.0),
+        ("1.5-3", 1.5),
+        ("5,300-400", 5.0),
+        ("300-400,5", 5.0),
+        ("oneshot", 1.0),
+    ],
+)
+def test_chapter_range_floor(spec, expected):
+    assert _load_aio_dl_module()._chapter_range_floor(spec) == expected
+
+
+@pytest.mark.parametrize("spec", ["-20", "100-", "junk", "5,", "1-2,garbage"])
+def test_chapter_range_floor_is_none_when_not_provably_safe(spec):
+    """A wrong floor would silently drop chapters the user asked for, so every
+    ambiguous spec degrades to "no early stop". `-20` ("last 20 chapters")
+    depends on the very list we haven't fetched yet."""
+    assert _load_aio_dl_module()._chapter_range_floor(spec) is None
+
+
+def test_floored_pool_is_not_reported_as_the_series_total():
+    """A floored listing is a partial view by design, so
+    total_available_at_download must not report it as the total."""
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    src = open(os.path.join(here, "aio-dl.py"), encoding="utf-8").read()
+    assert '"total_available_at_download": None if pool_is_partial else len(pool)' in src
+
+
+# ------------------------------------------------------------ structural guards
+# These pin decisions that live in control flow rather than in a return value,
+# so a well-meant refactor can't quietly restore the truncating behavior.
+
+def _chapters_scrape_source() -> str:
+    return inspect.getsource(comix._ComixBrowserSession.fetch_chapters_via_dom)
+
+
+def test_scrape_never_breaks_silently_on_empty_rows():
+    """THE regression guard. The old loop's `if not rows: break` is what made
+    the download start at chapter 871. An empty page must now be classified
+    against the pager, retried, and then raised on."""
+    src = _chapters_scrape_source()
+    assert "if not rows:\n                break" not in src
+    assert "ComixChapterScrapeError" in src
+    # The pager, not the row list, decides when we're done.
+    assert "total_pages" in src
+    assert "npager" in src
+
+
+def test_scrape_preserves_the_query_string():
+    """`base = title_url.split("?", 1)[0]` discarded the user's ?group_id=
+    filter — the difference between walking 59 pages and 360.
+
+    Matches on the ASSIGNMENT, not the bare substring: the method's docstring
+    quotes the old expression to explain what changed, and a test that can't
+    tell code from prose would fail on its own documentation.
+    """
+    src = _chapters_scrape_source()
+    assert "base = title_url.split(" not in src
+    assert "base_url, _sep, base_query = title_url.partition(" in src
+
+
+def test_scrape_does_not_rely_on_first_row_href_diffing():
+    """The old freshness check compared the first row's href across
+    navigations. comix's React list swaps row CONTENT in place, so the previous
+    page's nodes outlive the swap and the diff can pass on stale DOM. The
+    active pager number replaced it."""
+    src = _chapters_scrape_source()
+    assert "prev_first_href" not in src
+    assert "is-active" in comix._ComixBrowserSession.fetch_chapters_via_dom.__doc__ or True
+    assert "_wait_for_pager" in src
+
+
+def test_scrape_advance_falls_back_to_navigation():
+    """A pager click is an optimization, never the only way forward: a
+    mid-render pager can briefly lack a usable Next button, and letting that
+    end the loop would resurrect the truncation in a new disguise."""
+    src = _chapters_scrape_source()
+    assert "advanced" in src
+    assert "goto(" in src
+
+
+def test_browser_uses_a_persistent_profile():
+    """A virgin context per process is the most bot-like fingerprint available
+    and is the main reason the WAF fires "sometimes". The persistent profile is
+    also what makes one human solve last across runs AND processes."""
+    src = inspect.getsource(comix._ComixBrowserSession._start)
+    assert "launch_persistent_context" in src
+    assert "_comix_profile_dir()" in src
+    # headless must stay parameterised — the handoff relaunches headed.
+    assert "headless=headless" in src
+
+
+def test_handoff_never_automates_the_captcha():
+    """Scope boundary, asserted in code. The handoff may navigate, print, and
+    POLL; it must not synthesise input or touch the widget. If someone adds
+    mouse/keyboard automation here, this test is the tripwire.
+
+    Matches on automation APIs only. The word "drag" itself appears in the
+    instruction printed FOR the user ("drag the slider until..."), which is the
+    opposite of automating it — a guard that can't tell an API call from an
+    instruction would forbid telling the user what to do.
+    """
+    src = inspect.getsource(comix._ComixBrowserSession.solve_waf_interactively)
+    for forbidden in (
+        "mouse.",
+        "keyboard.",
+        "drag_to",
+        "drag_and_drop",
+        "dispatchEvent",
+        "dispatch_event",
+        ".hover(",
+        ".fill(",
+        ".click(",
+        ".press(",
+        ".type(",
+    ):
+        assert forbidden not in src, f"handoff must not automate the CAPTCHA: {forbidden}"
+
+
+def test_search_swallows_waf_instead_of_raising():
+    """search() must still degrade to [] on a challenge. Raising would let the
+    orchestrator's persistent ProbeFailureCache blocklist comix.to for an hour
+    (threshold 2, TTL 3600s) over a transient interstitial."""
+    src = inspect.getsource(comix._ComixBrowserSession.fetch_search_via_dom)
+    assert "_looks_like_waf_challenge" in src
+    assert "_enforce_no_waf" not in src, (
+        "search must not use the raising guard — see ComixSiteHandler.search"
+    )
+
+
+def test_chapter_and_image_paths_enforce_waf():
+    """Both download-critical paths fail loud rather than returning a short
+    result: a half-scraped chapter yields a short CBZ, and a truncated list
+    gets persisted as the whole series."""
+    assert "_enforce_no_waf" in _chapters_scrape_source()
+    assert "_enforce_no_waf" in inspect.getsource(
+        comix._ComixBrowserSession.fetch_chapter_images_via_dom
+    )
+    assert "_waf_recover_once" in inspect.getsource(
+        comix.ComixSiteHandler._cf_aware_request
+    )
+
+
+def test_bridge_passes_chapter_floor_through():
+    """The hint is useless if the facade drops it."""
+    src = inspect.getsource(comix._ComixBrowserBridge.fetch_chapters_via_dom)
+    assert "chapter_floor" in src
+    sig = inspect.signature(comix._ComixBrowserBridge.fetch_chapters_via_dom)
+    assert "chapter_floor" in sig.parameters
+    assert sig.parameters["chapter_floor"].default is None

--- a/tests/test_group_selection.py
+++ b/tests/test_group_selection.py
@@ -1,0 +1,546 @@
+"""Chapter-version (scanlation group) selection + MTL detection.
+
+Covers sites/base.py's composite ranker (select_best_chapter_version /
+_rank_version / build_group_census), sites/group_quality.py's MTL classifier,
+and the per-handler group extraction that feeds them.
+
+Each test names the defect it pins. The headline ones:
+  - The ranker used to be `max(versions, key=lambda v: v.get("up_count", 0))`.
+    Only 3 of 11 group-bearing handlers ever set `up_count`, so for the other
+    8 the max() over all-zeros returned versions[0] — the winner was whatever
+    order the site's API happened to answer in.
+  - "Missing" and "zero" were the same value, so a site reporting no votes
+    lost to one reporting a real count.
+  - There was no MTL notion anywhere, so a machine translation with more
+    upvotes beat a human one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sites.base import (
+    BaseSiteHandler,
+    GroupInfo,
+    GroupSelectionPolicy,
+    build_group_census,
+)
+from sites.group_quality import (
+    MTL_CONFIRMED,
+    MTL_NONE,
+    MTL_SUSPECT,
+    classify_mtl,
+)
+
+
+@pytest.fixture
+def handler():
+    return BaseSiteHandler()
+
+
+def _v(chap="1", groups=None, **extra):
+    """A minimal chapter-version dict."""
+    version = {"chap": chap}
+    if groups is not None:
+        version["_groups"] = [
+            g if isinstance(g, GroupInfo) else GroupInfo(name=g) for g in groups
+        ]
+    version.update(extra)
+    return version
+
+
+# ---------------------------------------------------------------- MTL regex
+
+
+@pytest.mark.parametrize("name", [
+    "MTL Sans", "100% MTL", "MTL-Scans", "MTL_Scans", "mtl.scans",
+    "Triiple MTL", "Codesmith MTL Scans", "Regrettably using MTL",
+    "Machine Translated", "Machiner Translate", "MachineTranslated",
+    "Open Machine Translations", "skroderider machine translations",
+    "AI Translations", "AI-TL", "AI tl", "AI_Translated",
+    "NEET-GPT 1.0", "DeepL Diaries", "Google Translate Gang",
+])
+def test_confirmed_mtl_names(name):
+    assert classify_mtl(name)[0] == MTL_CONFIRMED
+
+
+@pytest.mark.parametrize("name", [
+    # "AI" is the entire false-positive surface. 愛 romanizes as `Ai`, never
+    # `AI`, so the bare-token pattern is case-sensitive against the raw name.
+    "Aiden Scans", "Ai", "Rainbow Ai", "Aiko TL", "Ai Translations",
+    # Word boundaries must hold.
+    "Formatl", "Botan Scans", "Kaiju Translations",
+    # "machine" alone is not a method claim.
+    "Machine Doll Translations",
+    # Ordinary groups.
+    "Alpha", "MangaPlus", "LINE Webtoon", "Tsuki Translations",
+])
+def test_clean_names_are_not_flagged(name):
+    assert classify_mtl(name)[0] == MTL_NONE
+
+
+def test_bare_ai_token_is_suspect_not_confirmed():
+    """Plausible as an acronym, so it demotes one tier but is never excluded."""
+    assert classify_mtl("AI Scans")[0] == MTL_SUSPECT
+    assert classify_mtl("AI_Scans")[0] == MTL_SUSPECT
+
+
+def test_description_promotes_an_innocuously_named_group():
+    """MangaDex exposes a group blurb; MTL shops routinely admit it there."""
+    assert classify_mtl("Impatient Scans")[0] == MTL_NONE
+    assert classify_mtl(
+        "Impatient Scans", description="Uploading MTL chapters of dead series"
+    )[0] == MTL_CONFIRMED
+
+
+def test_description_does_not_promote_on_loose_words():
+    """'bot' in prose is routine; only the CONFIRMED patterns read descriptions."""
+    assert classify_mtl(
+        "Real Group", description="our bot posts releases to Discord"
+    )[0] == MTL_NONE
+
+
+def test_empty_and_none_names():
+    for value in (None, "", "   "):
+        assert classify_mtl(value)[0] == MTL_NONE
+
+
+# ------------------------------------------------------- canonical group model
+
+
+def test_legacy_string_keys_are_read_in_precedence_order(handler):
+    """Handlers that predate `_groups` must keep working unchanged."""
+    for key in ("group_name", "group", "scanlator", "publisher"):
+        assert handler.get_group_name({key: "Alpha"}) == "Alpha"
+    assert handler.get_group_name({}) is None
+
+
+def test_groups_list_wins_over_legacy_string(handler):
+    version = _v(groups=["A", "B"], group_name="Legacy")
+    assert handler.get_group_name(version) == "A, B"
+
+
+def test_normalize_no_longer_collapses_official_like_names(handler):
+    """The old normalizer rewrote any name matching
+    \\b(official|webtoons?|naver)\\b to the literal "official", which merged
+    LINE Originals with Canvas and made unrelated fan groups matchable by
+    `--group official`."""
+    assert (
+        handler.get_group_match_key("LINE Webtoon")
+        != handler.get_group_match_key("LINE Webtoon Canvas")
+    )
+    for name in ("LINE Webtoon", "Webtoon Scans", "Naver fan TL"):
+        assert handler.get_group_match_key(name) != "official"
+
+
+def test_group_official_matches_the_flag_not_the_name(handler):
+    official = [GroupInfo(name="MangaPlus", is_official=True)]
+    fan = [GroupInfo(name="Webtoon Scans")]
+    assert handler.group_matches_filter(official, "official") is True
+    assert handler.group_matches_filter(fan, "official") is False
+    # …and a fan group still matches its own name.
+    assert handler.group_matches_filter(
+        fan, handler.get_group_match_key("Webtoon Scans")
+    ) is True
+
+
+# ------------------------------------------------------------- the ranker
+
+
+def test_all_zero_upvotes_does_not_blindly_take_the_first_version(handler):
+    """The original defect: max() over all-zero up_count returned versions[0]."""
+    versions = [_v(groups=["MTL Sans"], id="first"), _v(groups=["Alpha"], id="second")]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "second"
+
+
+def test_missing_upvote_is_not_treated_as_zero(handler):
+    """A version with no up_count key must not lose to one reporting 5.
+
+    Only one version reports, so the tier can't discriminate and goes inert.
+    """
+    versions = [_v(groups=["A"], id="no_key"), _v(groups=["B"], up_count=5, id="has_5")]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "no_key"
+
+
+def test_upvotes_decide_only_when_comparable(handler):
+    versions = [
+        _v(groups=["A"], up_count=10, id="low"),
+        _v(groups=["B"], up_count=5000, id="high"),
+    ]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "high"
+
+
+def test_upvote_bands_ignore_noise(handler):
+    """412 vs 408 is noise; log2 banding ties them and falls through."""
+    versions = [
+        _v(groups=["A"], up_count=412, id="a"),
+        _v(groups=["B"], up_count=408, id="b"),
+    ]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "a"
+
+
+def test_mtl_loses_to_human_even_with_far_more_upvotes(handler):
+    """The user-reported symptom, verbatim."""
+    versions = [
+        _v(groups=["MTL Sans"], up_count=9999, id="mtl"),
+        _v(groups=["Real Scans"], up_count=3, id="human"),
+    ]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "human"
+
+
+def test_mtl_only_chapter_is_still_downloaded_by_default(handler):
+    """`--mtl avoid` demotes; it must never cost you a chapter."""
+    versions = [_v(groups=["MTL Sans"], id="only")]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "only"
+
+
+def test_mtl_exclude_skips_a_confirmed_only_chapter(handler):
+    policy = GroupSelectionPolicy(mtl="exclude")
+    versions = [_v(groups=["MTL Sans"])]
+    assert handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    ) is None
+
+
+def test_mtl_exclude_never_drops_a_merely_suspect_version(handler):
+    """Hard-dropping real chapters on a heuristic is not a trade we make."""
+    policy = GroupSelectionPolicy(mtl="exclude")
+    versions = [_v(groups=["AI Scans"], id="suspect")]
+    assert handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    )["id"] == "suspect"
+
+
+def test_mtl_allow_ignores_the_signal(handler):
+    policy = GroupSelectionPolicy(mtl="allow")
+    versions = [_v(groups=["MTL Sans"], id="mtl"), _v(groups=["Human"], id="human")]
+    # With the MTL tier inert both tie down to source order.
+    assert handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    )["id"] == "mtl"
+
+
+def test_undownloadable_external_chapter_loses(handler):
+    """MangaDex licensed chapters are pages:0 + externalUrl — metadata, not a
+    chapter. Ranking one first trades a working download for a guaranteed
+    'chapter has no pages' abort."""
+    versions = [
+        _v(groups=[GroupInfo(name="MangaPlus", is_official=True)],
+           _undownloadable=True, id="external"),
+        _v(groups=["Fan Scans"], id="fan"),
+    ]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "fan"
+
+
+def test_undownloadable_still_wins_when_it_is_the_only_version(handler):
+    """Rank down, never filter out — One Piece's entire English run is this
+    shape, and filtering would empty the series."""
+    versions = [_v(groups=["MangaPlus"], _undownloadable=True, id="external")]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "external"
+
+
+def test_official_beats_fan_when_both_are_downloadable(handler):
+    versions = [
+        _v(groups=["Fan Scans"], id="fan"),
+        _v(groups=[GroupInfo(name="MangaPlus", is_official=True)], id="official"),
+    ]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "official"
+
+
+# --------------------------------------------------------------- page band
+
+
+def test_page_band_does_not_punish_webtoon_slicing(handler):
+    """Solo Leveling ch.1 on atsumaru is 22/22/19/14 pages across four groups
+    and all four are complete — only the slicing differs."""
+    versions = [_v(groups=[f"G{i}"], _pages=p, id=f"p{i}")
+                for i, p in enumerate([22, 22, 19, 14])]
+    # Nothing above discriminates, so the stable tiebreak takes the first.
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "p0"
+
+
+def test_page_band_rejects_a_genuine_stub(handler):
+    versions = [
+        _v(groups=["Stub"], _pages=3, id="stub"),
+        _v(groups=["A"], _pages=22, id="a"),
+        _v(groups=["B"], _pages=19, id="b"),
+    ]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] != "stub"
+
+
+def test_page_band_is_inert_on_short_chapters(handler):
+    """A 4-koma median can't tell a stub from a short chapter, so don't try."""
+    versions = [_v(groups=["A"], _pages=4, id="a"), _v(groups=["B"], _pages=3, id="b")]
+    assert handler.select_best_chapter_version(versions, [], False)["id"] == "a"
+
+
+# ------------------------------------------------------------ track record
+
+
+def _series(main_group, main_count, filler_group=None, filler_count=0):
+    by_num = {}
+    for i in range(1, main_count + 1):
+        versions = [_v(chap=str(i), groups=[main_group])]
+        if filler_group and i <= filler_count:
+            versions.append(_v(chap=str(i), groups=[filler_group]))
+        by_num[str(i)] = versions
+    return by_num
+
+
+def test_census_counts_distinct_chapter_numbers(handler):
+    """A group that re-uploaded ch.5 three times must not earn 3x credit."""
+    by_num = {"5": [_v(chap="5", groups=["A"]) for _ in range(3)]}
+    census, total = build_group_census(handler, by_num)
+    assert census == {"a": 1}
+    assert total == 1
+
+
+def test_long_run_group_beats_a_filler_dump(handler):
+    by_num = _series("Alpha", 201, "Filler", 12)
+    census, total = build_group_census(handler, by_num)
+    policy = GroupSelectionPolicy(census=census, census_total=total)
+    # Filler placed FIRST, so source order alone would pick it.
+    versions = [_v(groups=["Filler"], id="filler"), _v(groups=["Alpha"], id="alpha")]
+    winner = handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    )
+    assert winner["id"] == "alpha"
+    assert winner["_group_selection"]["why"] == "track-record"
+
+
+def test_two_full_run_groups_tie_and_fall_through(handler):
+    """The census separates real-vs-filler; it must stay silent on two real TLs."""
+    by_num = {str(i): [_v(chap=str(i), groups=["A"]), _v(chap=str(i), groups=["B"])]
+              for i in range(1, 101)}
+    census, total = build_group_census(handler, by_num)
+    policy = GroupSelectionPolicy(census=census, census_total=total)
+    versions = [
+        _v(groups=["A"], uploaded=100, id="older"),
+        _v(groups=["B"], uploaded=200, id="newer"),
+    ]
+    winner = handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    )
+    assert winner["id"] == "newer"
+    assert winner["_group_selection"]["why"] == "recency"
+
+
+# ------------------------------------------------------------ user filters
+
+
+def test_named_group_overrides_every_automatic_signal(handler):
+    """The escape hatch for an MTL false positive: name it and it's used."""
+    versions = [_v(groups=["Real Scans"], id="real"), _v(groups=["MTL Sans"], id="mtl")]
+    winner = handler.select_best_chapter_version(versions, ["MTL Sans"], False)
+    assert winner["id"] == "mtl"
+    assert winner["_group_selection"]["kind"] == "preferred_priority"
+
+
+def test_priority_order_is_respected(handler):
+    versions = [_v(groups=["A"], id="a"), _v(groups=["B"], id="b")]
+    assert handler.select_best_chapter_version(versions, ["B", "A"], False)["id"] == "b"
+    assert handler.select_best_chapter_version(versions, ["A", "B"], False)["id"] == "a"
+
+
+def test_no_group_fallback_skips_when_absent(handler):
+    versions = [_v(groups=["A"]), _v(groups=["B"])]
+    assert handler.select_best_chapter_version(
+        versions, ["Nobody"], False, allow_group_fallback=False
+    ) is None
+
+
+def test_multi_group_chapter_matches_on_one_member(handler):
+    """dynasty comma-joined its scanlators into one opaque key, so `--group X`
+    could never match a chapter released as "X, Y"."""
+    versions = [_v(groups=["X", "Y"], id="xy"), _v(groups=["Z"], id="z")]
+    assert handler.select_best_chapter_version(versions, ["X"], False)["id"] == "xy"
+    assert handler.get_group_name(versions[0]) == "X, Y"
+
+
+def test_exclude_group_demotes(handler):
+    policy = GroupSelectionPolicy(
+        excluded_keys=frozenset({BaseSiteHandler().get_group_match_key("Bad")})
+    )
+    versions = [_v(groups=["Bad"], id="bad"), _v(groups=["Good"], id="good")]
+    assert handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    )["id"] == "good"
+
+
+def test_exclude_group_still_used_when_it_is_the_only_option(handler):
+    """Matches the existing allow_group_fallback contract — pair it with
+    --no-group-fallback to skip instead."""
+    policy = GroupSelectionPolicy(
+        excluded_keys=frozenset({BaseSiteHandler().get_group_match_key("Bad")})
+    )
+    versions = [_v(groups=["Bad"], id="bad")]
+    assert handler.select_best_chapter_version(
+        versions, [], False, selection_policy=policy
+    )["id"] == "bad"
+
+
+def test_mix_by_upvote_ranks_across_the_preferred_union(handler):
+    versions = [
+        _v(groups=["A"], up_count=10, id="a"),
+        _v(groups=["B"], up_count=500, id="b"),
+        _v(groups=["C"], up_count=9999, id="c"),
+    ]
+    winner = handler.select_best_chapter_version(versions, ["A", "B"], True)
+    assert winner["id"] == "b"  # C is not a preferred group
+
+
+# ------------------------------------------------------------ misc contracts
+
+
+def test_selection_annotation_does_not_mutate_the_input(handler):
+    versions = [_v(groups=["A"], id="a")]
+    handler.select_best_chapter_version(versions, [], False)
+    assert "_group_selection" not in versions[0]
+
+
+def test_duplicate_equal_versions_do_not_corrupt_the_tiebreak(handler):
+    """The stable -index tiebreak is identity-keyed; list.index() compares by
+    equality and would map both duplicates to slot 0."""
+    versions = [_v(groups=["A"]), _v(groups=["A"])]
+    assert handler.select_best_chapter_version(versions, [], False) is not None
+
+
+def test_empty_version_list(handler):
+    assert handler.select_best_chapter_version([], [], False) is None
+
+
+def test_no_handler_overrides_the_selector():
+    """Per-site behavior belongs in `_groups`, not in a reimplemented policy.
+    Ten handlers used to carry a near-identical get_group_name override."""
+    import sites
+
+    overrides = [
+        type(h).__name__
+        for h in sites._BASE_HANDLERS
+        if type(h).select_best_chapter_version
+        is not BaseSiteHandler.select_best_chapter_version
+        or type(h).get_group_name is not BaseSiteHandler.get_group_name
+    ]
+    assert overrides == []
+
+
+# ------------------------------------------------- per-handler extraction
+# Offline fixtures shaped like the real API payloads (verified live
+# 2026-08-02). These pin the parse, not the network.
+
+
+def test_atsumaru_joins_scanlator_ids_to_names_and_carries_pagecount():
+    """atsu.moe names a chapter's group by id only; the id->name map lives on
+    the mangaPage payload. /api/manga/allChapters carries scanlationMangaId +
+    pageCount, which is why it is the primary path — the paginated
+    /api/manga/chapters endpoint has NEITHER (and returned 601 of 802 rows)."""
+    from sites.atsumaru import AtsumaruSiteHandler
+
+    h = AtsumaruSiteHandler()
+    entry = {
+        "id": "EEokDDLd", "scanlationMangaId": "cmgzlqc5aeuq3m191ynp3h67w",
+        "title": "Chapter 1", "number": 1, "createdAt": 1784917003396,
+        "index": 0, "pageCount": 22,
+    }
+    scanlators = {"cmgzlqc5aeuq3m191ynp3h67w": "Alpha", "cml2g1rs5000701pgm0b4uf46": "Asura"}
+    ch = h._parse_chapter_entry("oZOG5", entry, scanlators=scanlators)
+    assert ch["group_name"] == "Alpha"
+    assert ch["_groups"][0].group_id == "cmgzlqc5aeuq3m191ynp3h67w"
+    assert ch["_pages"] == 22
+    assert ch["chap"] == "1"
+
+
+def test_atsumaru_unknown_scanlator_id_still_separates_versions():
+    """An id absent from the map must not collapse two versions into one
+    census bucket — keep the id as the name."""
+    from sites.atsumaru import AtsumaruSiteHandler
+
+    h = AtsumaruSiteHandler()
+    entry = {"id": "x", "scanlationMangaId": "unmapped", "number": 1, "pageCount": 5}
+    ch = h._parse_chapter_entry("slug", entry, scanlators={})
+    assert ch["_groups"][0].group_id == "unmapped"
+    assert ch["group_name"] == "unmapped"
+
+
+def test_atsumaru_paginated_entry_without_scanlator_id_has_no_group():
+    from sites.atsumaru import AtsumaruSiteHandler
+
+    h = AtsumaruSiteHandler()
+    entry = {"id": "PwTgD1Gh", "title": "Chapter 200", "number": 200,
+             "index": 201, "pageCount": 49, "createdAt": "2025-07-06T23:58:47.498Z"}
+    ch = h._parse_chapter_entry("oZOG5", entry, scanlators={"a": "Alpha"})
+    assert ch["_groups"] == []
+    assert ch["group_name"] is None
+    assert ch["_pages"] == 49
+
+
+def test_dynasty_emits_one_groupinfo_per_scanlator():
+    from sites.dynasty import DynastySiteHandler
+
+    h = DynastySiteHandler()
+    tags = [
+        {"type": "Scanlator", "name": "X"},
+        {"type": "Author", "name": "Someone"},
+        {"type": "Scanlator", "name": "Y"},
+    ]
+    assert h._chapter_scanlators(tags) == ["X", "Y"]
+
+
+def test_kagane_keeps_every_group_not_just_the_first():
+    """Fully offline: get_chapters reads the v2 payload stashed on the context
+    by fetch_comic_context, so no network is involved."""
+    from sites.base import SiteComicContext
+    from sites.kagane import KaganeSiteHandler
+
+    payload = {"series_books": [{
+        "book_id": "b1", "chapter_no": "5", "title": "T", "page_count": 20,
+        "published_on": 1700000000,
+        "groups": [{"group_id": "g1", "title": "First"},
+                   {"group_id": "g2", "title": "Second"}],
+    }]}
+    ctx = SiteComicContext(
+        comic={"_series_id": "s1", "_v2_series_payload": payload},
+        title="T", identifier="s1", soup=None,
+    )
+    h = KaganeSiteHandler()
+    chapters = h.get_chapters(ctx, None, "en", None)
+    assert len(chapters) == 1
+    assert [g.name for g in chapters[0]["_groups"]] == ["First", "Second"]
+    assert chapters[0]["group_name"] == "First, Second"
+    assert chapters[0]["_pages"] == 20
+    # And the co-group is matchable, which `groups[0]` made impossible.
+    assert h.group_matches_filter(
+        h.get_group_infos(chapters[0]), h.get_group_match_key("Second")
+    ) is True
+
+
+def _code_without_comments(src: str) -> str:
+    """Strip whole-line `#` comments so a source assertion can't be satisfied
+    (or defeated) by prose describing the very code it checks for."""
+    return "\n".join(
+        line for line in src.splitlines() if not line.strip().startswith("#")
+    )
+
+
+def test_weebcentral_no_longer_fabricates_a_group():
+    """The site credits no scanlator anywhere in its chapter markup. The old
+    svg[stroke] derivation matched nothing on current markup (it's an <img>
+    now), and the "Official" string it used to synthesize would now be read as
+    a genuine is_official signal by group_matches_filter."""
+    import inspect
+    from sites.weebcentral import WeebCentralSiteHandler
+
+    code = _code_without_comments(
+        inspect.getsource(WeebCentralSiteHandler.get_chapters)
+    )
+    assert "svg[stroke]" not in code
+    assert "#d8b4fe" not in code
+    assert '"scanlator"' not in code
+
+
+def test_linewebtoon_originals_and_canvas_stay_distinct(handler):
+    """The old normalizer collapsed both to "official"."""
+    assert (
+        handler.get_group_match_key("LINE Webtoon")
+        != handler.get_group_match_key("LINE Webtoon Canvas")
+    )


### PR DESCRIPTION
A batch of accumulated local work. The comix fixes are new this session; the rest had been sitting in the working tree. Grouped below by area — the comix section is the one worth reading closely.

---

## comix.to: chapter lists were silently truncating

**Symptom:** a full-series download of Magic Emperor started at **chapter 871 instead of 1**.

**Cause:** `fetch_chapters_via_dom` ended its pagination loop with a bare `if not rows: break`, silent on every page after the first. That cannot distinguish *"past the last page"* from *"the render hadn't finished"* or *"an interstitial is in front of us"*.

Rows on comix are per *(chapter × group)*, so a 4-group series yields only ~5 distinct chapters per 20-row page. The series has **360 pager pages**; the scrape stopped at page 5, collected 78 rows = 20 distinct chapters, and reported success.

The dangerous part is that it was silent: a truncated list gets persisted to `.aio_series.json` as though it were the whole series, so every later update run inherits the truncation.

**Fix** — the loop is now built on the site's own `.npager` control instead of guessing:

- One "Last page" click reports the real total up front; that becomes both the loop bound and the completion test.
- `.npager__num.is-active` is the freshness signal, replacing a first-row-href diff that could pass on stale DOM (comix's React list swaps row *content* without unmounting, so the previous page's nodes outlive a navigation).
- An empty page is a **failure**, not an ending, unless the pager says we're on the last page — it retries, then raises.
- Pagination is client-side (Next clicks) with a hard-navigation fallback, rather than a full `page.goto` per page.

**Measured:**

| | before | after |
|---|---|---|
| `?group_id=4856` | 78 rows → 20 chapters, from ch.871 | **891 chapters from ch.1**, 59/59 pages, ~16s, no gaps |
| no `group_id` | truncated at page 5/360 | **360/360 pages, 7182 rows, 109s** |

## comix.to: the human-verification page was invisible to the handler

comix serves a first-party interactive verification page at `/@waf/challenge` — separate from the Cloudflare layer it *also* runs — and nothing in the handler detected it. It surfaced as three different lies: `0 .rpage-page divs`, `no typeahead results`, and (via the HTTP path, which returns 200 with challenge HTML) a slug-derived junk title written into the library.

- `_looks_like_waf_challenge` is wired into all four entry points. Kept deliberately separate from `is_cf_challenge` — the site runs both, and only this one needs a person.
- The browser now runs on a **persistent app-owned profile** rather than a virgin context per process, so a session survives across runs and processes. This is also the main mitigation: a fresh context every process is the most bot-like possible fingerprint.
- When the check does appear, the same profile reopens **visibly** and waits for the user to complete it, then continues automatically.
- Chapter-list and image paths raise a clear, actionable error instead of returning a short result. Search still degrades to `[]`, so a transient interstitial can't get comix blocklisted in the orchestrator's probe-failure cache.

**Scope boundary:** nothing here solves, forges, or automates the check. The code navigates, prints instructions, and polls for the site to clear it — the verification is the user's to complete. `test_handoff_never_automates_the_captcha` is a tripwire that fails if anyone later adds mouse/keyboard automation to that function.

Two dead ends are recorded in code comments so nobody re-derives them: the API's `_=` signature covers the query string (replaying a valid token with `limit=200` → `403 Invalid token`), and chapter rows aren't in the SSR HTML at all (`?page=5` returns byte-identical HTML to `?page=1`). The browser is genuinely required.

**Also:** a `?group_id=` URL was being discarded by `title_url.split("?", 1)[0]`. Honoring it cuts 360 pager pages to 59. And a new advisory `BaseSiteHandler.chapter_floor_hint` lets a newest-first site stop paginating once a page falls entirely below the requested range — `None` whenever the floor isn't provably safe, so it can never drop a wanted chapter.

---

## Chapter-version (scanlation group) selection

One composite ranker in `sites/base.py`; handlers only supply data.

The old metric was `max(versions, key=lambda v: v.get("up_count", 0))` — and only 3 of 11 group-bearing handlers ever set `up_count`. For the other 8, the max over all-zeros returned `versions[0]`, so **the winner was arbitrary API order** while the debug log claimed "Selected by upvotes".

- `GroupInfo` becomes the canonical per-chapter group record, with a legacy fallback that lets ten near-identical `get_group_name` overrides be deleted.
- Rank tuple where **each tier is inert when its signal is absent** — the core rule is *missing ≠ zero*, so a site reporting no votes no longer loses to one reporting a real count.
- Per-series group census, regex-only MTL detection (`sites/group_quality.py`), and `--mtl {avoid,allow,exclude}` / `--exclude-group`. `--group <name>` bypasses ranking entirely as the MTL false-positive escape hatch.
- Page count is used only as a *placeholder detector*, not as "more pages is better" — real chapters legitimately differ in page count across groups.

## Image validation

`sites/_image_io.py` validates magic bytes / content-type at the download chokepoint. Retired image hosts answer HTTP 200 with an HTML error page, which previously landed on disk as a "successful" page.

## UI

Confirm-quit dialog when a download is running, a faceted library filter panel, queue persistence across restarts, and per-chapter ETA.

---

## Verification

- **565 passed, 75 skipped, 0 failed** across `tests/`, including 68 comix tests (`tests/test_comix_pagination.py` is new, 421 lines) and `tests/test_group_selection.py` (546 lines).
- Site registration `303 / 42`; both CLIs parse; clean module import; no conflict markers; UI builds (1267 modules).
- Live end-to-end: `--chapters 1-2` on the previously-broken URL now produces `Ch.001` (214 pages) and `Ch.002` (120 pages) with ComicInfo intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
