### PR TITLE
comix: make the human-verification window solvable (it opened blank)

### DIFF
--- a/sites/comix.py
+++ b/sites/comix.py
@@ -97,6 +97,40 @@ _COMIX_CAPTURE_STALL_S = 20.0
 # additional loading benefit.
 _COMIX_VIEWPORT = {"width": 1280, "height": 2400}
 
+# Viewport for the two windows a HUMAN has to use: the WAF handoff and the
+# sign-in window. Grep _apply_viewport for the swap.
+#
+# THE BUG THIS FIXES (measured against the live challenge page, 2026-08-03).
+# _COMIX_VIEWPORT above is emulated via Emulation.setDeviceMetricsOverride, so
+# it sets the CSS viewport REGARDLESS of how big the OS window is. comix's
+# interstitial is a flex-centred card on a `min-height:100vh` body, so at 2400
+# it lays out like this:
+#
+#     .card            top=978   bottom=1422
+#     .ring/.dragLayer top=1077  bottom=1297   <- the part you drag
+#     "Verify" button  top=1335
+#     scrollHeight == innerHeight == 2400      -> NOT scrollable
+#
+# A real Chromium window has ~950-1180 px of content area (1080p / maximised
+# 1440p), so every one of those lands below the bottom edge — and because the
+# document is exactly viewport-height there is no scrollbar to reach them with.
+# The user sees a correctly-loaded, completely blank window and cannot solve a
+# check the run then blames them for not completing. On 1080p not even the
+# card's top edge is visible; the Verify button is unreachable at ANY realistic
+# window height.
+#
+# This was invisible before 2026-08-03 only because the handoff used to relaunch
+# the browser headed with Playwright's 1280x720 default (no viewport= kwarg), so
+# it never inherited the reader's tall viewport. Making headed the default
+# removed that relaunch — see solve_waf_interactively's mode_switched — which is
+# right for clearance stickiness but handed the human the scrape geometry.
+#
+# 720 restores exactly the geometry that demonstrably worked. Deliberately a
+# FIXED size rather than something derived from window.screen: device-metrics
+# emulation overrides window.screen too, so the page would report the emulated
+# value back and the derivation would be circular.
+_COMIX_INTERACTIVE_VIEWPORT = {"width": 1280, "height": 720}
+
 # Opt-in: keep a chapter whose capture came up short instead of skipping it.
 #
 # Off by default, deliberately. The standing rule in this repo is that a stop
@@ -2023,11 +2057,19 @@ class _ComixBrowserSession:
             os.makedirs(profile_dir, exist_ok=True)
 
             def _launch(**extra):
-                # viewport= sets the CSS viewport the page renders against;
-                # --window-size makes the HEADED window actually that big, so a
-                # user watching the handoff sees a normal browser rather than a
-                # tiny frame scrolling a giant document. Both are needed — they
-                # control different things. See _COMIX_VIEWPORT for why 2400.
+                # viewport= sets the CSS viewport the page renders against (via
+                # device-metrics emulation, so it holds no matter what the OS
+                # window does). See _COMIX_VIEWPORT for why 2400.
+                #
+                # --window-size is a BEST-EFFORT HINT ONLY: a browser window
+                # can't exceed the display work area, so on any real monitor
+                # this resolves to "as tall as the screen" — nowhere near 2400.
+                # It must NOT be read as a guarantee that the emulated viewport
+                # is visible. An earlier version of this comment claimed it
+                # stopped the window being "a tiny frame scrolling a giant
+                # document", which is precisely what the clamp produces instead:
+                # the human-facing windows have to shrink the EMULATED viewport
+                # to be usable at all (grep _COMIX_INTERACTIVE_VIEWPORT).
                 return self._pw.chromium.launch_persistent_context(
                     profile_dir,
                     headless=headless,
@@ -2213,6 +2255,32 @@ class _ComixBrowserSession:
         if len(self._scrambled_urls) >= self._SCRAMBLED_URL_MEMORY:
             return
         self._scrambled_urls.add(url)
+
+    def _apply_viewport(self, page, size: Dict[str, int]) -> None:
+        """Re-emulate the CSS viewport on a live page. Best-effort, never raises.
+
+        Used to hand a HUMAN a window they can actually use and then put the
+        reader's tall geometry back — see _COMIX_INTERACTIVE_VIEWPORT for the
+        measurement, and solve_waf_interactively / open_login_window for the two
+        callers.
+
+        Swallows failures on purpose: a viewport swap is a usability
+        improvement, and neither caller has a better answer than "carry on" if
+        the page is mid-navigation or already gone. The restore side runs in a
+        `finally` precisely because the reverse — leaving the run at 720 — is
+        NOT cosmetic: it would silently strand comix's chunk-boundary pages
+        (grep _COMIX_VIEWPORT) and short every later chapter.
+
+        Note this only moves the EMULATED viewport, not the OS window; that is
+        what makes it usable, since the emulated size ends up smaller than the
+        window rather than larger.
+        """
+        if page is None:
+            return
+        try:
+            page.set_viewport_size(dict(size))
+        except Exception:
+            pass
 
     def _cleanup(self):
         # context.close() on a persistent context is what FLUSHES cookies and
@@ -2617,98 +2685,115 @@ class _ComixBrowserSession:
                 return result
 
         page = self._page
+        # Hand the user a window whose content they can actually reach. The
+        # reader's 2400px viewport puts this challenge's drag ring and Verify
+        # button below the bottom of any real window, on a page that cannot
+        # scroll — grep _COMIX_INTERACTIVE_VIEWPORT for the measured layout.
+        # Applied BEFORE the goto so the interstitial lays out at the size it
+        # will be read at, never reflowing under the user.
+        self._apply_viewport(page, _COMIX_INTERACTIVE_VIEWPORT)
         try:
-            page.goto(target, wait_until="domcontentloaded", timeout=30000)
-        except Exception as exc:
-            print(
-                f"[!] Comix: could not load the verification page "
-                f"({type(exc).__name__}: {exc}).",
-                flush=True,
-            )
-
-        # Every line is [!]-prefixed on purpose. The Electron LogPanel classifies
-        # by line shape (UI-source/electron/log-filter.js:classifyLogLevel):
-        # a leading "[!]" paints the line as an error, while a line starting
-        # with 2+ spaces is demoted to "verbose" — so an indented banner would
-        # render the one instruction the user MUST read as dim filler.
-        print("[!] " + "=" * 68, flush=True)
-        print(
-            "[!] ACTION NEEDED - comix.to is asking for human verification.",
-            flush=True,
-        )
-        print(
-            "[!] A browser window just opened. Complete the check in it: drag",
-            flush=True,
-        )
-        print(
-            "[!] the slider until the picture lines up, then press Verify.",
-            flush=True,
-        )
-        print(
-            f"[!] The download resumes by itself once it passes (waiting up to "
-            f"{int(timeout_s)}s).",
-            flush=True,
-        )
-        print(
-            "[!] The session is saved to disk, so this should be rare.",
-            flush=True,
-        )
-        print("[!] " + "=" * 68, flush=True)
-
-        deadline = time.monotonic() + timeout_s
-        solved = False
-        while time.monotonic() < deadline:
             try:
-                if page.is_closed():
-                    # User closed the window. Treat as a decision to abort
-                    # rather than waiting out the full timeout.
-                    print(
-                        "[!] Comix: verification window was closed before the "
-                        "check completed.",
-                        flush=True,
-                    )
-                    result["reason"] = "window_closed"
-                    break
-                current = page.url
-            except Exception:
-                result["reason"] = "window_lost"
-                break
-            if current and not _looks_like_waf_challenge(current):
-                # The site routed us off the interstitial — that IS the pass
-                # signal (it redirects back to ?return=). Small settle wait so
-                # the Set-Cookie lands before we read cookies.
-                try:
-                    page.wait_for_timeout(1500)
-                except Exception:
-                    pass
-                solved = True
-                break
-            try:
-                page.wait_for_timeout(1000)
-            except Exception:
-                break
-
-        if solved:
-            print("[*] Comix: verification passed - thanks. Resuming.", flush=True)
-            result["solved"] = True
-            with _COMIX_WAF_HANDOFF_LOCK:
-                # A success does NOT count against the ask-again budget: the
-                # cloudscraper session and the browser are separate identities
-                # to the WAF, so one run legitimately needs a solve for each.
-                _COMIX_WAF_SOLVES_DONE += 1
-                _COMIX_WAF_FAILURES = 0
-        else:
-            if not result.get("reason"):
-                result["reason"] = "timeout"
+                page.goto(target, wait_until="domcontentloaded", timeout=30000)
+            except Exception as exc:
                 print(
-                    f"[!] Comix: verification not completed within "
-                    f"{int(timeout_s)}s.",
+                    f"[!] Comix: could not load the verification page "
+                    f"({type(exc).__name__}: {exc}).",
                     flush=True,
                 )
-            with _COMIX_WAF_HANDOFF_LOCK:
-                # The user declined (timed out or closed the window). Stop
-                # asking — repeated windows they're ignoring help nobody.
-                _COMIX_WAF_FAILURES += 1
+
+            # Every line is [!]-prefixed on purpose. The Electron LogPanel
+            # classifies by line shape
+            # (UI-source/electron/log-filter.js:classifyLogLevel): a leading
+            # "[!]" paints the line as an error, while a line starting with 2+
+            # spaces is demoted to "verbose" — so an indented banner would
+            # render the one instruction the user MUST read as dim filler.
+            print("[!] " + "=" * 68, flush=True)
+            print(
+                "[!] ACTION NEEDED - comix.to is asking for human verification.",
+                flush=True,
+            )
+            print(
+                "[!] A browser window just opened. Complete the check in it: drag",
+                flush=True,
+            )
+            print(
+                "[!] the slider until the picture lines up, then press Verify.",
+                flush=True,
+            )
+            print(
+                f"[!] The download resumes by itself once it passes (waiting up to "
+                f"{int(timeout_s)}s).",
+                flush=True,
+            )
+            print(
+                "[!] The session is saved to disk, so this should be rare.",
+                flush=True,
+            )
+            print("[!] " + "=" * 68, flush=True)
+
+            deadline = time.monotonic() + timeout_s
+            solved = False
+            while time.monotonic() < deadline:
+                try:
+                    if page.is_closed():
+                        # User closed the window. Treat as a decision to abort
+                        # rather than waiting out the full timeout.
+                        print(
+                            "[!] Comix: verification window was closed before the "
+                            "check completed.",
+                            flush=True,
+                        )
+                        result["reason"] = "window_closed"
+                        break
+                    current = page.url
+                except Exception:
+                    result["reason"] = "window_lost"
+                    break
+                if current and not _looks_like_waf_challenge(current):
+                    # The site routed us off the interstitial — that IS the pass
+                    # signal (it redirects back to ?return=). Small settle wait so
+                    # the Set-Cookie lands before we read cookies.
+                    try:
+                        page.wait_for_timeout(1500)
+                    except Exception:
+                        pass
+                    solved = True
+                    break
+                try:
+                    page.wait_for_timeout(1000)
+                except Exception:
+                    break
+
+            if solved:
+                print("[*] Comix: verification passed - thanks. Resuming.", flush=True)
+                result["solved"] = True
+                with _COMIX_WAF_HANDOFF_LOCK:
+                    # A success does NOT count against the ask-again budget: the
+                    # cloudscraper session and the browser are separate identities
+                    # to the WAF, so one run legitimately needs a solve for each.
+                    _COMIX_WAF_SOLVES_DONE += 1
+                    _COMIX_WAF_FAILURES = 0
+            else:
+                if not result.get("reason"):
+                    result["reason"] = "timeout"
+                    print(
+                        f"[!] Comix: verification not completed within "
+                        f"{int(timeout_s)}s.",
+                        flush=True,
+                    )
+                with _COMIX_WAF_HANDOFF_LOCK:
+                    # The user declined (timed out or closed the window). Stop
+                    # asking — repeated windows they're ignoring help nobody.
+                    _COMIX_WAF_FAILURES += 1
+        finally:
+            # Put the reader's geometry back before anything else runs on this
+            # context. NOT cosmetic: every later chapter scrapes through this
+            # same page, and at 720 comix's chunk-boundary pages never enter the
+            # viewport, so chapters would come up ~10% short with no error.
+            # A `finally` rather than a trailing call because that failure is
+            # silent, so it must not depend on this method exiting normally.
+            self._apply_viewport(page, _COMIX_VIEWPORT)
 
         # No UA bookkeeping here any more. It used to re-read
         # navigator.userAgent and cache it, which became actively wrong once the
@@ -2783,90 +2868,104 @@ class _ComixBrowserSession:
                 return result
 
         page = self._page
+        # Same reason as the WAF handoff: the reader's 2400px viewport is
+        # emulated, so it survives whatever size the OS gives the window and
+        # pushes centred UI — comix's login card included — below the bottom
+        # edge of a page that cannot scroll. Grep _COMIX_INTERACTIVE_VIEWPORT.
+        self._apply_viewport(page, _COMIX_INTERACTIVE_VIEWPORT)
         try:
-            page.goto(
-                _WAF_CHALLENGE_HINT_URL,
-                wait_until="domcontentloaded",
-                timeout=30000,
-            )
-        except Exception as exc:
-            print(
-                f"[!] Comix: could not load comix.to "
-                f"({type(exc).__name__}: {exc}).",
-                flush=True,
-            )
-            result["reason"] = "navigation_failed"
-            return result
-
-        # [!]-prefixed so the Electron LogPanel paints these as must-read rather
-        # than dim filler — same reasoning as the WAF banner.
-        print("[!] " + "=" * 68, flush=True)
-        print("[!] ACTION NEEDED - sign in to comix.to.", flush=True)
-        print(
-            "[!] A browser window just opened on comix.to. Log in there as you",
-            flush=True,
-        )
-        print(
-            "[!] normally would. The downloader never sees your password.",
-            flush=True,
-        )
-        print(
-            f"[!] It saves the session and closes by itself (waiting up to "
-            f"{int(timeout_s)}s).",
-            flush=True,
-        )
-        print("[!] " + "=" * 68, flush=True)
-
-        deadline = time.monotonic() + timeout_s
-        while time.monotonic() < deadline:
             try:
-                if page.is_closed():
-                    result["reason"] = "window_closed"
-                    break
-                # The reader's own auth store. Present and populated is the
-                # SITE's statement that a session exists — more reliable than
-                # watching for a URL change, since comix keeps you on the same
-                # route after login.
-                signed = page.evaluate(
-                    """() => {
-                        try {
-                            const v = localStorage.getItem('auth');
-                            if (!v) return false;
-                            const p = JSON.parse(v);
-                            if (!p) return false;
-                            const s = p.state || p;
-                            return !!(s.token || s.user || s.accessToken);
-                        } catch (e) { return false; }
-                    }"""
+                page.goto(
+                    _WAF_CHALLENGE_HINT_URL,
+                    wait_until="domcontentloaded",
+                    timeout=30000,
                 )
-            except Exception:
-                result["reason"] = "window_lost"
-                break
-            if signed:
-                try:
-                    page.wait_for_timeout(1500)
-                except Exception:
-                    pass
-                result["signed_in"] = True
-                break
-            try:
-                page.wait_for_timeout(1000)
-            except Exception:
-                break
+            except Exception as exc:
+                print(
+                    f"[!] Comix: could not load comix.to "
+                    f"({type(exc).__name__}: {exc}).",
+                    flush=True,
+                )
+                result["reason"] = "navigation_failed"
+                return result
 
-        if result["signed_in"]:
-            print("[*] Comix: signed in - thanks. Session saved.", flush=True)
-        elif not result["reason"]:
-            result["reason"] = "timeout"
+            # [!]-prefixed so the Electron LogPanel paints these as must-read
+            # rather than dim filler — same reasoning as the WAF banner.
+            print("[!] " + "=" * 68, flush=True)
+            print("[!] ACTION NEEDED - sign in to comix.to.", flush=True)
             print(
-                f"[!] Comix: sign-in not completed within {int(timeout_s)}s.",
+                "[!] A browser window just opened on comix.to. Log in there as you",
                 flush=True,
             )
+            print(
+                "[!] normally would. The downloader never sees your password.",
+                flush=True,
+            )
+            print(
+                f"[!] It saves the session and closes by itself (waiting up to "
+                f"{int(timeout_s)}s).",
+                flush=True,
+            )
+            print("[!] " + "=" * 68, flush=True)
 
-        # Closing the context is what FLUSHES cookies + localStorage into the
-        # profile dir; without it a freshly-created session can be lost.
-        self._cleanup()
-        return result
+            deadline = time.monotonic() + timeout_s
+            while time.monotonic() < deadline:
+                try:
+                    if page.is_closed():
+                        result["reason"] = "window_closed"
+                        break
+                    # The reader's own auth store. Present and populated is the
+                    # SITE's statement that a session exists — more reliable than
+                    # watching for a URL change, since comix keeps you on the same
+                    # route after login.
+                    signed = page.evaluate(
+                        """() => {
+                            try {
+                                const v = localStorage.getItem('auth');
+                                if (!v) return false;
+                                const p = JSON.parse(v);
+                                if (!p) return false;
+                                const s = p.state || p;
+                                return !!(s.token || s.user || s.accessToken);
+                            } catch (e) { return false; }
+                        }"""
+                    )
+                except Exception:
+                    result["reason"] = "window_lost"
+                    break
+                if signed:
+                    try:
+                        page.wait_for_timeout(1500)
+                    except Exception:
+                        pass
+                    result["signed_in"] = True
+                    break
+                try:
+                    page.wait_for_timeout(1000)
+                except Exception:
+                    break
+
+            if result["signed_in"]:
+                print("[*] Comix: signed in - thanks. Session saved.", flush=True)
+            elif not result["reason"]:
+                result["reason"] = "timeout"
+                print(
+                    f"[!] Comix: sign-in not completed within {int(timeout_s)}s.",
+                    flush=True,
+                )
+
+            # Closing the context is what FLUSHES cookies + localStorage into the
+            # profile dir; without it a freshly-created session can be lost.
+            self._cleanup()
+            return result
+        finally:
+            # The success path already tore the context down, so this is a
+            # no-op there (the helper swallows the closed-page error). It exists
+            # for the paths that DON'T: the navigation_failed early return above
+            # leaves a live context behind, and leaving that context at 720
+            # would silently short every later chapter — see the matching
+            # `finally` in solve_waf_interactively.
+            self._apply_viewport(page, _COMIX_VIEWPORT)
 
     def context_cookies(self) -> List[Dict[str, Any]]:
         """Current cookies from the persistent context, or [] if unavailable.

--- a/tests/test_comix_pagination.py
+++ b/tests/test_comix_pagination.py
@@ -1034,3 +1034,203 @@ def test_zero_page_failure_does_not_claim_a_wait_that_never_happened():
     # The unconditional claim is gone.
     assert "divs in DOM \n" not in src
     assert "Either the React app failed to mount or" not in src
+
+
+# ------------------------------- human-facing window geometry (2026-08-03)
+# A user reported the verification window opening COMPLETELY BLANK, so the
+# check could not be solved at all. Nothing had failed to load: _COMIX_VIEWPORT
+# is 2400px tall and is applied via device-metrics EMULATION, so it holds no
+# matter how big the OS window is, while comix's interstitial is a flex-centred
+# card on a `min-height:100vh` body. Measured against the live challenge page:
+#
+#     .card 978->1422   .ring 1077   Verify 1335   scrollHeight == innerHeight
+#
+# A real window shows ~950-1180px, and the document being exactly
+# viewport-height means there is no scrollbar to reach the rest with — so the
+# widget sat below the fold, unreachable, on a page that reported itself fine.
+#
+# It only became reachable-by-accident before 2026-08-03 because the handoff
+# relaunched the browser headed at Playwright's 1280x720 default. Making headed
+# the default removed that relaunch, and the human inherited the reader's
+# scrape geometry. Both human-facing windows now swap in
+# _COMIX_INTERACTIVE_VIEWPORT and put the reader's back in a `finally`.
+#
+# Offline: the fake page records geometry calls, so no browser and no network.
+
+class _FakeHumanWindow:
+    """Page stand-in that records the viewport swaps and navigations a
+    human-facing window performs, in order.
+
+    `wait_for_timeout` is a no-op rather than a sleep — the handoff's poll loop
+    would otherwise make this suite wait real seconds for nothing.
+    """
+
+    def __init__(self, url="about:blank", goto_error=None, is_closed_error=None):
+        self._url = url
+        self.events: list = []
+        self._goto_error = goto_error
+        self._is_closed_error = is_closed_error
+
+    def set_viewport_size(self, size):
+        self.events.append(("viewport", dict(size)))
+
+    def goto(self, url, **_kwargs):
+        self.events.append(("goto", url))
+        if self._goto_error is not None:
+            raise self._goto_error
+        self._url = url
+
+    @property
+    def url(self):
+        return self._url
+
+    def is_closed(self):
+        if self._is_closed_error is not None:
+            raise self._is_closed_error
+        return False
+
+    def wait_for_timeout(self, _ms):
+        pass
+
+    def evaluate(self, *_args, **_kwargs):
+        # open_login_window's auth probe: report "signed in" so the happy path
+        # completes on the first poll.
+        return True
+
+
+def _viewport_events(page):
+    return [size for kind, size in page.events if kind == "viewport"]
+
+
+def _interactive_session(page, monkeypatch):
+    """A session wired for a human-facing window, with every environmental
+    escape hatch neutralised so the geometry code is actually REACHED.
+
+    DISPLAY matters most: CI is bare ubuntu-latest with no X server, and both
+    methods bail at their no_display guard before touching the viewport. Left
+    unset, these tests would pass green on a machine that never ran the code
+    they exist to pin. Setting it here (harmless on win32/darwin, which skip
+    the check) is what makes them meaningful in CI.
+    """
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv(comix._WAF_NO_INTERACTIVE_ENV, raising=False)
+    monkeypatch.delenv(comix._WAF_SOLVE_TIMEOUT_ENV, raising=False)
+    monkeypatch.delenv(comix._FORCE_WAF_ENV, raising=False)
+    # Module-level handoff budget: reset through monkeypatch so a test that
+    # spends it can't leak into the next one.
+    monkeypatch.setattr(comix, "_COMIX_WAF_SOLVES_DONE", 0)
+    monkeypatch.setattr(comix, "_COMIX_WAF_FAILURES", 0)
+    monkeypatch.setattr(comix, "_COMIX_WAF_LAST_PROMPT_AT", 0.0)
+
+    sess = comix._ComixBrowserSession.__new__(comix._ComixBrowserSession)
+    sess._page = page
+    # Headed already — the mode the default configuration runs in, and the one
+    # where no relaunch intervenes to reset the viewport for us.
+    sess._headless = False
+    sess._context = None
+    sess._browser = None
+    sess._pw = None
+    return sess
+
+
+def test_interactive_viewport_fits_a_real_window():
+    """The value itself is the fix, so pin it rather than just its use.
+
+    950px is the content height of a maximised window on a 1080p screen — the
+    reporter's case and the smallest realistic target. A future "let's make the
+    handoff taller too" edit has to fail here.
+    """
+    interactive = comix._COMIX_INTERACTIVE_VIEWPORT["height"]
+    assert interactive <= 950, (
+        "the human-facing viewport must fit inside a real window, else the "
+        "centred CAPTCHA lands below the fold on a page that cannot scroll"
+    )
+    assert interactive < comix._COMIX_VIEWPORT["height"], (
+        "shrinking is the entire point; the reader's tall viewport is what "
+        "pushed the widget off-screen"
+    )
+
+
+def test_waf_handoff_hands_the_user_a_usable_viewport_then_restores_it(monkeypatch):
+    """Shrink BEFORE the navigation, restore after.
+
+    Order matters on both ends: shrinking after the goto would reflow the
+    interstitial under the user mid-solve, and failing to restore would leave
+    the run at 720 — where comix's chunk-boundary pages never enter the
+    viewport, silently shorting every later chapter by ~10%.
+    """
+    page = _FakeHumanWindow()
+    sess = _interactive_session(page, monkeypatch)
+
+    # The handoff navigates to the page the user WANTED; the site is what
+    # redirects to /@waf/. Landing on a non-challenge URL means the poll loop
+    # sees a pass on its first iteration.
+    target = "https://comix.to/title/zq5g5-heavenly-demon-reborn"
+    result = sess.solve_waf_interactively(target)
+
+    assert result["solved"] is True
+    assert page.events[0] == ("viewport", dict(comix._COMIX_INTERACTIVE_VIEWPORT)), (
+        "the window must be resized before the challenge is loaded into it"
+    )
+    assert ("goto", target) in page.events
+    assert page.events[-1] == ("viewport", dict(comix._COMIX_VIEWPORT)), (
+        "the reader's geometry must be back before any chapter scrape resumes"
+    )
+
+
+def test_waf_handoff_restores_the_viewport_when_the_wait_is_interrupted(monkeypatch):
+    """The restore lives in a `finally` for a reason.
+
+    The user stares at this window for up to 180s, so Ctrl-C during the wait is
+    an ordinary event — and KeyboardInterrupt is a BaseException, so the poll
+    loop's `except Exception` does not catch it. A trailing call instead of a
+    `finally` would leave the session at 720px, and the resulting short
+    chapters carry no error to trace back to here.
+    """
+    page = _FakeHumanWindow(is_closed_error=KeyboardInterrupt())
+    sess = _interactive_session(page, monkeypatch)
+
+    with pytest.raises(KeyboardInterrupt):
+        sess.solve_waf_interactively("https://comix.to/title/x")
+
+    assert _viewport_events(page)[-1] == dict(comix._COMIX_VIEWPORT)
+
+
+def test_login_window_hands_the_user_a_usable_viewport(monkeypatch):
+    """comix's login card is centred too, so it had the same defect."""
+    page = _FakeHumanWindow()
+    sess = _interactive_session(page, monkeypatch)
+
+    result = sess.open_login_window(timeout_s=5.0)
+
+    assert result["signed_in"] is True
+    assert page.events[0] == ("viewport", dict(comix._COMIX_INTERACTIVE_VIEWPORT))
+
+
+def test_login_window_restores_the_viewport_when_navigation_fails(monkeypatch):
+    """The `navigation_failed` early return skips the trailing _cleanup(), so
+    it hands back a LIVE context — the one path where a missing restore would
+    silently leave the whole run at the interactive viewport."""
+    page = _FakeHumanWindow(goto_error=RuntimeError("net::ERR_CONNECTION_RESET"))
+    sess = _interactive_session(page, monkeypatch)
+
+    result = sess.open_login_window(timeout_s=5.0)
+
+    assert result["reason"] == "navigation_failed"
+    assert _viewport_events(page)[-1] == dict(comix._COMIX_VIEWPORT), (
+        "a failed navigation must not strand the run at the human viewport"
+    )
+
+
+def test_viewport_swap_survives_a_dead_page(monkeypatch):
+    """_apply_viewport is best-effort by contract: both callers may run it
+    against a page that has just been torn down (open_login_window's success
+    path closes the context before the `finally` fires). It must not turn that
+    into a raised error on an otherwise successful sign-in."""
+    class _DeadPage:
+        def set_viewport_size(self, _size):
+            raise RuntimeError("Target page, context or browser has been closed")
+
+    sess = comix._ComixBrowserSession.__new__(comix._ComixBrowserSession)
+    sess._apply_viewport(_DeadPage(), comix._COMIX_VIEWPORT)
+    sess._apply_viewport(None, comix._COMIX_VIEWPORT)


### PR DESCRIPTION
A user reported comix's human-verification window opening **completely blank**, so the CAPTCHA could not be completed at all. Nothing had failed to load — the page was the real interstitial, correctly rendered, with its widget positioned below the bottom edge of the window.

### Cause

`_COMIX_VIEWPORT` is 2400px tall and is applied through device-metrics **emulation**, so it fixes the CSS viewport no matter how big the OS window is. (`--window-size` cannot compensate — a browser window is clamped to the display work area.) comix's interstitial is a flex-centred card on a `min-height:100vh` body, so at 2400 it lays out like this — measured against the live challenge page:

```
.card 978 -> 1422    .ring 1077    Verify 1335
scrollHeight == innerHeight == 2400   ->   not scrollable
```

A real window shows ~950–1180px of content, so all of it sits below the fold — and because the document is exactly viewport-height there is no scrollbar to reach it with. On a 1080p screen not even the card's top edge is visible; the Verify button is unreachable at *any* realistic window height.

| window content height | card | drag ring | Verify |
|---|---|---|---|
| ~955px (1080p) | ✗ | ✗ | ✗ |
| ~1050px | sliver | ✗ | ✗ |
| ~1180px (maximised 1440p) | ✓ | ✓ | ✗ |

The run then reported the check as "not completed" by a user who was never shown anything to complete.

This was reachable-by-accident before the headed default landed in #70: the handoff used to relaunch the browser headed at Playwright's 1280x720 default, so it never inherited the reader's tall viewport. Removing that relaunch is correct — it is what makes a clearance stick — but it handed the human the scrape geometry.

### Fix

Both human-facing windows swap in `_COMIX_INTERACTIVE_VIEWPORT` (1280x720, the geometry that demonstrably worked) before navigating, and restore the reader's in a `finally`.

The restore is not cosmetic and the `finally` is not habit:

- every later chapter scrapes through this same page, and at 720 comix's chunk-boundary pages never enter the viewport — chapters would come up ~10% short **with no error at all**;
- the user stares at this window for up to 180s, so a Ctrl-C mid-wait is ordinary, and `KeyboardInterrupt` is not caught by the poll loop's `except Exception`.

`open_login_window` had the same defect (comix's login card is centred too) plus a worse variant: its `navigation_failed` early return skips the trailing `_cleanup()`, so it hands back a **live** context — the one path where a missing restore would strand the whole run at the human viewport.

Also corrects the `--window-size` comment, which claimed the arg prevents "a tiny frame scrolling a giant document". The work-area clamp means that is precisely what it produces instead; it is a hint, not a guarantee, and should not be read as one.

### Verification

Drove the **real** `_ComixBrowserSession` launch path (persistent context, channel + UA pin, headed) against the live challenge page on a throwaway profile:

```
BEFORE   innerHeight=2400   card 978->1422   ring 1077   Verify 1335   scrollable=False
AFTER    innerHeight=720    card 138->582    ring  237   Verify  495
RESTORED innerHeight=2400
```

Scope note: this verifies the widget is now *reachable*. A full solve still can't be confirmed from here — the reporting user is the only one currently being challenged.

### Tests

6 offline cases in `tests/test_comix_pagination.py` — no browser, no network. They pin the value itself (must fit a real window), the shrink-before-navigate ordering, the restore, the interrupted path, both login-window paths, and `_apply_viewport`'s best-effort contract against a dead page.

They set `DISPLAY` explicitly, which is load-bearing for CI: the runner is bare `ubuntu-latest` with no X server, and both methods bail at their `no_display` guard *before* reaching the geometry — so without it these would report green for code they never ran. Verified under simulated CI conditions (`platform=linux`, `DISPLAY` unset), including that negative control.

Full suite: 671 passed, 75 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
