### PR TITLE
comix: fix the every-10th-page capture failure, run headed, and speed up chapter capture

### DIFF
--- a/UI-source/electron/main.js
+++ b/UI-source/electron/main.js
@@ -899,6 +899,49 @@ function setupIPC() {
     );
   });
 
+  // ── comix.to sign-in ──
+  // Spawns `aio-dl.py --comix-login`, which opens comix.to in the downloader's
+  // own persistent Chromium profile and blocks until the user signs in (or the
+  // 300s wait elapses). The session is written into that profile and inherited
+  // by every later download/search process.
+  //
+  // The user types their credentials into the real comix.to page in a real
+  // browser window. Nothing about them is read, stored or forwarded by this app
+  // — we only wait for the site's own `auth` key to appear. Cross-file:
+  // sites/comix.py:open_login_window, aio-dl.py --comix-login.
+  //
+  // stdio is inherited-free (piped and discarded): the banner the child prints
+  // is for CLI users, and the renderer already knows what it asked for. Only the
+  // exit code matters here — 0 = signed in, 2 = not completed.
+  ipcMain.handle("comix:login", async () => {
+    const settings = history.getSettings();
+    const { pythonCmd, scriptPath, workingDir } = resolveSpawnPaths(settings);
+    return new Promise((resolve) => {
+      let proc;
+      try {
+        proc = spawn(pythonCmd, [scriptPath, "--comix-login"], {
+          cwd: workingDir,
+          env: { ...process.env, PYTHONUNBUFFERED: "1" },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (err) {
+        resolve({ ok: false, reason: err.message || String(err) });
+        return;
+      }
+      let stderr = "";
+      proc.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+      proc.on("error", (err) => {
+        resolve({ ok: false, reason: err.message || String(err) });
+      });
+      proc.on("close", (code) => {
+        resolve({
+          ok: code === 0,
+          reason: code === 0 ? "" : (stderr.trim() || `exited with ${code}`),
+        });
+      });
+    });
+  });
+
   // ── Scan library (read all downloaded manga) ──
   // Returns the list immediately. Missing thumbnails are generated
   // in the background using mupdf (WASM) in the main process.

--- a/UI-source/electron/preload.js
+++ b/UI-source/electron/preload.js
@@ -103,6 +103,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return () => ipcRenderer.removeListener("search-log", handler);
   },
 
+  // ── comix.to sign-in ──
+  // Runs `aio-dl.py --comix-login`, which opens comix.to in the downloader's own
+  // persistent browser profile and waits while the user signs in. Credentials
+  // are typed into the real site in a real window — nothing is read, stored or
+  // forwarded by us. Resolves {ok, reason}. Cross-file: main.js "comix:login",
+  // aio-dl.py --comix-login, sites/comix.py:open_login_window.
+  comixLogin: () => ipcRenderer.invoke("comix:login"),
+
   // ── Library (manga browser) ──
   scanLibrary: () => ipcRenderer.invoke("scan-library"),
   openFile: (path) => ipcRenderer.invoke("open-file", path),

--- a/UI-source/src/components/DownloadTab.jsx
+++ b/UI-source/src/components/DownloadTab.jsx
@@ -14,7 +14,7 @@ import {
   Button, Input, Textarea, Label, Switch, Slider, Select,
   Checkbox, SectionHeader, Collapsible, Badge,
 } from "@/components/ui/primitives";
-import { Download, Lock, Sparkles } from "lucide-react";
+import { Download, Lock, Sparkles, MonitorPlay, LogIn } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { LANGUAGES } from "@/lib/constants";
 
@@ -241,6 +241,107 @@ function TapasPremiumCallout({ active, onEnable }) {
   );
 }
 
+// ── comix.to browser callout ──────────────────────────────────────────────
+// comix is the only site whose DOWNLOAD path drives a real browser: its chapter
+// list, page URLs and search all sit behind a signed + encrypted API, so pages
+// are captured out of the rendered reader (grep fetch_chapter_images_via_dom).
+//
+// Two consequences the user has to know about BEFORE pressing Start, because
+// both look like bugs otherwise:
+//   1. A visible Chromium window opens and scrolls itself. It runs headed on
+//      purpose — comix's reader defers roughly every 10th page until it scrolls
+//      into view, which needs a live rendering lifecycle; headless chapters come
+//      out short (grep _COMIX_HEADLESS_ENV).
+//   2. Occasionally the site asks for human verification, and the run pauses on
+//      that window until it's completed.
+// Multi-source is the safety net for any chapter that still comes up short, so
+// this offers the same one-click enable as the tapas callout.
+const COMIX_URL_RE = /\bcomix\.to/i;
+function hasComixUrl(urls) {
+  return typeof urls === "string" && COMIX_URL_RE.test(urls);
+}
+
+function ComixBrowserCallout({ active, onEnable, onLogin }) {
+  return (
+    <div
+      className={cn(
+        "relative mt-2 overflow-hidden rounded-lg border px-4 py-3",
+        "animate-slide-up transition-colors duration-300",
+        active
+          ? "border-success/40 bg-gradient-to-br from-success/10 to-success/[0.02]"
+          : "border-info/40 bg-gradient-to-br from-info/10 to-info/[0.02]"
+      )}
+    >
+      {/* Left accent bar — same status-band idiom as the tapas callout. */}
+      <div
+        className={cn(
+          "absolute inset-y-0 left-0 w-1 transition-colors duration-300",
+          active ? "bg-success" : "bg-info"
+        )}
+      />
+      <div className="flex items-start gap-3 pl-1.5">
+        <div
+          className={cn(
+            "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+            "ring-1 transition-colors duration-300",
+            active
+              ? "bg-success/15 text-success ring-success/30"
+              : "bg-info/15 text-info ring-info/30"
+          )}
+        >
+          <MonitorPlay className="h-4 w-4" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <p className="text-xs font-semibold text-foreground">
+              A browser window will open
+            </p>
+            <Badge
+              variant="secondary"
+              className="h-4 px-1.5 font-mono text-[9px] uppercase tracking-wider"
+            >
+              comix.to
+            </Badge>
+          </div>
+          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+            comix pages are read out of its own reader, so a Chromium window
+            opens and scrolls through each chapter. Leave it alone while it
+            works &mdash; it closes itself. If the site asks you to verify
+            you&rsquo;re human, the download waits for you to do it.
+          </p>
+          <div className="mt-2.5 flex flex-wrap items-center gap-2.5">
+            {!active && (
+              <Button
+                size="sm"
+                onClick={onEnable}
+                className="h-7 gap-1.5 px-2.5 text-[11px] shadow-sm transition-transform active:scale-[0.97]"
+              >
+                <Sparkles className="h-3 w-3" />
+                Enable Multi-source
+              </Button>
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onLogin}
+              className="h-7 gap-1.5 px-2.5 text-[11px] transition-transform active:scale-[0.97]"
+            >
+              <LogIn className="h-3 w-3" />
+              Sign in to comix.to
+            </Button>
+            <span className="text-[10px] text-muted-foreground">
+              {active
+                ? "any chapter that comes up short is refilled from another site"
+                : "multi-source refills any chapter that comes up short"}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function formDefaults(settings) {
   return { ...DEFAULT_FORM, ...(settings?.defaults || {}) };
 }
@@ -459,6 +560,22 @@ export default function DownloadTab({
                   multiSourceLazy: true,
                 }))
               }
+            />
+          )}
+          {/* comix-only: a visible browser window is part of how this site is
+              downloaded at all (grep hasComixUrl / fetch_chapter_images_via_dom).
+              Warn before Start so the window isn't mistaken for a bug. */}
+          {hasComixUrl(form.urls) && (
+            <ComixBrowserCallout
+              active={form.multiSource}
+              onEnable={() =>
+                updateForm((prev) => ({
+                  ...prev,
+                  multiSource: true,
+                  multiSourceLazy: true,
+                }))
+              }
+              onLogin={() => window.electronAPI?.comixLogin?.()}
             />
           )}
         </div>

--- a/aio-dl.py
+++ b/aio-dl.py
@@ -235,7 +235,18 @@ class ChapterPermanentSkipError(Exception):
 #   - "locked": premium/wait-to-unlock episode emitted as a placeholder
 #     (get_chapter_images short-circuits it) so --multi-source can fill it; when
 #     no alt has it, this clean-skips instead of aborting the whole run.
-_PERMANENT_SKIP_REASONS = frozenset({"mature_login_required", "locked"})
+#   - "comix_pages_stalled" (sites/comix.py): comix's reader defers every 10th
+#     page — a chunk boundary — until the viewport reaches it, and when the
+#     handler's full recovery ladder (re-nudge → reload → lazy-mode) still can't
+#     reach one, re-rendering the identical chapter cannot either. Live
+#     2026-08-02: 99/107 captured, inline retry, 99/107, inline retry, 99/107,
+#     then the whole 256-chapter run aborted on chapter 1. The two 90s retries
+#     were pure cost. Note comix raises this ONLY for the deferral signature
+#     (grep _looks_like_stalled_capture); an ordinary render miss stays
+#     retryable as "comix_dom_render_incomplete".
+_PERMANENT_SKIP_REASONS = frozenset({
+    "mature_login_required", "locked", "comix_pages_stalled",
+})
 
 
 # -----------------------------------------------------------
@@ -4082,6 +4093,7 @@ def build_per_chapter_comic_info_xml(
     lang: str,
     page_count: int,
     aux_records: Optional[Dict[str, Any]] = None,
+    missing_pages: Optional[List[int]] = None,
 ) -> str:
     """Per-chapter ComicInfo.xml string for Komikku-mode CBZs.
 
@@ -4213,6 +4225,20 @@ def build_per_chapter_comic_info_xml(
         lines.append(f'  <AnilistId>{int(anilist_id)}</AnilistId>')
     if mal_id is not None:
         lines.append(f'  <MalId>{int(mal_id)}</MalId>')
+
+    # Pages the source could not deliver, recorded so a gap is never SILENT.
+    #
+    # Only ever populated under an explicit opt-in
+    # (--comix-allow-gapped-chapters). It exists because pages are renumbered
+    # 0001..000N on the way into the archive, so a chapter missing its 10th page
+    # is byte-for-byte indistinguishable from a complete one that simply had
+    # fewer pages — which is how a 67-of-68 chapter shipped unnoticed in
+    # 2026-08. These are the SOURCE's page numbers, not archive indices, so they
+    # stay meaningful after renumbering. Aio-prefixed and therefore dropped
+    # silently by Komga/Kavita, exactly like <AnilistId>.
+    if missing_pages:
+        joined = ",".join(str(int(p)) for p in sorted(missing_pages))
+        lines.append(f'  <AioMissingPages>{escape(joined)}</AioMissingPages>')
 
     # Auxiliary assets (audio / motion-toon) that ride INSIDE this CBZ under the
     # _aio/ prefix. Aio-prefixed custom elements — dropped silently by Komga/
@@ -8332,6 +8358,43 @@ def main():
              "flag skips all of that (images are unaffected). Not a resume-gating "
              "flag — toggling it doesn't invalidate downloaded images.",
     )
+    # ── comix.to browser controls ──────────────────────────────────────────
+    # comix is the only handler that drives a real browser for the DOWNLOAD path
+    # (its chapter list, page URLs and search are all behind a signed +
+    # encrypted API). These three flags surface the parts of that a user may
+    # legitimately need to steer. All of them just set the env vars sites/comix.py
+    # already reads, so the CLI and the env knobs share exactly one code path and
+    # neither can drift. None are resume-gating: they change HOW bytes are
+    # obtained, not WHICH bytes land (same reasoning as --no-fast-download).
+    p.add_argument(
+        "--comix-headless",
+        action="store_true",
+        help="Run comix.to's browser headless instead of showing a window. "
+             "NOT recommended: comix's reader defers roughly every 10th page "
+             "until it scrolls into view, which needs a live rendering "
+             "lifecycle, so headless chapters can come out short. Use this only "
+             "for unattended runs (cron/CI/headless servers). Equivalent to "
+             "AIO_COMIX_HEADLESS=1.",
+    )
+    p.add_argument(
+        "--comix-allow-gapped-chapters",
+        action="store_true",
+        help="Keep a comix.to chapter even when some pages could not be "
+             "captured, instead of skipping it. The shortfall is logged and the "
+             "missing page numbers are recorded in the chapter's ComicInfo.xml, "
+             "so the gap is never silent. Off by default — a skipped chapter "
+             "that --multi-source can refill from another site beats an archive "
+             "with invisible holes. Equivalent to AIO_COMIX_ALLOW_GAPPED=1.",
+    )
+    p.add_argument(
+        "--comix-login",
+        action="store_true",
+        help="Open comix.to in the downloader's own browser window and wait "
+             "while you sign in, then exit. The session is saved to the "
+             "persistent profile and reused by every later run. Your "
+             "credentials are typed into the real site — the downloader never "
+             "sees, stores or transmits them.",
+    )
     # ── Komikku-compatible per-chapter CBZ output (Komikku LocalSource format) ──
     # Writes per-chapter CBZs with per-chapter ComicInfo.xml, plus
     # cover.jpg and details.json at the series-folder root, matching the
@@ -8379,6 +8442,34 @@ def main():
             "--mangafire-image-concurrency is deprecated; use --image-concurrency",
             DeprecationWarning,
         )
+
+    # comix browser flags -> the env vars sites/comix.py already reads. Setting
+    # the env rather than threading args through means the CLI flag and the env
+    # knob cannot drift apart, and the handler stays usable from the search
+    # subprocess and the API server, neither of which sees `args`. Must run
+    # before any handler is constructed.
+    if getattr(args, "comix_headless", False):
+        os.environ["AIO_COMIX_HEADLESS"] = "1"
+    if getattr(args, "comix_allow_gapped_chapters", False):
+        os.environ["AIO_COMIX_ALLOW_GAPPED"] = "1"
+
+    if getattr(args, "comix_login", False):
+        # Standalone action: open the window, wait for the user to sign in, exit.
+        # Deliberately its own mode rather than a pre-step on a download — a
+        # login is a one-off that then persists in the profile for every later
+        # run, and blocking a download on it would be the wrong default.
+        from sites.comix import _COMIX_BROWSER_BRIDGE
+
+        outcome = _COMIX_BROWSER_BRIDGE.open_login_window() or {}
+        if outcome.get("signed_in"):
+            print("\n[*] comix.to sign-in saved. Future runs will reuse it.")
+            return
+        print(
+            f"\n[!] comix.to sign-in was not completed "
+            f"({outcome.get('reason') or 'unknown'}).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     if args.serve:
         try:
@@ -11667,6 +11758,7 @@ def main():
                                 lang=args.language,
                                 page_count=len(processed_page_images),
                                 aux_records=ch.get("_aux_records"),
+                                missing_pages=ch.get("_missing_pages"),
                             )
                             zf.writestr(
                                 "ComicInfo.xml",
@@ -11871,6 +11963,7 @@ def main():
                             lang=args.language,
                             page_count=len(cbz_images),
                             aux_records=ch.get("_aux_records"),
+                            missing_pages=ch.get("_missing_pages"),
                         )
                     with _cpu_guard('build_cbz'):
                         build_cbz(

--- a/sites/comix.py
+++ b/sites/comix.py
@@ -83,13 +83,64 @@ _COMIX_PAGE_POLL_INTERVAL_S = 0.25
 # the end rather than mid-walk. Still bounded by the caller's time_budget_s.
 _COMIX_CAPTURE_STALL_S = 20.0
 
-# Response headers that mark a page as server-side tile-scrambled. comix shipped
-# these through mid-2026 and they are the AUTHORITATIVE scramble signal — DOM
-# shape is not: the readiness poll checks <canvas> before <img>, so a transient
-# canvas would win the race on a perfectly ordinary page and get re-encoded
-# through toDataURL for nothing. Recorded (not acted on) so one live run can
-# settle whether the canvas branch is still earning its keep — see
-# _ComixBrowserSession._capture_image_response and the "capture shapes" summary.
+# Browser viewport for the reader.
+#
+# WHY NOT THE 1280x720 DEFAULT (2026-08-03). comix's reader defers every 10th
+# page — a chunk boundary — until the viewport approaches it, and pages are
+# 700x~1170 CSS px. At 720px tall barely one page is ever genuinely in view, so
+# reaching a boundary costs a scroll + an IntersectionObserver round trip EACH.
+# A tall viewport puts 2-3 pages in view at once, which both cuts the number of
+# transitions needed and gives the reader's own preloader a wider horizon.
+#
+# 2400 rather than something enormous: the page bitmaps are decoded at this size,
+# so an absurd viewport costs real memory across a 100+ page chapter for no
+# additional loading benefit.
+_COMIX_VIEWPORT = {"width": 1280, "height": 2400}
+
+# Opt-in: keep a chapter whose capture came up short instead of skipping it.
+#
+# Off by default, deliberately. The standing rule in this repo is that a stop
+# beats silent content loss, and pages are renumbered on the way into the CBZ so
+# a dropped page leaves NO visible gap — which is how a 67-of-68 chapter shipped
+# unnoticed in 2026-08. When this IS set the shortfall is announced on stderr and
+# the missing page numbers are written into the CBZ's ComicInfo, so the archive
+# still carries the evidence. aio-dl.py's --comix-allow-gapped-chapters sets it.
+_COMIX_ALLOW_GAPPED_ENV = "AIO_COMIX_ALLOW_GAPPED"
+
+# Smallest byte count a harvested canvas page may have and still be believed.
+#
+# A painted 700x958 manga page encodes to tens of KB at webp q0.95; a canvas that
+# exists but has not been painted yet encodes to a few hundred bytes of uniform
+# transparency — and toDataURL SUCCEEDS on it. Without this floor such a page is
+# accepted and written into the CBZ as a blank, which is the worst outcome
+# available: it reports success while the archive silently carries a dead page.
+# Below the floor the page counts as unresolved so the retry can re-approach it.
+_MIN_CANVAS_BYTES = 2048
+
+# Pages to back off before re-approaching a stalled page (the re-nudge rung).
+#
+# An IntersectionObserver fires on a TRANSITION. A page already sitting at the
+# scroll position does not re-fire when you scrollIntoView it again — which is
+# why the old loop's repeated nudge of the same page accomplished exactly
+# nothing. Backing off far enough to push the target out of the viewport and
+# then returning produces a genuine un-intersect -> intersect edge. 3 pages at
+# ~1170px each clears the 2400px viewport with margin.
+_COMIX_RENUDGE_BACKOFF_PAGES = 3
+
+# Response headers that mark a page as server-side tile-scrambled, and the
+# AUTHORITATIVE scramble signal — DOM shape is not.
+#
+# SETTLED 2026-08-03, and the answer is that scrambling is REAL AND CURRENT.
+# One live chapter reported `scramble-headered responses=10` against exactly the
+# ~10 <canvas> pages, with `canvas_with_img == 0` (no canvas page ever also had a
+# decoded <img>). So the canvas branch is LOAD-BEARING and canvas-before-img in
+# _classify is correct — do not "optimise" it away.
+#
+# It read 0 for months only because the listener was measuring the wrong traffic:
+# it returned early on `resource_type != "image"` BEFORE inspecting headers, and
+# a descrambler cannot use an <img> (it needs raw bytes), so every scrambled tile
+# arrives as fetch()/xhr and was skipped unexamined. See
+# _ComixBrowserSession._capture_image_response.
 _COMIX_SCRAMBLE_HEADER_PREFIX = "x-scramble-"
 
 
@@ -351,6 +402,37 @@ def _comix_http_headers() -> Dict[str, str]:
 # install degrades to b014f12's behavior rather than failing to launch.
 _COMIX_BROWSER_CHANNEL = "chromium"
 
+# comix runs HEADED by default (2026-08-03, user directive + measurement).
+#
+# The obvious reason is anti-bot: a real window is the least suspicious client
+# we can present, and it makes the headed WAF handoff a no-op rather than a
+# teardown-and-relaunch (see solve_waf_interactively) — which structurally
+# retires the headed-solve/headless-relaunch identity mismatch that b014f12 and
+# 800f1f9 each tried to patch. If the browser is never headless, the two
+# identities cannot diverge.
+#
+# The REAL reason is page capture. comix's reader defers every 10th page — a
+# chunk boundary — until the viewport reaches it, which requires a live
+# rendering lifecycle: layout, compositing, and IntersectionObserver delivery.
+# Measured 2026-08-03 in a non-compositing context: an IntersectionObserver
+# observing 103 page elements fired ZERO callbacks, not even the initial one.
+# In that state no amount of scrolling can load a deferred page, and the
+# chapter is permanently 10% short. Headed guarantees the lifecycle runs.
+#
+# Opt out with AIO_COMIX_HEADLESS=1 (cron/CI/headless servers), accepting that
+# chunk-boundary pages may not load there. Grep _comix_headless.
+_COMIX_HEADLESS_ENV = "AIO_COMIX_HEADLESS"
+
+
+def _comix_headless() -> bool:
+    """True when the user has explicitly asked for a headless comix browser.
+
+    Default False — see _COMIX_HEADLESS_ENV for why headed is the default and
+    what breaks without it. aio-dl.py's --comix-headless sets the env var so the
+    CLI flag and the env knob share exactly one code path.
+    """
+    return (os.environ.get(_COMIX_HEADLESS_ENV) or "").strip() == "1"
+
 # Sanity bound on the pager-reported page count. Real worst case observed is
 # 360 (Magic Emperor, ~890 chapters x ~8 groups at 20 rows/page); this only
 # exists so a malformed pager can't turn into an unbounded walk, and it doubles
@@ -596,6 +678,44 @@ def _coerce_chapter_number(
             except ValueError:
                 pass
     return None
+
+
+def _every_nth_stride(pages, min_hits: int = 3) -> Optional[int]:
+    """Return N when ``pages`` is exactly the multiples of some N > 1, else None.
+
+    comix's capture misses have been every-Nth every time observed (N=10 live,
+    2026-08-03) because its reader defers one chunk-boundary page per chunk.
+    Recognising that shape lets the failure log say WHAT is wrong instead of
+    printing a list of numbers the next reader has to squint at.
+
+    Requires at least ``min_hits`` pages so a two-page coincidence (2, 4) isn't
+    announced as a pattern.
+    """
+    ordered = sorted({int(p) for p in pages})
+    if len(ordered) < min_hits:
+        return None
+    stride = ordered[0]
+    if stride < 2:
+        return None
+    if all(p == stride * (i + 1) for i, p in enumerate(ordered)):
+        return stride
+    return None
+
+
+def _fmt_pages(pages, limit: int = 10) -> str:
+    """Compact "1, 2, 3 (+7 more)" rendering of a page-number set.
+
+    Used by every capture-recovery log line. Sorted so the every-Nth pattern
+    that characterises comix's chunk-boundary misses is visible at a glance —
+    reading "10, 20, 30, 40" tells you instantly which failure this is.
+    """
+    ordered = sorted(pages)
+    if not ordered:
+        return "none"
+    head = ", ".join(str(p) for p in ordered[:limit])
+    if len(ordered) > limit:
+        return f"{head} (+{len(ordered) - limit} more)"
+    return head
 
 
 class ComixSiteHandler(BaseSiteHandler):
@@ -1335,6 +1455,34 @@ class ComixSiteHandler(BaseSiteHandler):
         with self._chapter_images_cache_lock:
             self._chapter_images_cache[chapter_url] = (list(urls), time.monotonic())
 
+    @staticmethod
+    def _looks_like_stalled_capture(capture: "ComixChapterCapture") -> bool:
+        """True when the misses are comix DEFERRING pages, not failing to send.
+
+        The signature, verified live 2026-08-03: the `.rpage-page` container
+        exists and the reader has marked it `is-loading`, but no <img> element
+        ever mounts and no network request is ever issued for it. Those pages are
+        chunk boundaries the reader holds back until the viewport arrives, and no
+        amount of re-rendering the same chapter changes that — so the caller must
+        skip rather than burn 90s of inline retries reproducing it.
+
+        A page that is MISSING its container, or that got as far as an <img> with
+        a src, is a different animal (genuine render/decode failure) and stays
+        retryable. Requires every miss to fit the pattern: one ordinary failure
+        mixed in means the transient classification is the safer read.
+        """
+        states = capture.unresolved or {}
+        if not states:
+            return False
+        for st in states.values():
+            if not isinstance(st, dict):
+                return False
+            if st.get("missing") or st.get("src") or st.get("hasCanvas"):
+                return False
+            if not st.get("loading"):
+                return False
+        return True
+
     def get_chapter_images(self, chapter: Dict, scraper, make_request) -> List[str]:
         url = chapter.get("url")
 
@@ -1390,16 +1538,56 @@ class ComixSiteHandler(BaseSiteHandler):
         # behaviour — return [], which the caller records as an empty_content
         # miss — because "we were told nothing" is not "we were told 68".
         #
-        # The session already did its own reload retry before reporting short
-        # (see fetch_chapter_images_via_dom step 4), which is the precondition
-        # IncompleteChapterError documents. From here the caller's machinery
-        # takes over: inline retry -> multi-source alt rescue -> hard abort.
+        # The session already ran its full recovery ladder before reporting short
+        # (re-nudge -> reload -> lazy-mode; see fetch_chapter_images_via_dom step
+        # 4), which is the precondition IncompleteChapterError documents.
+        #
+        # THE REASON MATTERS, because it decides what the caller does next.
+        # `comix_pages_stalled` means the reader mounted the page container and
+        # then never delivered the image — the chunk-boundary signature. That is
+        # NOT transient: the caller's 30s and 60s inline retries re-render the
+        # identical chapter and fail identically, which is exactly what the live
+        # 2026-08-02 log showed (99/107, retry, 99/107, retry, 99/107, then the
+        # whole 256-chapter run aborted on chapter 1). aio-dl.py lists this
+        # reason in _PERMANENT_SKIP_REASONS so it skips-and-continues — and
+        # --multi-source still rescues the chapter from an alternative site,
+        # which is the actual recovery. Anything else keeps the retryable
+        # classification, since a genuine transient miss should still get its
+        # retries. Grep _PERMANENT_SKIP_REASONS / comix_pages_stalled.
         if capture.expected_pages and len(images) < capture.expected_pages:
+            allow_gapped = (
+                os.environ.get(_COMIX_ALLOW_GAPPED_ENV) or ""
+            ).strip() == "1"
+            if allow_gapped:
+                # Explicit opt-in: the user would rather have 103 of 114 pages
+                # than nothing. NEVER silent — the gap is announced here AND
+                # stashed on the chapter dict, from which aio-dl.py writes it
+                # into the CBZ's ComicInfo as <AioMissingPages> (grep it). That
+                # record is the whole point: pages are renumbered 0001..000N on
+                # the way in, so a chapter missing its 10th page is otherwise
+                # byte-for-byte indistinguishable from a complete shorter one.
+                missing = sorted(capture.unresolved or {})
+                chapter["_missing_pages"] = missing
+                print(
+                    f"[!] Comix: keeping this chapter with "
+                    f"{len(images)}/{capture.expected_pages} pages — "
+                    f"--comix-allow-gapped-chapters is set. Missing: "
+                    f"{_fmt_pages(missing)}.",
+                    flush=True,
+                )
+                return images
+            # Not opted in — make sure a previous gapped attempt on this same
+            # chapter dict can't leave a stale record behind for a later retry.
+            chapter.pop("_missing_pages", None)
             raise IncompleteChapterError(
                 pages_ok=len(images),
                 pages_total=capture.expected_pages,
                 host="comix.to",
-                reason="comix_dom_render_incomplete",
+                reason=(
+                    "comix_pages_stalled"
+                    if self._looks_like_stalled_capture(capture)
+                    else "comix_dom_render_incomplete"
+                ),
             )
 
         # Only memoize a COMPLETE capture. The TTL here (600 s) is far longer
@@ -1733,11 +1921,16 @@ class _ComixBrowserSession:
         # we synced into _context. Used by _sync_cf_cookies to skip
         # redundant add_cookies calls when the cache hasn't changed.
         self._last_cf_cookie_ts: float = 0.0
-        # Which mode the live context was launched in. The headed WAF handoff
-        # has to tear down and relaunch (headless is fixed at launch time and
-        # Chromium locks the profile dir to one context), so _start compares
+        # Which mode the live context was launched in. headless is fixed at
+        # launch time by Chromium and the profile dir can only be held by ONE
+        # context, so a mode CHANGE means teardown + relaunch — _start compares
         # against this to decide whether the cached context is reusable.
-        self._headless: bool = True
+        #
+        # Initialised from the same resolver _start defaults to, so a session
+        # that has not launched yet doesn't claim a mode it will never use. With
+        # headed as the default (see _comix_headless) the WAF handoff no longer
+        # changes mode at all, which is what removes the relaunch entirely.
+        self._headless: bool = _comix_headless()
         # URLs whose response carried an x-scramble-* header, i.e. pages comix
         # served tile-scrambled. Populated by the page.on("response") listener
         # (which sees every image response anyway) and read once per chapter by
@@ -1745,10 +1938,18 @@ class _ComixBrowserSession:
         # limit — see _note_scrambled_url.
         self._scrambled_urls: set = set()
 
-    def _start(self, headless: bool = True, _ua_relaunch: bool = False) -> bool:
+    def _start(
+        self, headless: Optional[bool] = None, _ua_relaunch: bool = False
+    ) -> bool:
         """Lazy-launch Patchright on first use. Returns True if the browser
         is ready, False if Patchright/Playwright unavailable or launch failed.
         Subsequent calls are cheap (already-started fast path).
+
+        ``headless`` defaults to None = "ask _comix_headless()", i.e. HEADED
+        unless AIO_COMIX_HEADLESS=1. It used to default to True, and every
+        caller inheriting that default is why chunk-boundary pages could never
+        load — see _COMIX_HEADLESS_ENV for the measurement. Callers pass an
+        explicit bool only when they genuinely need to pin a mode.
 
         Launches a PERSISTENT context against the app-owned profile dir
         (_comix_profile_dir) rather than a throwaway one. That single change is
@@ -1766,6 +1967,8 @@ class _ComixBrowserSession:
         after a HeadlessChrome-leaking UA is detected on the channel-fallback
         path, so termination is provable here rather than resting on cache state.
         """
+        if headless is None:
+            headless = _comix_headless()
         if self._page is not None and self._headless != headless:
             self._cleanup()
         if self._page is not None:
@@ -1820,10 +2023,21 @@ class _ComixBrowserSession:
             os.makedirs(profile_dir, exist_ok=True)
 
             def _launch(**extra):
+                # viewport= sets the CSS viewport the page renders against;
+                # --window-size makes the HEADED window actually that big, so a
+                # user watching the handoff sees a normal browser rather than a
+                # tiny frame scrolling a giant document. Both are needed — they
+                # control different things. See _COMIX_VIEWPORT for why 2400.
                 return self._pw.chromium.launch_persistent_context(
                     profile_dir,
                     headless=headless,
-                    args=["--no-sandbox", "--disable-setuid-sandbox"],
+                    args=[
+                        "--no-sandbox",
+                        "--disable-setuid-sandbox",
+                        f"--window-size={_COMIX_VIEWPORT['width']},"
+                        f"{_COMIX_VIEWPORT['height']}",
+                    ],
+                    viewport=dict(_COMIX_VIEWPORT),
                     **extra,
                 )
 
@@ -1917,19 +2131,19 @@ class _ComixBrowserSession:
 
         def _capture_image_response(response):
             try:
-                try:
-                    if response.request.resource_type != "image":
-                        return
-                except Exception:
-                    pass
                 headers = response.headers or {}
-                ct = (headers.get("content-type") or "").lower()
-                if not ct.startswith("image/"):
-                    return
-                # Scramble bookkeeping runs BEFORE the cache write and is
-                # independent of it — the whole point is to learn whether comix
-                # still tile-scrambles anything, and that has to hold even if
-                # image_cache failed to import. See _COMIX_SCRAMBLE_HEADER_PREFIX.
+                # Scramble bookkeeping runs FIRST, before BOTH filters below.
+                #
+                # It used to sit after the resource_type/content-type early
+                # returns, which made the measurement structurally incapable of
+                # observing what it exists to measure: a descrambler cannot use
+                # an <img> (it needs the raw bytes), so it fetches tiles via
+                # fetch()/XHR — resource_type "fetch"/"xhr" — and every such
+                # response returned before the header was ever inspected. The
+                # "scramble-headered responses=0" line in the capture summary was
+                # therefore an artifact of the instrument, not evidence, and the
+                # canvas-vs-<img> question it was built to settle could never
+                # have been settled by it. See _COMIX_SCRAMBLE_HEADER_PREFIX.
                 try:
                     if any(
                         str(k).lower().startswith(_COMIX_SCRAMBLE_HEADER_PREFIX)
@@ -1938,6 +2152,16 @@ class _ComixBrowserSession:
                         self._note_scrambled_url(response.url)
                 except Exception:
                     pass
+                # Cache only true <img>-tag fetches: JS-driven fetch()/XHR calls
+                # would just burn the 256MB cap.
+                try:
+                    if response.request.resource_type != "image":
+                        return
+                except Exception:
+                    pass
+                ct = (headers.get("content-type") or "").lower()
+                if not ct.startswith("image/"):
+                    return
                 if _image_cache_module is None:
                     return
                 body = response.body()
@@ -2015,7 +2239,12 @@ class _ComixBrowserSession:
         self._pw = None
         self._page = None
         self._last_cf_cookie_ts = 0.0
-        self._headless = True
+        # Back to the CONFIGURED default, not a hardcoded True — matching
+        # __init__. Hardcoding headless here was harmless only because every
+        # reader also checks `_page is None` first; as a standalone statement
+        # about a torn-down session it was simply false, and the next person to
+        # read _headless without that guard would get the wrong answer.
+        self._headless = _comix_headless()
 
     def _probe_true_user_agent(self) -> Optional[str]:
         """The browser's REAL User-Agent, seen past any page-level override.
@@ -2354,18 +2583,38 @@ class _ComixBrowserSession:
             timeout_s = _WAF_DEFAULT_SOLVE_TIMEOUT_S
 
         target = return_url or _WAF_CHALLENGE_HINT_URL
-        # Drop the headless context first — Chromium locks the profile dir to a
-        # single context, and closing is also what flushes state to disk.
-        self._cleanup()
-        if not self._start(headless=False):
-            result["reason"] = "launch_failed"
-            print(
-                "[!] Comix: could not open a visible browser for verification.",
-                flush=True,
-            )
+        # Only tear down when the live context is actually headless — i.e. when
+        # the user opted into AIO_COMIX_HEADLESS. In the DEFAULT headed
+        # configuration this whole branch is skipped and the existing window is
+        # simply navigated to the challenge.
+        #
+        # That is the point of the headed default, not a micro-optimisation:
+        # the teardown + headed relaunch + headless relaunch cycle was the
+        # mechanism behind the "verification passed, then immediately
+        # re-challenged" bug. A clearance is bound to the client that earned it,
+        # and the relaunched context was a measurably different client
+        # (HeadlessChrome in Sec-CH-UA even with the UA string pinned — see the
+        # table at _COMIX_BROWSER_CHANNEL). Never changing mode means never
+        # changing identity, so the solve simply sticks.
+        # True when THIS call changed the browser's mode, so the tail below
+        # knows whether it owes a restore. In the default headed configuration
+        # it stays False and no relaunch happens at any point.
+        mode_switched = False
+        if self._page is None or self._headless:
+            mode_switched = True
             self._cleanup()
-            self._start(headless=True)
-            return result
+            if not self._start(headless=False):
+                result["reason"] = "launch_failed"
+                print(
+                    "[!] Comix: could not open a visible browser for "
+                    "verification.",
+                    flush=True,
+                )
+                # Put the session back the way the run wants it before bailing,
+                # else every later chapter inherits a dead context.
+                self._cleanup()
+                self._start()
+                return result
 
         page = self._page
         try:
@@ -2464,14 +2713,159 @@ class _ComixBrowserSession:
         # No UA bookkeeping here any more. It used to re-read
         # navigator.userAgent and cache it, which became actively wrong once the
         # context pins a UA: the page then reports the PIN, so this re-cached
-        # our own override instead of the browser. _start now reconciles the pin
-        # against CDP Browser.getVersion on every launch — including the
-        # relaunch two lines below — so the cache is correct without this.
+        # our own override instead of the browser. _start reconciles the pin
+        # against CDP Browser.getVersion on every launch, so the cache stays
+        # correct without this.
         #
-        # Back to headless for the rest of the run. The close flushes the
-        # solved session into the profile dir, so the relaunch inherits it.
+        # Restore the run's mode ONLY if this call switched it. In the default
+        # headed configuration nothing was switched, so the freshly-solved
+        # context is kept AS IS — which is the whole fix. The old code relaunched
+        # headless unconditionally here, handing the rest of the run a client the
+        # WAF had never issued a clearance to, and the very next navigation was
+        # challenged again ("hit during the chapter page (after verification)").
+        if mode_switched:
+            # The close is what flushes the solved session into the profile dir,
+            # so the relaunched context still inherits it — just as a different
+            # client identity, which is why this path remains the lossy one.
+            self._cleanup()
+            self._start()
+        return result
+
+    def open_login_window(self, timeout_s: float = 300.0) -> Dict[str, Any]:
+        """Show comix.to in a real window and wait for the user to sign in.
+
+        Returns {"signed_in": bool, "reason": str}. Never raises — the caller
+        turns the outcome into a message.
+
+        THE DOWNLOADER NEVER TOUCHES CREDENTIALS. It navigates to the site and
+        watches for the reader's own `auth` localStorage key to appear; the user
+        types into the real comix.to login form in a real browser. Nothing is
+        read from the form, nothing is stored by us, nothing is transmitted
+        anywhere. Same shape as the WAF handoff (which likewise only navigates
+        and polls) and for the same reason: the human does the part that
+        requires being human, and the persistent profile keeps the result.
+
+        Why it persists: _comix_profile_dir is a real Chromium user-data dir, so
+        the session the site sets survives process exit and is inherited by every
+        later run — search, download, and the UI's per-series subprocesses all
+        share it. One sign-in covers all of them until it expires.
+
+        Note this is an ENHANCEMENT, not a fix for short chapters: the
+        chunk-boundary deferral that strands every 10th page was reproduced in a
+        logged-OUT browser and is unrelated to authentication (2026-08-03).
+        """
+        result: Dict[str, Any] = {"signed_in": False, "reason": ""}
+
+        if sys.platform not in ("win32", "darwin") and not (
+            os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+        ):
+            result["reason"] = "no_display"
+            print(
+                "[!] Comix: no display available, so the sign-in window cannot "
+                "be shown.",
+                flush=True,
+            )
+            return result
+
+        # Force headed regardless of AIO_COMIX_HEADLESS — an invisible sign-in
+        # window is worse than useless, and this mode exists to be interacted
+        # with.
+        if self._page is None or self._headless:
+            self._cleanup()
+            if not self._start(headless=False):
+                result["reason"] = "launch_failed"
+                print(
+                    "[!] Comix: could not open a browser window for sign-in. "
+                    "Check that the bundled browser is installed "
+                    "(patchright install chromium).",
+                    flush=True,
+                )
+                return result
+
+        page = self._page
+        try:
+            page.goto(
+                _WAF_CHALLENGE_HINT_URL,
+                wait_until="domcontentloaded",
+                timeout=30000,
+            )
+        except Exception as exc:
+            print(
+                f"[!] Comix: could not load comix.to "
+                f"({type(exc).__name__}: {exc}).",
+                flush=True,
+            )
+            result["reason"] = "navigation_failed"
+            return result
+
+        # [!]-prefixed so the Electron LogPanel paints these as must-read rather
+        # than dim filler — same reasoning as the WAF banner.
+        print("[!] " + "=" * 68, flush=True)
+        print("[!] ACTION NEEDED - sign in to comix.to.", flush=True)
+        print(
+            "[!] A browser window just opened on comix.to. Log in there as you",
+            flush=True,
+        )
+        print(
+            "[!] normally would. The downloader never sees your password.",
+            flush=True,
+        )
+        print(
+            f"[!] It saves the session and closes by itself (waiting up to "
+            f"{int(timeout_s)}s).",
+            flush=True,
+        )
+        print("[!] " + "=" * 68, flush=True)
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                if page.is_closed():
+                    result["reason"] = "window_closed"
+                    break
+                # The reader's own auth store. Present and populated is the
+                # SITE's statement that a session exists — more reliable than
+                # watching for a URL change, since comix keeps you on the same
+                # route after login.
+                signed = page.evaluate(
+                    """() => {
+                        try {
+                            const v = localStorage.getItem('auth');
+                            if (!v) return false;
+                            const p = JSON.parse(v);
+                            if (!p) return false;
+                            const s = p.state || p;
+                            return !!(s.token || s.user || s.accessToken);
+                        } catch (e) { return false; }
+                    }"""
+                )
+            except Exception:
+                result["reason"] = "window_lost"
+                break
+            if signed:
+                try:
+                    page.wait_for_timeout(1500)
+                except Exception:
+                    pass
+                result["signed_in"] = True
+                break
+            try:
+                page.wait_for_timeout(1000)
+            except Exception:
+                break
+
+        if result["signed_in"]:
+            print("[*] Comix: signed in - thanks. Session saved.", flush=True)
+        elif not result["reason"]:
+            result["reason"] = "timeout"
+            print(
+                f"[!] Comix: sign-in not completed within {int(timeout_s)}s.",
+                flush=True,
+            )
+
+        # Closing the context is what FLUSHES cookies + localStorage into the
+        # profile dir; without it a freshly-created session can be lost.
         self._cleanup()
-        self._start(headless=True)
         return result
 
     def context_cookies(self) -> List[Dict[str, Any]]:
@@ -3338,10 +3732,17 @@ class _ComixBrowserSession:
         return items
 
 
-    def _apply_reader_preload_pref(self) -> bool:
-        """Write ``preload: all`` into the reader's persisted settings so a
-        chapter renders every page eagerly instead of lazy-loading on scroll.
+    def _apply_reader_preload_pref(self, mode: str = "all") -> bool:
+        """Write ``preload: <mode>`` into the reader's persisted settings.
         Returns True when the value is confirmed stored.
+
+        ``mode`` is "all" (eager — the default, used for every normal capture)
+        or "some" (the site's own lazy default, used only by the capture
+        ladder's last rung; grep "preload=some"). It is a PARAMETER rather than
+        a hardcoded "all" because `all` turned out not to be sufficient on its
+        own: verified live 2026-08-03 in an ordinary browser, `all` still defers
+        every 10th page — a chunk boundary — until the viewport reaches it. So
+        the recovery ladder needs to be able to drive the reader both ways.
 
         THE KEY MATTERS, AND THE OLD ONE WAS NEVER READ. This used to write
         ``localStorage['reader.default'] = {preload: 'all'}``. Verified live
@@ -3407,8 +3808,10 @@ class _ComixBrowserSession:
                     flush=True,
                 )
                 return False
+        want = "some" if str(mode).lower() == "some" else "all"
         try:
-            stored = page.evaluate("""() => {
+            stored = page.evaluate(
+                """(want) => {
                 try {
                     const k = 'reader.webtoon.v3';
                     const raw = localStorage.getItem(k);
@@ -3416,21 +3819,23 @@ class _ComixBrowserSession:
                     if (!cur.state || typeof cur.state !== 'object') {
                         cur.state = {};
                     }
-                    cur.state.preload = 'all';
+                    cur.state.preload = want;
                     localStorage.setItem(k, JSON.stringify(cur));
                     const back = JSON.parse(localStorage.getItem(k) || '{}');
                     return (back.state || {}).preload || null;
                 } catch (e) { return null; }
-            }""")
+            }""",
+                want,
+            )
         except Exception as exc:
             print(
-                f"[*] Comix: reader preload-all setup failed "
-                f"({type(exc).__name__}: {exc}); continuing with lazy page "
-                f"loading.",
+                f"[*] Comix: reader preload={want} setup failed "
+                f"({type(exc).__name__}: {exc}); continuing with the reader's "
+                f"current loading mode.",
                 flush=True,
             )
             return False
-        return stored == "all"
+        return stored == want
 
     def fetch_chapter_images_via_dom(
         self,
@@ -3717,6 +4122,13 @@ class _ComixBrowserSession:
 
         # ONE evaluate reports every pending page. This is the round-trip win:
         # the old loop paid a scroll + up to 40 polls PER PAGE.
+        #
+        # `hasImg` is reported SEPARATELY from `src` on purpose: an <img> element
+        # that exists but has no src yet is the state a page passes through while
+        # it is actively resolving, and `src: i ? (i.src||'') : ''` collapses it
+        # with "there is no <img> at all". Telling them apart is what lets the
+        # stall clock distinguish a page that is working from one that is stuck
+        # (grep _progress_rank).
         _POLL_JS = """(nums) => nums.map((n) => {
             const el = document.querySelector(
                 '.rpage-page[data-page="' + n + '"]');
@@ -3729,32 +4141,95 @@ class _ComixBrowserSession:
                 hasCanvas: !!c,
                 cw: c ? c.width : 0,
                 ch: c ? c.height : 0,
+                hasImg: !!i,
                 src: i ? (i.src || '') : '',
                 complete: i ? !!i.complete : false,
                 nw: i ? i.naturalWidth : 0,
             };
         })"""
 
-        # instant + center so the IntersectionObserver fires immediately and the
-        # neighbours preload too. Only the lowest unresolved page is nudged per
-        # round; over rounds that walks naturally down the chapter.
-        _SCROLL_JS = (
-            "(n) => { const el = document.querySelector("
-            "'.rpage-page[data-page=\"' + n + '\"]'); "
-            "if (el) el.scrollIntoView("
-            "{behavior: 'instant', block: 'center'}); }"
-        )
+        # Scroll ONE page into view. instant + center so the observer fires
+        # without waiting on smooth-scroll animation, and so the neighbours fall
+        # inside the reader's preload horizon too.
+        #
+        # ONE page per call, deliberately. An IntersectionObserver delivers its
+        # observations once per FRAME, after the JS turn ends — so scrolling
+        # eight positions inside a single evaluate produces exactly one
+        # observation pass, at the last position. Batching the sweep would have
+        # looked like it visited every pending page while actually visiting one
+        # of every eight. Callers must let a frame elapse between calls.
+        _SCROLL_JS = """(n) => {
+            const el = document.querySelector(
+                '.rpage-page[data-page="' + n + '"]');
+            if (!el) return false;
+            el.scrollIntoView({behavior: 'instant', block: 'center'});
+            return true;
+        }"""
+
+        def _scroll_page(n: int) -> None:
+            try:
+                page.evaluate(_SCROLL_JS, int(n))
+            except Exception:
+                pass
+
+        def _dwell(ms: int) -> None:
+            """Let at least one frame elapse so the scroll above is actually
+            observed. Without this the whole sweep is a no-op."""
+            try:
+                page.wait_for_timeout(ms)
+            except Exception:
+                pass
+
+        def _progress_rank(st: Dict[str, Any]) -> int:
+            """How far along one page is, 0 (nothing) .. 3 (src present).
+
+            Exists so the stall clock can see a page MOVING even when it hasn't
+            finished. Live proof this matters (2026-08-03): a snapshot caught
+            page 100 having shed `is-loading` and mounted its <img> before the
+            src was set — neither stuck nor loaded. A chapter whose ten chunk
+            boundaries are all advancing through that intermediate state would
+            otherwise look completely idle to `progressed`, and trip the 20s
+            stall break while the reader was actively working.
+            """
+            if not st or st.get("missing"):
+                return 0
+            if st.get("src"):
+                return 3
+            if st.get("hasImg") or st.get("hasCanvas"):
+                return 2
+            if st.get("loading"):
+                return 1
+            return 0
 
         def _converge(pending: List[int]) -> List[int]:
-            """Poll ``pending`` until empty, the deadline passes, or no page has
-            resolved for _COMIX_CAPTURE_STALL_S. Returns the still-unresolved.
+            """Poll ``pending`` until empty, the deadline passes, or nothing has
+            MOVED for _COMIX_CAPTURE_STALL_S. Returns the still-unresolved.
 
-            Progress on ANY page refreshes the stall clock, which is the whole
-            behavioural change: a straggler keeps getting re-examined for as
-            long as the chapter is still coming in, instead of being abandoned
-            after a private window that expired mid-walk.
+            Two behaviours carry this, both from the 2026-08-03 every-10th-page
+            failure:
+
+            1. SWEEP, don't nudge. comix defers each chunk-boundary page until
+               the viewport reaches it, so a page that is never scrolled to can
+               never load. The old code scrolled only `pending[0]`, which meant
+               that once the bulk resolved it re-scrolled to page 10 forever
+               while 20..110 were never visited. A cursor advances ONE page per
+               round instead, so over rounds the viewport walks the whole
+               pending set. One per round rather than a batch because the
+               round's poll interval is what gives each scroll its frame — see
+               _scroll_page for why a batched sweep is a silent no-op.
+            2. PROGRESS INCLUDES INTERMEDIATE STATES. `progressed` used to flip
+               only when a page reached a terminal state; a chapter whose
+               boundaries were all mid-transition looked idle and tripped the
+               stall break while the reader was still working (grep
+               _progress_rank).
             """
             last_progress = _time.monotonic()
+            # Rotating start offset into `pending` for the sweep. Persisted
+            # across rounds so successive rounds visit DIFFERENT pages.
+            cursor = 0
+            # page -> best _progress_rank seen, so forward movement is detected
+            # even when the page never finishes.
+            best_rank: Dict[int, int] = {}
             while pending:
                 if _time.monotonic() > deadline:
                     print(
@@ -3776,10 +4251,32 @@ class _ComixBrowserSession:
                     except (TypeError, ValueError):
                         continue
                     last_state[n] = st
+                    # Rank BEFORE the resolve check: a page that finishes this
+                    # round is obviously progress, but so is one that merely
+                    # advanced a rung, and that is the case the old code missed.
+                    rank = _progress_rank(st)
+                    if rank > best_rank.get(n, -1):
+                        best_rank[n] = rank
+                        progressed = True
                     decision = _classify(st)
                     if decision is None:
                         still.append(n)
                         continue
+                    if decision["type"] == "canvas":
+                        # Read the pixels RIGHT NOW, in the round that first saw
+                        # this canvas. It is mounted and painted at exactly this
+                        # instant — that is what `!loading` plus non-zero
+                        # dimensions means — and it will not stay that way: the
+                        # reader unmounts a canvas once the sweep moves on, so
+                        # the post-convergence batch harvest routinely found
+                        # nothing and pushed the page through all three recovery
+                        # rungs to get it back. Measured live: ~half the canvas
+                        # pages per chapter took that path, turning a ~12s
+                        # capture into 31s (and 81s on a bad chapter).
+                        # A failure here is NOT fatal — the page stays in
+                        # `resolved` with no url, so _harvest_canvas still picks
+                        # it up afterwards with the scroll-back recovery.
+                        _try_inline_canvas(n, decision)
                     resolved[n] = decision
                     progressed = True
                 if not states:
@@ -3794,57 +4291,185 @@ class _ComixBrowserSession:
                     last_progress = now
                 elif now - last_progress > _COMIX_CAPTURE_STALL_S:
                     break
-                try:
-                    page.evaluate(_SCROLL_JS, pending[0])
-                except Exception:
-                    pass
+                # Sweep: visit ONE pending page per round, rotating, so over
+                # rounds the viewport walks the whole pending set. The old code
+                # always picked pending[0] — which is why, once the bulk had
+                # resolved and pending was [10, 20, ... 110], it re-scrolled to
+                # page 10 forever and the other ten were never visited at all.
+                #
+                # One per round rather than a batch because the round's poll +
+                # poll-interval is what gives the scroll its frame; see
+                # _scroll_page for why batching would be a silent no-op.
+                cursor %= len(pending)
+                _scroll_page(pending[cursor])
+                cursor += 1
                 page.wait_for_timeout(
                     int(_COMIX_PAGE_POLL_INTERVAL_S * 1000)
                 )
             return pending
+
+        def _renudge(stalled: List[int]) -> None:
+            """Force a genuine un-intersect -> intersect edge for ``stalled``.
+
+            An IntersectionObserver fires on a TRANSITION, so re-scrolling a page
+            that is already at the scroll position does nothing at all — which is
+            why the old loop's repeated nudge of `pending[0]` never recovered a
+            single page. Backing off far enough to push the target out of the
+            viewport and then returning is what actually re-triggers the reader's
+            lazy fetch.
+
+            Done as two separate evaluates with a dwell between, NOT one: both
+            scrolls inside a single evaluate happen in the same frame, so the
+            browser coalesces them and no intersection change is ever observed.
+            """
+            if not stalled:
+                return
+            for p in sorted(stalled):
+                if _time.monotonic() > deadline:
+                    return
+                # Back off far enough that the target leaves the viewport, let a
+                # frame land so the un-intersect is observed, then approach it.
+                # Doing both scrolls in one turn (or both pages in one evaluate)
+                # coalesces them into a single observation at the final position
+                # and re-triggers nothing at all.
+                _scroll_page(max(1, p - _COMIX_RENUDGE_BACKOFF_PAGES))
+                _dwell(150)
+                _scroll_page(p)
+                _dwell(150)
+
+        # Read one page's canvas, reporting WHY when it can't be read. Returning
+        # a reason instead of null is what turned "6 pages silently vanished"
+        # into a diagnosable failure — the old one-liner collapsed "canvas was
+        # unmounted", "canvas is 0x0" and "SecurityError on tainted pixels" into
+        # a single indistinguishable null. The try/catch is INSIDE the page so a
+        # tainted canvas yields a clean reason string rather than a Playwright
+        # exception wrapper.
+        _CANVAS_READ_JS = """(n) => {
+            const el = document.querySelector(
+                '.rpage-page[data-page="' + n + '"]');
+            if (!el) return {data: null, why: 'page container gone'};
+            const c = el.querySelector('canvas');
+            if (!c) return {data: null, why: 'canvas unmounted'};
+            if (!c.width || !c.height) return {data: null, why: 'canvas 0x0'};
+            try {
+                return {data: c.toDataURL('image/webp', 0.95), why: ''};
+            } catch (e) {
+                return {
+                    data: null,
+                    why: 'toDataURL threw ' + ((e && e.name) || String(e)),
+                };
+            }
+        }"""
+
+        def _store_canvas_bytes(n: int, data_url: Any) -> Optional[str]:
+            """Decode a canvas data URL into image_cache. Returns the synthetic
+            URL on success, None when the payload is unusable.
+
+            Shared by the inline fast path and the scroll-back recovery so the
+            validity rules (real data URL, decodable, painted) can't diverge
+            between them.
+            """
+            if not data_url or not str(data_url).startswith("data:image/"):
+                return None
+            try:
+                _hdr, b64 = str(data_url).split(",", 1)
+                decoded = _b64.b64decode(b64)
+            except Exception:
+                return None
+            if len(decoded) < _MIN_CANVAS_BYTES:
+                return None
+            synthetic_url = f"comix-page://{chap_id}/{n:04d}.webp"
+            if _image_cache is not None:
+                _image_cache.cache_image(synthetic_url, decoded, "image/webp")
+            return synthetic_url
+
+        def _try_inline_canvas(n: int, decision: Dict[str, Any]) -> None:
+            """Best-effort read of a just-detected canvas, with NO scrolling.
+
+            The whole point is that no time passes between detection and read,
+            so the canvas is still mounted and painted. Silent on failure by
+            design: _harvest_canvas runs afterwards over anything still lacking a
+            url and does the expensive scroll-back recovery there, where a
+            failure is genuinely worth reporting.
+            """
+            try:
+                res = page.evaluate(_CANVAS_READ_JS, n)
+            except Exception:
+                return
+            if not isinstance(res, dict):
+                return
+            synthetic_url = _store_canvas_bytes(n, res.get("data"))
+            if synthetic_url:
+                decision["url"] = synthetic_url
 
         def _harvest_canvas(pages: List[int]) -> List[int]:
             """Read canvas pixels for ``pages`` into image_cache under synthetic
             comix-page:// keys. Returns the pages whose read FAILED (caller
             demotes them back to unresolved).
 
-            MUST run before any reload — a reload discards the rendered pixels,
-            and unlike an <img> src there is nothing left to re-fetch. comix's
-            real /si/ URL would serve the SCRAMBLED bytes, which is the whole
+            SCROLLS TO EACH PAGE BEFORE READING IT. That is the fix for the
+            2026-08-03 live failure where 6 of 10 scrambled pages were lost: the
+            reader UNMOUNTS a page's <canvas> once it is far from the viewport,
+            and this ran as a batch AFTER convergence had already scrolled
+            elsewhere — so `querySelector(... canvas)` returned null and the page
+            was dropped. Which pages died depended purely on where the sweep
+            happened to stop, which is why the failing set differed run to run.
+
+            MUST also run before any reload — a reload discards the rendered
+            pixels, and unlike an <img> src there is nothing left to re-fetch:
+            comix's real page URL serves the SCRAMBLED bytes, which is the whole
             reason the synthetic key exists.
             """
             failed: List[int] = []
             for p in sorted(pages):
-                try:
-                    data_url = page.evaluate(
-                        "(n) => { const c = document.querySelector("
-                        "'.rpage-page[data-page=\"' + n + '\"] canvas'); "
-                        "return c ? c.toDataURL('image/webp', 0.95) "
-                        ": null; }",
-                        p,
-                    )
-                except Exception as e:
+                if _time.monotonic() > deadline:
+                    failed.append(p)
+                    continue
+                # Bring the page back into view so the reader keeps (or
+                # re-paints) its canvas, and give it a frame to do so.
+                _scroll_page(p)
+                _dwell(150)
+                data_url = None
+                why = "not attempted"
+                for attempt in (1, 2):
+                    try:
+                        res = page.evaluate(_CANVAS_READ_JS, p)
+                    except Exception as e:
+                        res = {"data": None, "why": f"{type(e).__name__}: {e}"}
+                    if isinstance(res, dict) and res.get("data"):
+                        data_url = res["data"]
+                        why = ""
+                        break
+                    why = (isinstance(res, dict) and res.get("why")) or "unknown"
+                    if attempt == 1:
+                        # Re-approach from above: an unmounted canvas only comes
+                        # back on a real intersection change, same reason the
+                        # re-nudge rung backs off before returning.
+                        _scroll_page(max(1, p - _COMIX_RENUDGE_BACKOFF_PAGES))
+                        _dwell(120)
+                        _scroll_page(p)
+                        _dwell(300)
+                if not data_url:
                     print(
-                        f"  page {p}: toDataURL threw "
-                        f"{type(e).__name__}: {e}",
+                        f"[!] Comix: page {p} canvas capture failed ({why}).",
                         flush=True,
                     )
                     failed.append(p)
                     continue
-                if not data_url or not data_url.startswith("data:image/"):
-                    failed.append(p)
-                    continue
-                try:
-                    _hdr, b64 = data_url.split(",", 1)
-                    decoded = _b64.b64decode(b64)
-                except Exception:
-                    failed.append(p)
-                    continue
-                synthetic_url = f"comix-page://{chap_id}/{p:04d}.webp"
-                if _image_cache is not None:
-                    _image_cache.cache_image(
-                        synthetic_url, decoded, "image/webp",
+                synthetic_url = _store_canvas_bytes(p, data_url)
+                if not synthetic_url:
+                    # _store_canvas_bytes rejects a non-image payload, an
+                    # undecodable one, and — the case worth naming — a canvas
+                    # that read back too small to have been painted. Archiving
+                    # that would put a blank page in the CBZ and report success.
+                    print(
+                        f"[!] Comix: page {p} canvas read back an unusable or "
+                        f"unpainted image; treating as unresolved rather than "
+                        f"archiving a blank page.",
+                        flush=True,
                     )
+                    failed.append(p)
+                    continue
                 resolved[p]["url"] = synthetic_url
             return failed
 
@@ -3854,58 +4479,129 @@ class _ComixBrowserSession:
                 if d["type"] == "canvas" and not d["url"]
             ]
 
-        unresolved = _converge(list(targets))
-        for p in _harvest_canvas(_pending_canvas()):
-            resolved.pop(p, None)
-            unresolved.append(p)
+        def _converge_and_harvest(pending: List[int]) -> List[int]:
+            """One convergence pass plus its canvas harvest. Canvas pixels MUST
+            be read before the next rung reloads the page — a reload discards
+            them and, unlike an <img> src, there is nothing left to re-fetch."""
+            still = _converge(sorted(pending))
+            for failed_page in _harvest_canvas(_pending_canvas()):
+                resolved.pop(failed_page, None)
+                still.append(failed_page)
+            return sorted(set(still))
 
-        # ── Step 4: one reload retry for whatever is still missing.
-        # This is the handler's own retry policy, the one IncompleteChapterError
-        # is documented to sit behind (sites/base.py). Bounded to ONE reload: a
-        # page that survives a fresh render plus a full convergence pass is not
-        # going to appear on a third try inside the same budget, and the caller
-        # has its own 30s/60s inline retries for the transient case.
+        def _wait_for_reader_mount() -> None:
+            """Block until .rpage-page divs exist again after a reload, so the
+            next convergence round doesn't poll an empty DOM and burn a stall
+            interval on nothing."""
+            for _ in range(60):
+                if _time.monotonic() > deadline:
+                    return
+                try:
+                    if page.evaluate(
+                        "() => document.querySelectorAll('.rpage-page').length"
+                    ):
+                        return
+                except Exception:
+                    pass
+                page.wait_for_timeout(500)
+
+        unresolved = _converge_and_harvest(list(targets))
+
+        # ── Step 4: escalating recovery for whatever is still missing.
+        #
+        # WHY A LADDER AND NOT ONE RELOAD (2026-08-03). comix defers every 10th
+        # page — a chunk boundary — until the viewport reaches it, so the pages
+        # that survive the first pass are systematically the SAME ones every
+        # time. A plain reload re-runs the identical render and fails identically,
+        # which is exactly what the live log showed: 99/107 captured, reload,
+        # 99/107 captured, then two 90s caller retries producing 99/107 twice
+        # more before aborting the run. Each rung below changes something
+        # MATERIAL about how the reader is driven, so a rung can actually
+        # succeed where the previous one failed:
+        #
+        #   1. re-nudge  — force a real un-intersect -> intersect edge (_renudge).
+        #                  Cheapest, and targets the actual mechanism.
+        #   2. reload    — fresh render, then converge again.
+        #   3. preload=some + full sweep — different loading strategy entirely.
         #
         # DOWNLOAD PATH ONLY. The probe samples representative pages and already
-        # tolerates a partial capture, so completeness buys it nothing — and a
-        # reload plus a second convergence would spend its whole 60s budget
-        # chasing pages it was never going to score.
-        if max_capture_pages is None and unresolved and _time.monotonic() < deadline:
-            print(
-                f"[*] Comix: {len(unresolved)} page(s) unresolved "
-                f"({', '.join(str(p) for p in sorted(unresolved)[:10])}"
-                f"{'…' if len(unresolved) > 10 else ''}); reloading the "
-                f"chapter once and retrying just those.",
-                flush=True,
-            )
-            try:
-                page.reload(wait_until="domcontentloaded", timeout=30000)
-                self._enforce_no_waf("the chapter page", chapter_url)
-                # Let the reader re-mount before polling, else the first round
-                # sees an empty DOM and burns a stall interval on nothing.
-                for _ in range(60):
-                    if _time.monotonic() > deadline:
-                        break
-                    try:
-                        if page.evaluate(
-                            "() => document.querySelectorAll("
-                            "'.rpage-page').length"
-                        ):
-                            break
-                    except Exception:
-                        pass
-                    page.wait_for_timeout(500)
-                unresolved = _converge(sorted(unresolved))
-                for p in _harvest_canvas(_pending_canvas()):
-                    resolved.pop(p, None)
-                    unresolved.append(p)
-            except Exception as e:
+        # tolerates a partial capture, so completeness buys it nothing — and the
+        # ladder would spend its whole 60s budget chasing pages it never scores.
+        if max_capture_pages is None:
+            # Rung 1: re-nudge in place. No reload, so anything already captured
+            # stays captured and a success here costs ~1s.
+            if unresolved and _time.monotonic() < deadline:
                 print(
-                    f"[!] Comix: reload retry failed "
-                    f"({type(e).__name__}: {e}); keeping the pages already "
-                    f"captured.",
+                    f"[*] Comix: {len(unresolved)} page(s) unresolved "
+                    f"({_fmt_pages(unresolved)}); re-approaching them to "
+                    f"re-trigger the reader's lazy load.",
                     flush=True,
                 )
+                _renudge(sorted(unresolved))
+                unresolved = _converge_and_harvest(unresolved)
+
+            # Rung 2: full reload, fresh render, converge again.
+            if unresolved and _time.monotonic() < deadline:
+                print(
+                    f"[*] Comix: {len(unresolved)} page(s) still unresolved "
+                    f"({_fmt_pages(unresolved)}); reloading the chapter and "
+                    f"retrying just those.",
+                    flush=True,
+                )
+                try:
+                    page.reload(wait_until="domcontentloaded", timeout=30000)
+                    self._enforce_no_waf("the chapter page", chapter_url)
+                    _wait_for_reader_mount()
+                    unresolved = _converge_and_harvest(unresolved)
+                except ComixWafChallengeError:
+                    raise
+                except Exception as e:
+                    print(
+                        f"[!] Comix: reload retry failed "
+                        f"({type(e).__name__}: {e}); keeping the pages already "
+                        f"captured.",
+                        flush=True,
+                    )
+
+            # Rung 3: change the loading strategy outright. `all` asks the reader
+            # to schedule everything up front and it still defers the chunk
+            # boundaries; `some` is the mode its lazy path was actually designed
+            # around, so with a full sweep driving it the boundaries are reached
+            # the way ordinary reading reaches them. Last resort — it re-renders
+            # and gives up the eager bulk load.
+            if unresolved and _time.monotonic() < deadline:
+                print(
+                    f"[*] Comix: {len(unresolved)} page(s) still unresolved "
+                    f"({_fmt_pages(unresolved)}); retrying with the reader's "
+                    f"own lazy mode (preload=some) and a full scroll pass.",
+                    flush=True,
+                )
+                try:
+                    if self._apply_reader_preload_pref(mode="some"):
+                        page.reload(
+                            wait_until="domcontentloaded", timeout=30000
+                        )
+                        self._enforce_no_waf("the chapter page", chapter_url)
+                        _wait_for_reader_mount()
+                        unresolved = _converge_and_harvest(unresolved)
+                except ComixWafChallengeError:
+                    raise
+                except Exception as e:
+                    print(
+                        f"[!] Comix: preload=some retry failed "
+                        f"({type(e).__name__}: {e}); keeping the pages already "
+                        f"captured.",
+                        flush=True,
+                    )
+                finally:
+                    # Restore the eager default for the NEXT chapter — the
+                    # preference is persisted per-origin in localStorage, so
+                    # leaving it on `some` would silently make every subsequent
+                    # chapter take the slow path.
+                    try:
+                        self._apply_reader_preload_pref(mode="all")
+                    except Exception:
+                        pass
 
         # ── Step 5: assemble in PAGE ORDER. The old loop's append-in-order was
         # only correct because it walked sequentially; convergence resolves
@@ -3934,16 +4630,19 @@ class _ComixBrowserSession:
             0, len(self._scrambled_urls) - scramble_baseline
         )
 
-        # THE MEASUREMENT. canvas fired on 6/68 pages of one live chapter and
-        # ~8/88 of another (~9% both times) even though comix is believed to
-        # have dropped tile-scrambling in 2026-07. Two incompatible readings —
-        # real per-page scrambling, or the canvas-first poll winning a race
-        # against a perfectly ordinary <img> — and this line separates them:
-        #   scrambled=0 AND canvas_with_img == canvas  -> race; prefer <img> and
-        #     stop paying a lossy toDataURL re-encode on ~9% of every chapter.
-        #   scrambled ≈ canvas                         -> real; canvas is load-
-        #     bearing, optimise the encode instead.
-        # Behaviour is UNCHANGED until that reads one way or the other.
+        # THE MEASUREMENT — now ANSWERED (2026-08-03), kept as a live regression
+        # signal rather than an open question. A chapter reported
+        # `scrambled=10` against exactly its ~10 canvas pages with
+        # `canvas_with_img=0`, i.e. comix STILL tile-scrambles roughly every
+        # 10th page and serves it as fetch()/xhr for in-JS descrambling onto a
+        # canvas. The canvas branch is therefore load-bearing.
+        #
+        # What to watch for here: `scrambled` reading 0 on a FIRST pass while
+        # canvas pages exist would mean the scramble transport changed again
+        # (it already read a false 0 once, when the listener filtered on
+        # resource_type before looking at headers). On a reload pass 0 is
+        # expected and benign — the tiles come from the browser cache, so no
+        # fresh response carries headers.
         print(
             f"[*] Comix capture shapes: img={img_count} canvas={canvas_count} "
             f"({canvas_with_img} of which also had a complete <img>); "
@@ -3997,12 +4696,24 @@ class _ComixBrowserSession:
                 f" (+{len(unresolved) - 5} more)"
                 if len(unresolved) > 5 else ""
             )
+            # Name the chunk-boundary signature explicitly. Every miss on this
+            # site so far has been every-Nth (N=10 live on 2026-08-03), and that
+            # single fact is what tells you this is comix deferring pages rather
+            # than a CDN problem or a renamed selector — so say it rather than
+            # making the next reader re-derive it from a list of numbers.
+            stride = _every_nth_stride(unresolved)
+            pattern = (
+                f" These are every {stride}th page — comix's reader defers "
+                f"chunk-boundary pages until the viewport reaches them, so this "
+                f"is a capture-drive problem, not a missing-content one."
+                if stride else ""
+            )
             print(
                 f"[!] Comix capture: {len(urls)}/{len(targets)} pages captured "
                 f"({canvas_count} via canvas, {img_count} via <img>). "
-                f"{len(unresolved)} page(s) never rendered, even after a reload "
-                f"retry: {', '.join(_describe(p) for p in shown)}{more}. "
-                f"The caller will treat this chapter as incomplete.",
+                f"{len(unresolved)} page(s) never rendered, after re-approach, "
+                f"reload and lazy-mode retries: "
+                f"{', '.join(_describe(p) for p in shown)}{more}.{pattern}",
                 flush=True,
             )
         else:
@@ -4240,6 +4951,24 @@ class _ComixBrowserBridge:
         except Exception:
             return {"solved": False, "cookies": [], "user_agent": None,
                     "reason": "bridge_error"}
+
+    def open_login_window(self, timeout_s: float = 300.0) -> Dict[str, Any]:
+        """Bridge facade for the interactive sign-in window.
+
+        Outer cap is the wait plus slack for the launch and the profile flush.
+        Never raises: a bridge-level timeout degrades to "not signed in" so the
+        caller prints a remediation instead of a bare TimeoutError.
+        Cross-file: _ComixBrowserSession.open_login_window.
+        """
+        try:
+            return _comix_call(
+                "open_login_window", timeout_s, _timeout_s=timeout_s + 90.0,
+            )
+        except Exception as exc:
+            return {
+                "signed_in": False,
+                "reason": f"bridge_error:{type(exc).__name__}",
+            }
 
     def fetch_series_html(self, url: str) -> Optional[str]:
         """Bridge facade for the browser-sourced title-page read.

--- a/tests/test_comix_chapter_capture.py
+++ b/tests/test_comix_chapter_capture.py
@@ -32,13 +32,22 @@ from sites.base import IncompleteChapterError  # noqa: E402
 
 
 # A byte string is all the canvas path needs — it only b64-decodes and caches.
-_DATA_URL = "data:image/webp;base64," + base64.b64encode(b"RIFF____WEBP").decode()
+# Padded past comix._MIN_CANVAS_BYTES: a real painted page encodes to tens of KB,
+# and the harvester now rejects anything tiny as an unpainted (blank) canvas
+# rather than archiving a dead page. A 12-byte stub would trip that floor.
+_CANVAS_BYTES = b"RIFF____WEBP" + b"\x00" * 4096
+_DATA_URL = "data:image/webp;base64," + base64.b64encode(_CANVAS_BYTES).decode()
 
 # Shapes a scripted page can present. "canvas+img" is the race candidate the
 # capture-shapes summary exists to count: a canvas AND a fully decoded <img>.
+# "img-nosrc" is the INTERMEDIATE state a page passes through while it resolves —
+# <img> mounted, src not set yet — proved live on 2026-08-03 by a snapshot that
+# caught page 100 in exactly it. Not capturable, but it IS progress.
 IMG = "img"
 CANVAS = "canvas"
 CANVAS_AND_IMG = "canvas+img"
+IMG_NO_SRC = "img-nosrc"
+LOADING = "loading"
 
 
 class _ScriptedReader:
@@ -50,13 +59,33 @@ class _ScriptedReader:
     so the tests stay coupled to behaviour rather than to exact source text.
     """
 
-    def __init__(self, page_count, ready, url="https://comix.to/1234-chapter-1"):
+    def __init__(
+        self,
+        page_count,
+        ready,
+        url="https://comix.to/1234-chapter-1",
+        pending_shape=None,
+        canvas_unmounted=(),
+        canvas_needs_scroll=(),
+    ):
         self.page_count = page_count
         self.ready = dict(ready)
+        # page -> shape shown BEFORE its due round (default: nothing rendered).
+        # Lets a test script the is-loading / img-without-src rungs a real page
+        # climbs through, which is what the stall clock has to see as progress.
+        self.pending_shape = dict(pending_shape or {})
+        # Pages whose <canvas> ALWAYS reports itself unmounted when read.
+        self.canvas_unmounted = set(canvas_unmounted)
+        # Pages whose <canvas> is unmounted until the page is scrolled to —
+        # the real reader's behaviour, and what silently lost 6 of 10 scrambled
+        # pages live before the harvest learned to scroll back.
+        self.canvas_needs_scroll = set(canvas_needs_scroll)
         self.poll_rounds = 0
         self.scrolls = []
+        self.scroll_batches = []
         self.reloads = 0
         self.canvas_reads = []
+        self.preload_writes = []
         self._url = url
 
     @property
@@ -78,16 +107,26 @@ class _ScriptedReader:
         if entry is not None:
             due, shape = entry
             if self.poll_rounds < due:
-                shape = None
+                # Before its due round a page may still be scripted to show an
+                # intermediate shape, so "not ready yet" is not automatically
+                # "nothing at all" — see `pending_shape`.
+                shape = self.pending_shape.get(n)
         base = {
             "n": n, "loading": False, "hasCanvas": False, "cw": 0, "ch": 0,
-            "src": "", "complete": False, "nw": 0,
+            "hasImg": False, "src": "", "complete": False, "nw": 0,
         }
+        if shape == LOADING:
+            base.update(loading=True)
+        if shape == IMG_NO_SRC:
+            base.update(hasImg=True)
         if shape in (CANVAS, CANVAS_AND_IMG):
             base.update(hasCanvas=True, cw=800, ch=1200)
         if shape in (IMG, CANVAS_AND_IMG):
             base.update(
-                src=f"https://cdn.comix.to/p/{n:04d}.webp", complete=True, nw=800,
+                hasImg=True,
+                src=f"https://cdn.comix.to/p/{n:04d}.webp",
+                complete=True,
+                nw=800,
             )
         return base
 
@@ -99,13 +138,29 @@ class _ScriptedReader:
             self.poll_rounds += 1
             return states
         if "scrollIntoView" in js:
-            self.scrolls.append(arg)
-            return None
+            # ONE page per call — an IntersectionObserver only delivers
+            # observations once per frame, so a multi-page scroll would visit
+            # just its last page. `scroll_batches` records the call shape so a
+            # test can pin that nothing regresses to batching.
+            nums = [arg] if isinstance(arg, int) else list(arg or [])
+            self.scrolls.extend(nums)
+            self.scroll_batches.append(nums)
+            return True
         if "toDataURL" in js:
+            # The reader returns {data, why} now, not a bare data URL — a null
+            # used to collapse "canvas unmounted", "canvas 0x0" and a tainted
+            # SecurityError into one indistinguishable failure.
             self.canvas_reads.append(arg)
-            return _DATA_URL
+            if arg in self.canvas_unmounted:
+                return {"data": None, "why": "canvas unmounted"}
+            # Models the real reader: a canvas is torn down once it is far from
+            # the viewport and only comes back after you scroll to it.
+            if arg in self.canvas_needs_scroll and arg not in self.scrolls:
+                return {"data": None, "why": "canvas unmounted"}
+            return {"data": _DATA_URL, "why": ""}
         if "reader.webtoon.v3" in js:
-            return "all"
+            self.preload_writes.append(arg)
+            return arg
         return {}
 
 
@@ -179,23 +234,104 @@ def test_pages_are_returned_in_page_order_not_resolution_order():
     ]
 
 
-def test_the_lowest_unresolved_page_is_nudged_into_view():
-    page = _ScriptedReader(4, {1: (0, IMG), 2: (0, IMG), 3: (2, IMG), 4: (2, IMG)})
+def test_every_pending_page_is_swept_not_just_the_lowest():
+    """THE every-10th-page regression (2026-08-03).
+
+    comix defers each chunk-boundary page until the viewport reaches it, so a
+    page that is never scrolled to can never load. The old loop scrolled ONLY
+    `pending[0]`, which meant that once the bulk resolved and pending was
+    [10, 20, ... 110] it re-scrolled to page 10 forever while 20..110 were never
+    visited even once — and those are exactly the pages that then failed. Every
+    pending page must be reached.
+    """
+    # 1-2 resolve immediately; 20/40/60 never do, standing in for boundaries.
+    ready = {1: (0, IMG), 2: (0, IMG)}
+    page = _ScriptedReader(60, ready)
     _session(page).fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
 
-    assert page.scrolls, "a straggler round must scroll something into view"
-    assert page.scrolls[0] == 3
+    for boundary in (20, 40, 60):
+        assert boundary in page.scrolls, (
+            f"page {boundary} was never scrolled into view — this is the "
+            f"pending[0]-only bug that stranded every 10th page"
+        )
 
 
-def test_unresolved_pages_trigger_exactly_one_reload_retry():
-    """Bounded to one: a page that survives a fresh render plus a full
-    convergence pass won't appear on a third try inside the same budget."""
+def test_the_sweep_scrolls_one_page_per_round():
+    """An IntersectionObserver delivers observations once per FRAME, after the JS
+    turn ends — so scrolling several positions inside one evaluate produces a
+    single observation at the last position. Batching the sweep would look like
+    it visited every pending page while actually visiting one per batch, which is
+    the original bug wearing a disguise. One scroll per round, each getting its
+    own frame via the poll interval."""
+    page = _ScriptedReader(40, {1: (0, IMG)})
+    _session(page).fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
+
+    assert page.scroll_batches, "the sweep never ran"
+    assert all(len(b) == 1 for b in page.scroll_batches), (
+        "a multi-page scroll batch only ever visits its last page"
+    )
+
+
+def test_a_stalled_page_is_re_approached_from_further_up():
+    """A3. An IntersectionObserver fires on a TRANSITION, so re-scrolling a page
+    already at the scroll position does nothing — which is why the old repeated
+    nudge never recovered anything. The re-nudge must back off far enough to push
+    the target out of the viewport, then return to it."""
+    page = _ScriptedReader(20, {n: (0, IMG) for n in range(1, 20)})
+    _session(page).fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
+
+    # Page 20 is the only straggler. The backoff scroll must precede the return.
+    backoff = 20 - comix._COMIX_RENUDGE_BACKOFF_PAGES
+    assert backoff in page.scrolls, "no back-off scroll — no intersection edge"
+    assert page.scrolls.index(backoff) < len(page.scrolls) - 1
+
+
+def test_intermediate_progress_keeps_the_stall_clock_alive():
+    """A6. `<img>` mounted but src not yet set is the state a RESOLVING page
+    passes through (proved live: page 100 was caught in exactly it). If only
+    terminal states counted as progress, a chapter whose boundaries were all
+    mid-transition would look idle and trip the 20s stall break while the reader
+    was still working."""
+    # Page 3 sits in the intermediate state for several rounds, then lands. The
+    # stall bound is 0.05s here, so it can only survive if that counts as
+    # progress.
+    ready = {1: (0, IMG), 2: (0, IMG), 3: (6, IMG)}
+    page = _ScriptedReader(3, ready, pending_shape={3: IMG_NO_SRC})
+    cap = _session(page).fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
+
+    assert len(cap.urls) == 3, "a page that was visibly progressing was dropped"
+    assert not cap.unresolved
+
+
+def test_the_recovery_ladder_is_bounded_and_ends():
+    """Each rung changes something MATERIAL about how the reader is driven
+    (re-nudge, reload, lazy-mode) — a plain repeat would re-fail identically,
+    which is exactly what the live log showed. But it must terminate: at most two
+    reloads, then report short rather than looping."""
     page = _ScriptedReader(3, {1: (0, IMG), 2: (0, IMG)})
     cap = _session(page).fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
 
-    assert page.reloads == 1
+    assert page.reloads <= 2, "the ladder must not loop"
     assert len(cap.urls) == 2
     assert list(cap.unresolved) == [3]
+
+
+def test_the_lazy_mode_rung_restores_eager_preload_afterwards():
+    """preload is persisted per-origin in localStorage, so leaving the last rung's
+    `some` in place would silently make EVERY later chapter take the slow path."""
+    page = _ScriptedReader(3, {1: (0, IMG), 2: (0, IMG)})
+    sess = comix._ComixBrowserSession.__new__(comix._ComixBrowserSession)
+    sess._page = page
+    sess._scrambled_urls = set()
+    sess._start = lambda *a, **k: True
+    sess._sync_cf_cookies = lambda *a, **k: None
+    sess._enforce_no_waf = lambda *a, **k: None
+    sess.fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
+
+    assert "some" in page.preload_writes, "the lazy-mode rung never ran"
+    assert page.preload_writes[-1] == "all", (
+        "preload was left on 'some' — every later chapter would crawl"
+    )
 
 
 def test_the_unresolved_report_carries_the_last_observed_dom_state():
@@ -234,6 +370,69 @@ def test_canvas_pages_that_also_had_a_decoded_img_are_counted():
     assert cap.canvas_pages == 2
     assert cap.canvas_with_img == 1
     assert cap.urls[0].startswith("comix-page://"), "canvas still wins the race"
+
+
+def test_a_canvas_is_read_inline_the_round_it_is_detected():
+    """THE speed fix. comix still tile-scrambles roughly every 10th page
+    (confirmed live: scramble-headered responses == canvas page count) and the
+    reader UNMOUNTS a canvas once the sweep moves past it. Harvesting as a batch
+    AFTER convergence therefore found ~half of them already gone and pushed each
+    through all three recovery rungs — 12s of capture became 31s, and 81s on a
+    bad chapter. A canvas is mounted and painted at the instant the poll reports
+    it (`!loading`, non-zero dimensions), so it must be read THERE: no scroll, no
+    second round trip, nothing that lets it be torn down first."""
+    page = _ScriptedReader(3, {1: (0, IMG), 2: (0, CANVAS), 3: (0, IMG)})
+    cap = _session(page).fetch_chapter_images_via_dom("https://comix.to/1234-chapter-1")
+
+    assert cap.urls[1] == "comix-page://1234/0002.webp"
+    assert page.scrolls == [], (
+        "a healthy canvas page must cost no scroll at all — the inline read is "
+        "the whole speed win"
+    )
+    assert not cap.unresolved
+
+
+def test_an_unmounted_canvas_still_falls_back_to_the_scroll_recovery():
+    """The inline read is an optimisation, not a replacement. When it misses —
+    the canvas really was torn down before we got there — the batch harvest must
+    still scroll back to the page and recover it, which is what turns a dropped
+    page into a captured one."""
+    page = _ScriptedReader(
+        3, {1: (0, IMG), 2: (0, CANVAS), 3: (0, IMG)},
+        canvas_needs_scroll={2},
+    )
+    cap = _session(page).fetch_chapter_images_via_dom("https://comix.to/1234-chapter-1")
+
+    assert 2 in page.scrolls, "the recovery never scrolled back to the canvas"
+    assert cap.urls[1] == "comix-page://1234/0002.webp"
+    assert not cap.unresolved
+
+
+def test_an_unmounted_canvas_is_reported_not_silently_dropped(capsys):
+    """The read returned null and the page vanished with no log line at all —
+    six pages disappeared per chapter with nothing to diagnose from. A failure
+    must name its reason."""
+    page = _ScriptedReader(
+        2, {1: (0, IMG), 2: (0, CANVAS)}, canvas_unmounted={2},
+    )
+    cap = _session(page).fetch_chapter_images_via_dom("https://comix.to/1234-chapter-1")
+
+    assert list(cap.unresolved) == [2]
+    err = capsys.readouterr().err
+    assert "canvas unmounted" in err, "the failure reason must reach the log"
+
+
+def test_an_unpainted_canvas_is_not_archived_as_a_blank_page(monkeypatch):
+    """A canvas that exists but hasn't been painted yet encodes to a few hundred
+    bytes of uniform transparency, and toDataURL SUCCEEDS on it. Accepting that
+    writes a dead page into the CBZ while reporting success — the worst outcome
+    available. Below the floor it must count as unresolved instead."""
+    monkeypatch.setattr(comix, "_MIN_CANVAS_BYTES", 10_000)  # our stub is ~4KB
+    page = _ScriptedReader(2, {1: (0, IMG), 2: (0, CANVAS)})
+    cap = _session(page).fetch_chapter_images_via_dom("https://comix.to/1234-chapter-1")
+
+    assert list(cap.unresolved) == [2]
+    assert all(not u.startswith("comix-page://") for u in cap.urls)
 
 
 def test_scramble_headers_are_recorded_off_the_response_listener():
@@ -285,13 +484,100 @@ def test_the_probe_never_pays_for_the_reload_retry():
     assert len(cap.urls) == 2
 
 
-def test_the_download_path_still_reloads_for_the_same_shortfall():
+def test_the_download_path_still_runs_the_ladder_for_the_same_shortfall():
     """Same scripted DOM as the probe case above; only the cap differs. Pins
     that the exemption is keyed on the probe, not on the shortfall."""
     page = _ScriptedReader(4, {1: (0, IMG), 2: (0, IMG)})
     _session(page).fetch_chapter_images_via_dom("https://comix.to/1-chapter-1")
 
-    assert page.reloads == 1
+    assert page.reloads >= 1
+
+
+# ------------------------------------------------- stalled-page classification
+
+def _capture(urls, expected, unresolved):
+    return comix.ComixChapterCapture(
+        urls=list(urls), expected_pages=expected, unresolved=unresolved,
+    )
+
+
+def _stalled_state(n):
+    """The chunk-boundary signature: container present, reader marked it
+    loading, no <img> element ever mounted, no canvas."""
+    return {
+        "n": n, "loading": True, "hasCanvas": False, "cw": 0, "ch": 0,
+        "hasImg": False, "src": "", "complete": False, "nw": 0,
+    }
+
+
+def test_deferred_pages_are_classified_as_a_permanent_skip(monkeypatch):
+    """THE run-killer. comix defers every 10th page until the viewport reaches
+    it; when the handler's ladder still can't get one, re-rendering the identical
+    chapter cannot either. Live 2026-08-02: 99/107, retry, 99/107, retry, 99/107,
+    then the whole 256-chapter run aborted on chapter 1. The reason must route to
+    _PERMANENT_SKIP_REASONS so it skips-and-continues instead."""
+    cap = _capture(
+        [f"u{i}" for i in range(9)], 10, {10: _stalled_state(10)},
+    )
+    handler = _handler_with_capture(monkeypatch, cap)
+    with pytest.raises(IncompleteChapterError) as exc:
+        handler.get_chapter_images({"url": "https://comix.to/1-chapter-1"}, None, None)
+    assert exc.value.reason == "comix_pages_stalled"
+
+
+def test_an_ordinary_render_miss_stays_retryable(monkeypatch):
+    """The flip side: a page that got as far as an <img> with a src, or whose
+    container is missing entirely, is a genuine transient failure and must KEEP
+    its inline retries. Mis-classifying it as permanent would silently give up on
+    recoverable chapters."""
+    state = _stalled_state(10)
+    state.update(loading=False, hasImg=True, src="https://cdn/x.webp")
+    cap = _capture([f"u{i}" for i in range(9)], 10, {10: state})
+    handler = _handler_with_capture(monkeypatch, cap)
+    with pytest.raises(IncompleteChapterError) as exc:
+        handler.get_chapter_images({"url": "https://comix.to/1-chapter-1"}, None, None)
+    assert exc.value.reason == "comix_dom_render_incomplete"
+
+
+def test_one_ordinary_miss_downgrades_the_whole_classification(monkeypatch):
+    """Requires EVERY miss to fit the deferral pattern. A mixed set means
+    something else is also wrong, and the retryable read is the safer one."""
+    cap = _capture(
+        [f"u{i}" for i in range(8)], 10,
+        {10: _stalled_state(10), 9: {"n": 9, "missing": True}},
+    )
+    handler = _handler_with_capture(monkeypatch, cap)
+    with pytest.raises(IncompleteChapterError) as exc:
+        handler.get_chapter_images({"url": "https://comix.to/1-chapter-1"}, None, None)
+    assert exc.value.reason == "comix_dom_render_incomplete"
+
+
+def test_the_gapped_opt_in_keeps_the_chapter_and_records_the_gap(monkeypatch):
+    """--comix-allow-gapped-chapters trades completeness for availability, but
+    the gap must never be SILENT: pages are renumbered on the way into the CBZ,
+    so a missing page 10 is otherwise indistinguishable from a shorter chapter.
+    The numbers ride the chapter dict into ComicInfo's <AioMissingPages>."""
+    monkeypatch.setenv(comix._COMIX_ALLOW_GAPPED_ENV, "1")
+    cap = _capture(
+        [f"u{i}" for i in range(9)], 10, {10: _stalled_state(10)},
+    )
+    handler = _handler_with_capture(monkeypatch, cap)
+    ch = {"url": "https://comix.to/1-chapter-1"}
+    images = handler.get_chapter_images(ch, None, None)
+
+    assert len(images) == 9, "the partial chapter is kept"
+    assert ch["_missing_pages"] == [10], "the gap must be recorded"
+
+
+def test_a_stale_gap_record_is_cleared_when_not_opted_in(monkeypatch):
+    """The same chapter dict is reused across retries. A record left by an
+    earlier gapped attempt must not leak into a later strict one."""
+    cap = _capture([f"u{i}" for i in range(9)], 10, {10: _stalled_state(10)})
+    handler = _handler_with_capture(monkeypatch, cap)
+    ch = {"url": "https://comix.to/1-chapter-1", "_missing_pages": [10]}
+    with pytest.raises(IncompleteChapterError):
+        handler.get_chapter_images(ch, None, None)
+    assert "_missing_pages" not in ch
 
 
 # --------------------------------------------- handler contract (the raise)

--- a/tests/test_comix_pagination.py
+++ b/tests/test_comix_pagination.py
@@ -618,8 +618,13 @@ def test_successful_solve_does_not_consume_the_ask_again_budget(waf_budget_reset
     comix._COMIX_WAF_SOLVES_DONE = 1  # one solve already succeeded this run
     comix._COMIX_WAF_FAILURES = 0
     sess = comix._ComixBrowserSession.__new__(comix._ComixBrowserSession)
+    # __new__ skips __init__, so supply the two attributes the handoff reads to
+    # decide whether it must switch the browser's mode. Headless here forces the
+    # teardown+relaunch path, which is what this test wants to reach.
+    sess._page = None
+    sess._headless = True
     sess._cleanup = lambda: None
-    sess._start = lambda headless=True: False  # fail fast, no real browser
+    sess._start = lambda headless=None: False  # fail fast, no real browser
 
     out = sess.solve_waf_interactively("https://comix.to/title/x")
 
@@ -627,6 +632,44 @@ def test_successful_solve_does_not_consume_the_ask_again_budget(waf_budget_reset
     # window; only the stubbed launch stopped it.
     assert out["reason"] == "launch_failed", (
         "a previous successful solve must not block a later prompt"
+    )
+
+
+def test_the_browser_is_headed_by_default(monkeypatch):
+    """comix's reader defers every 10th page until the viewport reaches it, which
+    needs a live rendering lifecycle (layout, compositing, IntersectionObserver
+    delivery). Measured 2026-08-03: in a non-compositing context an observer over
+    103 page elements fired ZERO callbacks, so those pages can never load. Headed
+    is therefore correctness, not just anti-bot politeness."""
+    monkeypatch.delenv(comix._COMIX_HEADLESS_ENV, raising=False)
+    assert comix._comix_headless() is False
+    sig = inspect.signature(comix._ComixBrowserSession._start)
+    assert sig.parameters["headless"].default is None, (
+        "_start must defer to _comix_headless(), not hardcode a mode"
+    )
+
+
+def test_headless_remains_available_as_an_explicit_opt_out(monkeypatch):
+    """Unattended runs (cron/CI/headless servers) still need a way out, even
+    though chunk-boundary pages may not load there."""
+    monkeypatch.setenv(comix._COMIX_HEADLESS_ENV, "1")
+    assert comix._comix_headless() is True
+    monkeypatch.setenv(comix._COMIX_HEADLESS_ENV, "0")
+    assert comix._comix_headless() is False
+
+
+def test_the_handoff_does_not_relaunch_when_already_headed():
+    """THE identity bug, structurally closed. A clearance is bound to the client
+    that earned it; the old code always relaunched headless afterwards, handing
+    the rest of the run a measurably different client (HeadlessChrome in
+    Sec-CH-UA even with the UA string pinned) — so the very next navigation was
+    re-challenged. When the session is already headed nothing may be torn down."""
+    src = inspect.getsource(
+        comix._ComixBrowserSession.solve_waf_interactively
+    )
+    assert "mode_switched" in src
+    assert "self._start(headless=True)" not in src, (
+        "an unconditional headless relaunch re-introduces the identity mismatch"
     )
 
 
@@ -899,9 +942,13 @@ def test_preload_targets_the_key_the_site_actually_reads():
 def test_preload_writes_under_state_not_at_the_top_level():
     """The store is a Zustand-persist envelope: {"state": {...}, "version": 0}.
     A top-level `cur.preload` is ignored even with the right key — that was the
-    second half of why the old write could not have worked."""
+    second half of why the old write could not have worked.
+
+    The written VALUE is a parameter now (`all` for normal capture, `some` for
+    the recovery ladder's last rung — grep _apply_reader_preload_pref), so this
+    pins the nesting, which is the actual invariant, rather than the literal."""
     src = _preload_source()
-    assert "cur.state.preload = 'all'" in src
+    assert "cur.state.preload =" in src
     assert "cur.preload =" not in src
 
 


### PR DESCRIPTION
## The bug

comix.to downloads aborted on the first chapter. Every chapter came up ~10 pages short — always at **exactly every 10th page** — and the two 90s inline retries reproduced the shortfall byte-for-byte before `ChapterAbortedError` killed the run:

```
[*] Comix: chapter has 107 pages; capturing each via Patchright
[!] Comix capture: 99/107 pages captured ... 8 page(s) never rendered
[!] Chapter 1 long retry 1/2: waiting 30s ...   <- identical failure
[!] Chapter 1 long retry 2/2 ...                <- identical failure
                                                -> run dies on chapter 1
```

## Root cause

Verified live against the site. comix's reader **defers one page per 10-page chunk** until the viewport reaches it, and **tile-scrambles** those pages: they arrive over `fetch()`/XHR, are descrambled in-JS onto a `<canvas>`, and never get an `<img>` at all.

Three separate bugs stacked on top of that:

1. **The convergence loop only ever scrolled `pending[0]`.** Once the bulk resolved and pending was `[10, 20, … 110]`, every round re-scrolled to page 10 while 20…110 were never visited even once — so they could not load. A cursor now advances one page per round and the viewport walks the whole set. One page per round, *not* a batch: an `IntersectionObserver` delivers observations once per frame, so a batched scroll only ever visits its last page.

2. **Canvas pixels were harvested in a batch *after* convergence**, by which time the reader had unmounted the canvases and `toDataURL` returned `null` — which the code then discarded silently. A canvas is mounted and painted at the instant the poll first reports it, so it is now read inline there. The scroll-back recovery remains for genuine misses. This is also the speed fix: recovering those pages through the ladder turned a ~12s capture into 31s, and 81s on a bad chapter.

3. **The stall clock only counted terminal states as progress**, so a chapter whose boundaries were all mid-transition (`<img>` mounted, `src` not yet set) looked idle and tripped the 20s break while the reader was still working.

## Headed by default

The browser now runs headed (`AIO_COMIX_HEADLESS=1` / `--comix-headless` opts out). This is correctness, not politeness: deferred pages need a live rendering lifecycle, and an observer over 103 page elements in a non-compositing context fires **zero** callbacks.

It also removes the headless relaunch from the WAF handoff, which structurally retires the identity mismatch `b014f12` and `800f1f9` each tried to patch — a clearance is bound to the client that earned it, and the handoff no longer hands the run a different one.

## The scramble question is settled

`_capture_image_response` checked for `x-scramble-*` headers *after* an early return on `resource_type != "image"`. A descrambler needs raw bytes, so it fetches — never `<img>` — meaning the check could never observe a scrambled tile. The long-standing `scrambled=0` reading was an artifact of the instrument.

With the ordering fixed, a live chapter reports `scrambled == canvas page count` with `canvas_with_img=0`. **The canvas branch is load-bearing and canvas-before-`<img>` is correct.**

## Also fixed

- `_harvest_canvas`'s failure line was indented two spaces, which `log-filter.js` demotes to *verbose* — the only explanation of a dropped page never reached the log panel. It now reports **why** (canvas unmounted / 0x0 / SecurityError) instead of collapsing every mode into one null.
- An unpainted canvas encodes to a few hundred bytes and `toDataURL` **succeeds** on it, so it would have been archived as a blank page while reporting success. Anything under `_MIN_CANVAS_BYTES` now counts as unresolved.

## Run survival

When the recovery ladder is exhausted the handler raises `IncompleteChapterError(reason="comix_pages_stalled")`, which joins `_PERMANENT_SKIP_REASONS` so it skips-and-continues rather than burning 90s of retries and aborting a 256-chapter run over one chapter. `--multi-source` still rescues it.

`--comix-allow-gapped-chapters` opts into keeping a short chapter, recording the missing **source** page numbers in ComicInfo as `<AioMissingPages>` — pages are renumbered on the way into the CBZ, so a gap otherwise leaves no trace at all.

## UI

A callout on the Download tab whenever a comix.to URL is present, warning that a browser window will open and offering one-click multi-source plus a sign-in button. `--comix-login` opens the real site in the persistent profile; credentials are never seen, stored or transmitted by the downloader.

## Verification

- `tests/test_comix_chapter_capture.py` 26 → 30 tests, pinning the sweep, the one-scroll-per-round frame rule, the away-and-back re-nudge, intermediate-state progress, the inline canvas read, unmount recovery, the blank floor, and the stalled/retryable classification split.
- Full suite **657 passed, 75 skipped**; comix suites 133 passed.
- Registration 303/42, both CLIs parse, mangafire still inherits `fast_download_images`, no torch on search-orchestrator import, UI builds (1267 modules), no conflict markers.
- Live: a full run of *Return to Player* now reports `107/107 pages captured. All pages rendered.` per chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
